### PR TITLE
add dynamic rewriting

### DIFF
--- a/apps/couch/src/couch_btree.erl
+++ b/apps/couch/src/couch_btree.erl
@@ -300,10 +300,9 @@ chunkify([InElement | RestInList], ChunkThreshold, OutList, OutListSize, OutputC
     end.
 
 modify_node(Bt, RootPointerInfo, Actions, QueryOutput) ->
-    {NodeType, NodeList} = case RootPointerInfo of
-    nil -> 
+    {NodeType, NodeList} = case RootPointerInfo of
+    nil ->
         {kv_node, []};
-
     _Tuple ->
         Pointer = element(1, RootPointerInfo),
         get_node(Bt, Pointer)

--- a/apps/couch/src/couch_native_process.erl
+++ b/apps/couch/src/couch_native_process.erl
@@ -169,6 +169,9 @@ run(_, Unknown) ->
     ?LOG_ERROR("Native Process: Unknown command: ~p~n", [Unknown]),
     throw({error, unknown_command}).
     
+ddoc(State, {DDoc}, [Source, Args]) ->
+    Fun = makefun(State, Source),
+    {State, (catch apply(Fun, Args))};
 ddoc(State, {DDoc}, [FunPath, Args]) ->
     % load fun from the FunPath
     BFun = lists:foldl(fun

--- a/apps/couch/src/couch_query_servers.erl
+++ b/apps/couch/src/couch_query_servers.erl
@@ -26,6 +26,8 @@
 % For 210-os-proc-pool.t
 -export([get_os_process/1, ret_os_process/1]).
 
+-export([run_script/4]).
+
 -include("couch_db.hrl").
 
 -record(proc, {
@@ -265,6 +267,16 @@ filter_docs(Req, Db, DDoc, FName, Docs) ->
     [true, Passes] = ddoc_prompt(DDoc, [<<"filters">>, FName],
         [JsonDocs, JsonReq]),
     {ok, Passes}.
+
+run_script(Req, Db, DDoc, Src) ->
+    JsonReq = case Req of
+                    {json_req, JsonObj} ->
+                        JsonObj;
+                    #httpd{} = HttpReq ->
+                        couch_httpd_external:json_req_obj(HttpReq, Db)
+              end,
+
+    ddoc_prompt(DDoc, [<<"run">>, Src], [JsonReq]).
 
 ddoc_proc_prompt({Proc, DDocId}, FunPath, Args) ->
     proc_prompt(Proc, [<<"ddoc">>, DDocId, FunPath, Args]).

--- a/apps/couch_changes/src/couch_changes.erl
+++ b/apps/couch_changes/src/couch_changes.erl
@@ -495,11 +495,11 @@ view_changes_enumerator({{Seq, _Key, DocId}, Val}, Acc) ->
         {ok, DocInfo} ->
             #doc_info{revs=[#rev_info{deleted= Del}=RevInfo | Rest]} = DocInfo,
             case {Del, IncludeRemovedDocs} of
-                {true, _} -> 
+                {true, _} ->
                     changes_enumerator(DocInfo, Acc, Seq);
-                {false, true} -> 
+		{false, true} ->
                     RevInfo2 = RevInfo#rev_info{deleted= removed},
-                    DocInfo2 = DocInfo#doc_info{revs = [RevInfo2 | Rest]},
+                    DocInfo2 = DocInfo#doc_info{revs = [RevInfo2 | Rest]},
                     changes_enumerator(DocInfo2, Acc, Seq);
                 {false, false} ->
                     {ok, Acc}

--- a/apps/couch_replicator/src/couch_replicator_api_wrap.erl
+++ b/apps/couch_replicator/src/couch_replicator_api_wrap.erl
@@ -514,7 +514,7 @@ maybe_add_changes_filter_q_args(BaseQS, Options) ->
         %% when using a view vchanges feed we don't want to received removed documents
         if
             FilterName =:= <<"_view">> ->
-                [{"include_removed_docs", false} | QS];
+                [{"include_removed_docs", false} | QS];
             true ->
                 QS
         end

--- a/share/server/loop.js
+++ b/share/server/loop.js
@@ -63,7 +63,8 @@ var DDoc = (function() {
     "views"     : Filter.filter_view,
     "updates"  : Render.update,
     "validate_doc_update" : Validate.validate,
-    "validate_doc_read" : Validate.validate
+    "validate_doc_read" : Validate.validate,
+    "run": Script.run
   };
   var ddocs = {};
   return {
@@ -88,6 +89,12 @@ var DDoc = (function() {
         // the first member of the fun path determines the type of operation
         var funArgs = args.shift();
         if (ddoc_dispatch[cmd]) {
+
+          if (cmd == "run") {
+            var src = funPath[1];
+            return Script.run(src, ddoc, funArgs);
+          } 
+
           // get the function, call the command with it
           var point = ddoc;
           for (var i=0; i < funPath.length; i++) {

--- a/share/server/main-coffee.js
+++ b/share/server/main-coffee.js
@@ -1402,7 +1402,28 @@ var Views = (function() {
     }
   };
 })();
-/**
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+//
+// Copyright 2015 (c) Benoît Chesneau
+
+Script = {
+
+	run: function(source, ddoc, args) {
+		var fun = Couch.compileFunction(source, ddoc, "rewrite");
+		Res = fun.apply(ddoc, args),
+		respond(Res);
+	}
+};/**
  * CoffeeScript Compiler v1.2.0
  * http://coffeescript.org
  *
@@ -1474,7 +1495,8 @@ var DDoc = (function() {
     "views"     : Filter.filter_view,
     "updates"  : Render.update,
     "validate_doc_update" : Validate.validate,
-    "validate_doc_read" : Validate.validate
+    "validate_doc_read" : Validate.validate,
+    "run": Script.run
   };
   var ddocs = {};
   return {
@@ -1499,6 +1521,12 @@ var DDoc = (function() {
         // the first member of the fun path determines the type of operation
         var funArgs = args.shift();
         if (ddoc_dispatch[cmd]) {
+
+          if (cmd == "run") {
+            var src = funPath[1];
+            return Script.run(src, ddoc, funArgs);
+          } 
+
           // get the function, call the command with it
           var point = ddoc;
           for (var i=0; i < funPath.length; i++) {

--- a/share/server/main.js
+++ b/share/server/main.js
@@ -1413,6 +1413,27 @@ var Views = (function() {
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
+//
+// Copyright 2015 (c) Benoît Chesneau
+
+Script = {
+
+	run: function(source, ddoc, args) {
+		var fun = Couch.compileFunction(source, ddoc, "rewrite");
+		Res = fun.apply(ddoc, args),
+		respond(Res);
+	}
+};// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
 
 var sandbox = null;
 var filter_sandbox = null;
@@ -1467,7 +1488,8 @@ var DDoc = (function() {
     "views"     : Filter.filter_view,
     "updates"  : Render.update,
     "validate_doc_update" : Validate.validate,
-    "validate_doc_read" : Validate.validate
+    "validate_doc_read" : Validate.validate,
+    "run": Script.run
   };
   var ddocs = {};
   return {
@@ -1492,6 +1514,12 @@ var DDoc = (function() {
         // the first member of the fun path determines the type of operation
         var funArgs = args.shift();
         if (ddoc_dispatch[cmd]) {
+
+          if (cmd == "run") {
+            var src = funPath[1];
+            return Script.run(src, ddoc, funArgs);
+          } 
+
           // get the function, call the command with it
           var point = ddoc;
           for (var i=0; i < funPath.length; i++) {

--- a/share/server/script.js
+++ b/share/server/script.js
@@ -1,0 +1,22 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+//
+// Copyright 2015 (c) Benoît Chesneau
+
+Script = {
+
+	run: function(source, ddoc, args) {
+		var fun = Couch.compileFunction(source, ddoc, "rewrite");
+		Res = fun.apply(ddoc, args),
+		respond(Res);
+	}
+};

--- a/share/www/script/test/rewrite.js
+++ b/share/www/script/test/rewrite.js
@@ -186,7 +186,8 @@ couchTests.rewrite = function(debug) {
             {
               "from": "/db/*",
               "to": "../../*"
-            }
+            },
+            "function(req) { return [{\"from\": \"/db2/*\", \"to\": \"../../*\"}]; }"
           ],
           lists: {
             simpleForm: stringFun(function(head, req) {
@@ -408,6 +409,12 @@ couchTests.rewrite = function(debug) {
         
         // COUCHDB-2031 - path normalization versus qs params
         xhr = CouchDB.request("GET", "/"+dbName+"/_design/test/_rewrite/db/_design/test?meta=true");
+        T(xhr.status == 200, "path normalization works with qs params");
+        var result = JSON.parse(xhr.responseText);
+        T(result['_id'] == "_design/test");
+        T(typeof(result['_revs_info']) === "object");
+
+         xhr = CouchDB.request("GET", "/"+dbName+"/_design/test/_rewrite/db2/_design/test?meta=true");
         T(xhr.status == 200, "path normalization works with qs params");
         var result = JSON.parse(xhr.responseText);
         T(result['_id'] == "_design/test");

--- a/support/build_js.escript
+++ b/support/build_js.escript
@@ -27,6 +27,7 @@ main([]) ->
                "share/server/util.js",
                "share/server/validate.js",
                "share/server/views.js",
+               "share/server/script.js",
                "share/server/loop.js"],
 
     CoffeeFiles = ["share/server/json2.js",
@@ -37,6 +38,7 @@ main([]) ->
                    "share/server/util.js",
                    "share/server/validate.js",
                    "share/server/views.js",
+                   "share/server/script.js",
                    "share/server/coffee-script.js",
                    "share/server/loop.js"],
 


### PR DESCRIPTION
this change add the possibility to pass a function inside the list of rewrites
rules instead of an object.

The function is expected to return a new list of rewrites rule. A rewrite
function take the request as argument. This can be useful to return a list of
path based on a request (like returning paths alowed for a user).

Ex:

     {
        "_id": "_design/test",
        "rewrites": [
             "function(req) { return  [{\"from\": \"/db\", \"to\": \"../..\"}]; }"
        ]
    }