### PR TITLE
feat(server): embeddable route API for host livery apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,203 @@
+name: CI
+
+# Umbrella CI for the barrel monorepo. Jobs:
+#   - umbrella: integrated build + tests (default profile, no FAISS)
+#   - leaf:     each standalone library builds and tests on its own, which
+#               catches hidden cross-app dependencies before publishing
+#   - faiss:    optional FAISS backend leg (needs the FAISS C++ library)
+#   - server:   network server leg (pulls livery + transports)
+#   - barrel-lite: TypeScript client (typecheck, build, unit tests)
+# Dev target is OTP 29; CI pins OTP 28 (image guaranteed, code builds on both).
+
+on:
+  push:
+    branches: [main]
+    # 'barrel-v*' has no underscore, so 'barrel_*-v*' does not match it.
+    tags: ['barrel-v*', 'barrel_*-v*', 'v*']
+  pull_request:
+  # The e2e job builds a Docker image and runs two containers, so it is opt-in
+  # (manual dispatch) rather than on every push.
+  workflow_dispatch:
+
+env:
+  OTP_VERSION: '28'
+
+jobs:
+  umbrella:
+    name: Umbrella (compile, eunit, ct, xref)
+    runs-on: ubuntu-latest
+    container:
+      image: erlang:28
+    steps:
+      - uses: actions/checkout@v4
+      - name: System dependencies
+        run: |
+          apt-get update
+          apt-get install -y cmake build-essential libssl-dev zlib1g-dev \
+            libsnappy-dev liblz4-dev libzstd-dev python3 python3-venv
+          git config --global --add safe.directory '*'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/rebar3
+          key: rebar3-umbrella-${{ hashFiles('rebar.lock') }}
+      - run: rebar3 compile
+      - run: rebar3 as test eunit --app barrel,barrel_crypto,barrel_docdb,barrel_vectordb,barrel_rerank
+      # barrel_embed's venv/ollama tests need an external backend; run only the
+      # backend-free modules (mocked provider dispatch + request building).
+      - run: rebar3 as test eunit --module=barrel_embed_tests,barrel_embed_provider_tests,barrel_embed_request_tests
+      - run: rebar3 as test ct
+
+  leaf:
+    name: Leaf (${{ matrix.app }})
+    runs-on: ubuntu-latest
+    container:
+      image: erlang:28
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [barrel_crypto, barrel_docdb, barrel_rerank, barrel_embed]
+    steps:
+      - uses: actions/checkout@v4
+      - name: System dependencies
+        run: |
+          apt-get update
+          apt-get install -y cmake build-essential libssl-dev zlib1g-dev \
+            libsnappy-dev liblz4-dev libzstd-dev python3 python3-venv
+          git config --global --add safe.directory '*'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/rebar3
+          key: rebar3-${{ matrix.app }}-${{ hashFiles(format('apps/{0}/rebar.config', matrix.app)) }}
+      # barrel_docdb depends on the sibling barrel_crypto; isolated builds
+      # resolve it as a checkout dependency
+      - name: Link sibling checkouts
+        if: matrix.app == 'barrel_docdb'
+        run: |
+          mkdir -p apps/barrel_docdb/_checkouts
+          ln -s ../../barrel_crypto apps/barrel_docdb/_checkouts/barrel_crypto
+      - name: Compile (isolated)
+        working-directory: apps/${{ matrix.app }}
+        run: rebar3 compile
+      - name: Xref (isolated)
+        working-directory: apps/${{ matrix.app }}
+        run: rebar3 xref
+      # barrel_embed's tests need a Python model backend; build-only here.
+      - name: EUnit (isolated)
+        if: matrix.app != 'barrel_embed'
+        working-directory: apps/${{ matrix.app }}
+        run: rebar3 eunit
+    # Note: barrel_vectordb, barrel, and barrel_server have sibling deps, so
+    # they are exercised by the umbrella/server jobs. Standalone (hex-resolved)
+    # builds for them land with the publishing workflow.
+
+  faiss:
+    name: FAISS backend
+    runs-on: ubuntu-latest
+    container:
+      image: erlang:28
+    steps:
+      - uses: actions/checkout@v4
+      - name: System dependencies
+        run: |
+          apt-get update
+          apt-get install -y cmake build-essential libssl-dev zlib1g-dev \
+            libsnappy-dev liblz4-dev libzstd-dev libfaiss-dev libomp-dev libopenblas-dev
+          git config --global --add safe.directory '*'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/rebar3
+          key: rebar3-faiss-${{ hashFiles('rebar.lock') }}
+      - run: rebar3 as faiss compile
+      # the FAISS C++ library is installed above, so run the suite (not just compile)
+      - run: rebar3 as faiss ct --suite apps/barrel_faiss/test/barrel_faiss_SUITE
+
+  barrel-lite:
+    name: barrel-lite (TS client)
+    runs-on: ubuntu-latest
+    container:
+      image: erlang:28
+    steps:
+      - uses: actions/checkout@v4
+      # Erlang base image so later stages can boot barrel_server for
+      # integration tests; Node rides on top via nodesource.
+      - name: Node toolchain
+        run: |
+          apt-get update
+          apt-get install -y curl ca-certificates
+          curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+          apt-get install -y nodejs
+          git config --global --add safe.directory '*'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-barrel-lite-${{ hashFiles('clients/barrel-lite/package-lock.json') }}
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/rebar3
+          key: rebar3-server-${{ hashFiles('rebar.lock') }}
+      - name: Install
+        working-directory: clients/barrel-lite
+        run: npm ci
+      - name: Typecheck
+        working-directory: clients/barrel-lite
+        run: npm run typecheck
+      - name: Build
+        working-directory: clients/barrel-lite
+        run: npm run build
+      - name: Unit tests
+        working-directory: clients/barrel-lite
+        run: npm test
+      - name: System dependencies (server boot)
+        run: |
+          apt-get install -y cmake build-essential libssl-dev zlib1g-dev \
+            libsnappy-dev liblz4-dev libzstd-dev python3 python3-venv
+      - name: Integration tests (boots barrel_server)
+        working-directory: clients/barrel-lite
+        env:
+          BARREL_PORT: '18080'
+        run: npm run test:integration
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('clients/barrel-lite/package-lock.json') }}
+      - name: Browser smoke (Playwright chromium)
+        working-directory: clients/barrel-lite
+        env:
+          BARREL_PORT: '18080'
+          STATIC_PORT: '5173'
+          CI: 'true'
+        run: |
+          npx playwright install --with-deps chromium
+          npm run test:browser
+
+  server:
+    name: Network server
+    runs-on: ubuntu-latest
+    container:
+      image: erlang:28
+    steps:
+      - uses: actions/checkout@v4
+      - name: System dependencies
+        run: |
+          apt-get update
+          apt-get install -y cmake build-essential libssl-dev zlib1g-dev \
+            libsnappy-dev liblz4-dev libzstd-dev
+          git config --global --add safe.directory '*'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/rebar3
+          key: rebar3-server-${{ hashFiles('rebar.lock') }}
+      - run: rebar3 as server compile
+      # run every server suite (REST, sync/rep/convergence, att, auth, spaces,
+      # cors, audit, encryption, timeline, and the MCP suites), not just the base
+      - run: rebar3 as server ct
+
+  e2e-replication:
+    name: E2E replication (two containers)
+    # Opt-in: needs a Docker-capable runner and builds the server image.
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Replication across two peers
+        run: bash test/e2e/replication.sh

--- a/apps/barrel_server/README.md
+++ b/apps/barrel_server/README.md
@@ -10,6 +10,10 @@ You need this when you want to reach a barrel database over the network (other
 languages, remote clients, agents) instead of embedding it in an Erlang
 application. For embedded use, depend on `barrel` directly and skip this app.
 
+To serve barrel's routes from your own `livery` service (under a sub-path, with
+your own auth), use `barrel_server_api:routes/router` rather than the standalone
+listener; see the [embedding guide](../../docs/guides/embedding-barrel-server.md).
+
 [Documentation](https://barrel-db.eu/docs/lib/server/) |
 [HexDocs](https://hexdocs.pm/barrel_server) |
 [Repository](https://github.com/barrel-db/barrel)

--- a/apps/barrel_server/src/barrel_server_api.erl
+++ b/apps/barrel_server/src/barrel_server_api.erl
@@ -1,0 +1,170 @@
+%%%-------------------------------------------------------------------
+%%% @doc Embeddable route table for the barrel REST/sync surface.
+%%%
+%%% Exposes barrel's routes as a plain livery route list (and a compiled
+%%% router) so a host livery application can mount them into its own
+%%% service, optionally under a sub-path, and apply its own middleware.
+%%% The route handlers live in {@link barrel_server_http},
+%%% {@link barrel_server_sync}, {@link barrel_server_spaces}, and
+%%% {@link barrel_server_mcp}; this module only assembles the table.
+%%%
+%%% Routes are grouped so an embedder can take just what it needs:
+%%% <ul>
+%%%   <li>`meta'     - `/' and `/health' (standalone only by default).</li>
+%%%   <li>`db'       - database lifecycle, documents, bulk, find, query,
+%%%                    changes, attachments, vector add.</li>
+%%%   <li>`sync'     - the replication wire (`/db/:db/_sync/*').</li>
+%%%   <li>`timeline' - branch, merge, lineage.</li>
+%%%   <li>`search'   - vector/bm25/hybrid search.</li>
+%%%   <li>`spaces'   - the agent layer (`/spaces', `/handoffs').</li>
+%%%   <li>`mcp'      - the MCP endpoint (empty when disabled).</li>
+%%% </ul>
+%%%
+%%% `routes/0' returns the default DB surface (`db', `sync', `timeline',
+%%% `search') that {@link //barrel-lite} needs. The standalone service
+%%% ({@link barrel_server_http}) takes `groups => all'.
+%%%
+%%% Embedding (DB surface, host owns auth) needs no barrel_server
+%%% supervisor; just start `barrel' and `barrel_spaces', then:
+%%% ```
+%%% Barrel  = barrel_server_api:router(),
+%%% HostR1  = livery_router:nest(<<"/barrel">>, Barrel, HostRouter),
+%%% {ok, _} = livery:start_service(#{http => #{port => 8080},
+%%%                                  router => HostR1,
+%%%                                  middleware => HostAuthStack}).
+%%% '''
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_server_api).
+
+-export([routes/0, routes/1, router/0, router/1, groups/0]).
+
+-type group() :: meta | db | sync | timeline | search | spaces | mcp.
+-type route() :: {binary(), binary(), term()}.
+-export_type([group/0, route/0]).
+
+%% Groups served in an embedder's default (what barrel-lite needs).
+-define(DEFAULT_GROUPS, [db, sync, timeline, search]).
+%% Every group, in a stable order. `meta' first so `/' and `/health'
+%% keep working in the standalone service.
+-define(ALL_GROUPS, [meta, db, timeline, sync, search, spaces, mcp]).
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc The known route groups.
+-spec groups() -> [group()].
+groups() ->
+    ?ALL_GROUPS.
+
+%% @doc The default DB-surface routes (`db', `sync', `timeline', `search').
+-spec routes() -> [route()].
+routes() ->
+    routes(#{groups => ?DEFAULT_GROUPS}).
+
+%% @doc Routes for the selected groups. `Opts' is `#{groups => all |
+%% [group()]}'; unknown group names fail loud.
+-spec routes(map()) -> [route()].
+routes(Opts) when is_map(Opts) ->
+    Groups = resolve_groups(maps:get(groups, Opts, ?DEFAULT_GROUPS)),
+    lists:append([group_routes(G) || G <- Groups]).
+
+%% @doc A compiled router for the default DB surface.
+-spec router() -> livery_router:router().
+router() ->
+    router(#{}).
+
+%% @doc A compiled router for the selected groups. In addition to
+%% `groups', `Opts' may carry `prefix => binary()' to mount the routes
+%% under a sub-path (equivalent to `livery_router:nest/2').
+-spec router(map()) -> livery_router:router().
+router(Opts) when is_map(Opts) ->
+    Router = livery_router:compile(routes(Opts)),
+    case maps:get(prefix, Opts, undefined) of
+        undefined -> Router;
+        <<>> -> Router;
+        Prefix when is_binary(Prefix) -> livery_router:nest(Prefix, Router)
+    end.
+
+%%====================================================================
+%% Internal
+%%====================================================================
+
+resolve_groups(all) ->
+    ?ALL_GROUPS;
+resolve_groups(Groups) when is_list(Groups) ->
+    lists:foreach(fun validate_group/1, Groups),
+    Groups.
+
+validate_group(Group) ->
+    case lists:member(Group, ?ALL_GROUPS) of
+        true -> ok;
+        false -> error({unknown_route_group, Group})
+    end.
+
+-spec group_routes(group()) -> [route()].
+group_routes(meta) ->
+    [
+        {<<"GET">>, <<"/">>,       {barrel_server_http, root}},
+        {<<"GET">>, <<"/health">>, {barrel_server_http, health}}
+    ];
+group_routes(db) ->
+    [
+        {<<"PUT">>,    <<"/db/:db">>,                        {barrel_server_http, create_db}},
+        {<<"GET">>,    <<"/db/:db">>,                        {barrel_server_http, db_info}},
+        {<<"DELETE">>, <<"/db/:db">>,                        {barrel_server_http, drop_db}},
+
+        {<<"PUT">>,    <<"/db/:db/doc/:id">>,               {barrel_server_http, put_doc}},
+        {<<"GET">>,    <<"/db/:db/doc/:id">>,               {barrel_server_http, get_doc}},
+        {<<"DELETE">>, <<"/db/:db/doc/:id">>,               {barrel_server_http, delete_doc}},
+        {<<"GET">>,    <<"/db/:db/_history">>,              {barrel_server_http, history}},
+        {<<"GET">>,    <<"/db/:db/doc/:id/_versions">>,     {barrel_server_http, doc_versions}},
+        {<<"GET">>,    <<"/db/:db/doc/:id/_versions/:rev">>, {barrel_server_http, version_body}},
+        {<<"POST">>,   <<"/db/:db/_bulk_docs">>,            {barrel_server_http, bulk_docs}},
+        {<<"POST">>,   <<"/db/:db/_bulk_get">>,             {barrel_server_http, bulk_get}},
+        {<<"POST">>,   <<"/db/:db/find">>,                  {barrel_server_http, find}},
+        %% GET exists for browser EventSource (SUBSCRIBE over SSE)
+        {<<"POST">>,   <<"/db/:db/query">>,                 {barrel_server_http, query}},
+        {<<"GET">>,    <<"/db/:db/query">>,                 {barrel_server_http, query}},
+        {<<"GET">>,    <<"/db/:db/changes">>,               {barrel_server_http, changes}},
+
+        {<<"PUT">>,    <<"/db/:db/doc/:id/att/:name">>,     {barrel_server_http, put_att}},
+        {<<"GET">>,    <<"/db/:db/doc/:id/att/:name">>,     {barrel_server_http, get_att}},
+        {<<"DELETE">>, <<"/db/:db/doc/:id/att/:name">>,     {barrel_server_http, delete_att}},
+
+        {<<"POST">>,   <<"/db/:db/vector">>,                {barrel_server_http, vector_add}}
+    ];
+group_routes(timeline) ->
+    [
+        {<<"GET">>,  <<"/db/:db/_timeline">>,        {barrel_server_http, timeline_info}},
+        {<<"POST">>, <<"/db/:db/_timeline/branch">>, {barrel_server_http, timeline_branch}},
+        {<<"POST">>, <<"/db/:db/_timeline/merge">>,  {barrel_server_http, timeline_merge}}
+    ];
+group_routes(sync) ->
+    [
+        {<<"GET">>,    <<"/db/:db/_sync/info">>,          {barrel_server_sync, info}},
+        {<<"POST">>,   <<"/db/:db/_sync/hlc">>,           {barrel_server_sync, sync_hlc}},
+        {<<"POST">>,   <<"/db/:db/_sync/changes">>,       {barrel_server_sync, changes}},
+        {<<"POST">>,   <<"/db/:db/_sync/diff">>,          {barrel_server_sync, diff}},
+        {<<"GET">>,    <<"/db/:db/_sync/doc/:id">>,       {barrel_server_sync, get_doc}},
+        {<<"PUT">>,    <<"/db/:db/_sync/doc/:id">>,       {barrel_server_sync, put_version}},
+        {<<"GET">>,    <<"/db/:db/_sync/local/:id">>,     {barrel_server_sync, get_local}},
+        {<<"PUT">>,    <<"/db/:db/_sync/local/:id">>,     {barrel_server_sync, put_local}},
+        {<<"DELETE">>, <<"/db/:db/_sync/local/:id">>,     {barrel_server_sync, delete_local}},
+        {<<"GET">>,    <<"/db/:db/_sync/att_changes">>,   {barrel_server_sync, att_changes}},
+        {<<"POST">>,   <<"/db/:db/_sync/att_diff">>,      {barrel_server_sync, att_diff}},
+        {<<"GET">>,    <<"/db/:db/_sync/att/:id/:name">>, {barrel_server_sync, get_att}},
+        {<<"PUT">>,    <<"/db/:db/_sync/att/:id/:name">>, {barrel_server_sync, put_att}},
+        {<<"DELETE">>, <<"/db/:db/_sync/att/:id/:name">>, {barrel_server_sync, delete_att}}
+    ];
+group_routes(search) ->
+    [
+        {<<"POST">>, <<"/db/:db/search/vector">>, {barrel_server_http, search_vector}},
+        {<<"POST">>, <<"/db/:db/search/bm25">>,   {barrel_server_http, search_bm25}},
+        {<<"POST">>, <<"/db/:db/search/hybrid">>, {barrel_server_http, search_hybrid}}
+    ];
+group_routes(spaces) ->
+    barrel_server_spaces:routes();
+group_routes(mcp) ->
+    barrel_server_mcp:routes().

--- a/apps/barrel_server/src/barrel_server_http.erl
+++ b/apps/barrel_server/src/barrel_server_http.erl
@@ -94,64 +94,12 @@ middleware() ->
     end,
     Base ++ Cors ++ Auth.
 
+%% The standalone service serves every group (DB surface + agent layer +
+%% MCP + `/' and `/health'). The grouped, embeddable table lives in
+%% {@link barrel_server_api}, which host applications mount into their own
+%% livery service.
 routes() ->
-    [
-        {<<"GET">>,    <<"/">>,                          {?MODULE, root}},
-        {<<"GET">>,    <<"/health">>,                    {?MODULE, health}},
-
-        {<<"PUT">>,    <<"/db/:db">>,                    {?MODULE, create_db}},
-        {<<"GET">>,    <<"/db/:db">>,                    {?MODULE, db_info}},
-        {<<"DELETE">>, <<"/db/:db">>,                    {?MODULE, drop_db}},
-
-        %% Timeline (branch, merge, lineage)
-        {<<"GET">>,    <<"/db/:db/_timeline">>,          {?MODULE, timeline_info}},
-        {<<"POST">>,   <<"/db/:db/_timeline/branch">>,   {?MODULE, timeline_branch}},
-        {<<"POST">>,   <<"/db/:db/_timeline/merge">>,    {?MODULE, timeline_merge}},
-
-        {<<"PUT">>,    <<"/db/:db/doc/:id">>,            {?MODULE, put_doc}},
-        {<<"GET">>,    <<"/db/:db/doc/:id">>,            {?MODULE, get_doc}},
-        {<<"DELETE">>, <<"/db/:db/doc/:id">>,            {?MODULE, delete_doc}},
-        {<<"GET">>,    <<"/db/:db/_history">>,           {?MODULE, history}},
-        {<<"GET">>,    <<"/db/:db/doc/:id/_versions">>,  {?MODULE, doc_versions}},
-        {<<"GET">>,    <<"/db/:db/doc/:id/_versions/:rev">>, {?MODULE, version_body}},
-        {<<"POST">>,   <<"/db/:db/_bulk_docs">>,         {?MODULE, bulk_docs}},
-        {<<"POST">>,   <<"/db/:db/_bulk_get">>,          {?MODULE, bulk_get}},
-        {<<"POST">>,   <<"/db/:db/find">>,               {?MODULE, find}},
-        %% GET exists for browser EventSource (SUBSCRIBE over SSE)
-        {<<"POST">>,   <<"/db/:db/query">>,              {?MODULE, query}},
-        {<<"GET">>,    <<"/db/:db/query">>,              {?MODULE, query}},
-        {<<"GET">>,    <<"/db/:db/changes">>,            {?MODULE, changes}},
-
-        %% Replication wire (barrel_rep_transport over HTTP)
-        {<<"GET">>,    <<"/db/:db/_sync/info">>,         {barrel_server_sync, info}},
-        {<<"POST">>,   <<"/db/:db/_sync/hlc">>,          {barrel_server_sync, sync_hlc}},
-        {<<"POST">>,   <<"/db/:db/_sync/changes">>,      {barrel_server_sync, changes}},
-        {<<"POST">>,   <<"/db/:db/_sync/diff">>,         {barrel_server_sync, diff}},
-        {<<"GET">>,    <<"/db/:db/_sync/doc/:id">>,      {barrel_server_sync, get_doc}},
-        {<<"PUT">>,    <<"/db/:db/_sync/doc/:id">>,      {barrel_server_sync, put_version}},
-        {<<"GET">>,    <<"/db/:db/_sync/local/:id">>,    {barrel_server_sync, get_local}},
-        {<<"PUT">>,    <<"/db/:db/_sync/local/:id">>,    {barrel_server_sync, put_local}},
-        {<<"DELETE">>, <<"/db/:db/_sync/local/:id">>,    {barrel_server_sync, delete_local}},
-        {<<"GET">>,    <<"/db/:db/_sync/att_changes">>,  {barrel_server_sync, att_changes}},
-        {<<"POST">>,   <<"/db/:db/_sync/att_diff">>,     {barrel_server_sync, att_diff}},
-        {<<"GET">>,    <<"/db/:db/_sync/att/:id/:name">>,    {barrel_server_sync, get_att}},
-        {<<"PUT">>,    <<"/db/:db/_sync/att/:id/:name">>,    {barrel_server_sync, put_att}},
-        {<<"DELETE">>, <<"/db/:db/_sync/att/:id/:name">>,    {barrel_server_sync, delete_att}},
-
-        {<<"PUT">>,    <<"/db/:db/doc/:id/att/:name">>,  {?MODULE, put_att}},
-        {<<"GET">>,    <<"/db/:db/doc/:id/att/:name">>,  {?MODULE, get_att}},
-        {<<"DELETE">>, <<"/db/:db/doc/:id/att/:name">>,  {?MODULE, delete_att}},
-
-        {<<"POST">>,   <<"/db/:db/vector">>,             {?MODULE, vector_add}},
-        {<<"POST">>,   <<"/db/:db/search/vector">>,      {?MODULE, search_vector}},
-        {<<"POST">>,   <<"/db/:db/search/bm25">>,        {?MODULE, search_bm25}},
-        {<<"POST">>,   <<"/db/:db/search/hybrid">>,      {?MODULE, search_hybrid}}
-
-        %% Agent layer (spaces, grants, sessions, handoffs)
-        | barrel_server_spaces:routes()
-    ]
-    %% MCP endpoint (empty when disabled)
-    ++ barrel_server_mcp:routes().
+    barrel_server_api:routes(#{groups => all}).
 
 %%====================================================================
 %% Meta handlers

--- a/apps/barrel_server/test/barrel_server_embed_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_embed_SUITE.erl
@@ -1,0 +1,166 @@
+%%%-------------------------------------------------------------------
+%%% @doc Embedding tests: mount barrel's routes inside a host livery
+%%% service under a sub-path, with the host owning authentication.
+%%%
+%%% No barrel_server application is started here. The suite starts only
+%%% `barrel' and `barrel_spaces', builds its own livery router with a
+%%% host-owned `/ping' route plus barrel's default DB surface
+%%% ({@link barrel_server_api:router/0}) nested under `/barrel', and
+%%% installs its own auth middleware. This proves the DB surface is
+%%% mountable with a prefix and governed by the host's middleware.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_server_embed_SUITE).
+-behaviour(livery_middleware).
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([
+    t_host_route/1,
+    t_embedded_db_lifecycle/1,
+    t_embedded_doc_crud/1,
+    t_embedded_sync_info/1,
+    t_host_owns_auth/1,
+    t_default_excludes_spaces/1
+]).
+
+%% Host router handler and middleware (referenced from the route table
+%% and the service middleware stack).
+-export([ping/1, call/3]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-define(DB, "embeddb").
+-define(AUTH, {<<"x-host-auth">>, <<"let-me-in">>}).
+
+all() ->
+    [t_host_route, t_embedded_db_lifecycle, t_embedded_doc_crud,
+     t_embedded_sync_info, t_host_owns_auth, t_default_excludes_spaces].
+
+init_per_suite(Config) ->
+    application:set_env(barrel_docdb, data_dir, ?config(priv_dir, Config)),
+    {ok, _} = application:ensure_all_started(barrel),
+    {ok, _} = application:ensure_all_started(barrel_spaces),
+    {ok, _} = application:ensure_all_started(livery),
+    {ok, _} = application:ensure_all_started(hackney),
+    %% Host router: a host-owned /ping plus barrel's default DB surface
+    %% mounted under /barrel. The host middleware owns auth for the whole
+    %% service (barrel ships none in embedded mode).
+    HostRouter = livery_router:compile(
+        [{<<"GET">>, <<"/ping">>, {?MODULE, ping}}]),
+    Router = livery_router:nest(<<"/barrel">>,
+                                barrel_server_api:router(),
+                                HostRouter),
+    {ok, Pid} = livery:start_service(#{
+        http => #{port => 0},
+        router => Router,
+        middleware => [{?MODULE, #{}}]
+    }),
+    %% start_service links to this (ephemeral) init process; unlink so the
+    %% service survives until end_per_suite stops it explicitly.
+    true = unlink(Pid),
+    #{h1 := Port} = livery:which_listeners(Pid),
+    Base = "http://127.0.0.1:" ++ integer_to_list(Port),
+    {201, _} = req(put, Base ++ "/barrel/db/" ++ ?DB, <<>>),
+    [{svc, Pid}, {base, Base} | Config].
+
+end_per_suite(Config) ->
+    livery:stop_service(?config(svc, Config)),
+    application:stop(barrel_spaces),
+    application:stop(barrel),
+    ok.
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+%% The host's own route coexists with the mounted barrel subtree.
+t_host_route(Config) ->
+    B = base(Config),
+    {200, <<"pong">>} = req_raw(get, B ++ "/ping"),
+    ok.
+
+t_embedded_db_lifecycle(Config) ->
+    B = base(Config),
+    {200, Info} = req(get, B ++ "/barrel/db/" ++ ?DB, <<>>),
+    ?assert(is_map(Info)),
+    ok.
+
+t_embedded_doc_crud(Config) ->
+    B = base(Config),
+    {201, _} = req_json(put, B ++ "/barrel/db/" ++ ?DB ++ "/doc/d1",
+                        #{<<"v">> => 42}),
+    {200, #{<<"v">> := 42}} =
+        req(get, B ++ "/barrel/db/" ++ ?DB ++ "/doc/d1", <<>>),
+    ok.
+
+%% The sync wire (what barrel-lite drives) is reachable under the prefix.
+t_embedded_sync_info(Config) ->
+    B = base(Config),
+    {200, Info} = req(get, B ++ "/barrel/db/" ++ ?DB ++ "/_sync/info", <<>>),
+    ?assertMatch(#{<<"db">> := _}, Info),
+    ok.
+
+%% Without the host's header the host middleware rejects the request,
+%% proving the host governs auth for barrel's routes.
+t_host_owns_auth(Config) ->
+    B = base(Config),
+    {401, _} = req_noauth(get, B ++ "/barrel/db/" ++ ?DB),
+    ok.
+
+%% The agent layer is not part of the default DB surface.
+t_default_excludes_spaces(Config) ->
+    B = base(Config),
+    {404, _} = req(post, B ++ "/barrel/spaces", <<>>),
+    ok.
+
+%%====================================================================
+%% Host router handler + middleware
+%%====================================================================
+
+ping(_Req) ->
+    livery_resp:text(200, <<"pong">>).
+
+call(Req, Next, _Cfg) ->
+    case livery_req:header(<<"x-host-auth">>, Req, undefined) of
+        <<"let-me-in">> ->
+            Next(Req);
+        _ ->
+            livery_resp:new(
+                401,
+                [{<<"content-type">>, <<"application/json">>}],
+                {full, <<"{\"error\":\"host_auth\"}">>})
+    end.
+
+%%====================================================================
+%% HTTP helpers
+%%====================================================================
+
+base(Config) -> ?config(base, Config).
+
+req(Method, Url, Body) ->
+    decode(hackney:request(Method, list_to_binary(Url), [?AUTH], Body,
+                           [with_body])).
+
+req_json(Method, Url, Map) ->
+    Headers = [?AUTH, {<<"content-type">>, <<"application/json">>}],
+    decode(hackney:request(Method, list_to_binary(Url), Headers,
+                           json:encode(Map), [with_body])).
+
+req_raw(Method, Url) ->
+    {ok, S, _H, Body} = hackney:request(Method, list_to_binary(Url), [?AUTH],
+                                        <<>>, [with_body]),
+    {S, Body}.
+
+req_noauth(Method, Url) ->
+    decode(hackney:request(Method, list_to_binary(Url), [], <<>>,
+                           [with_body])).
+
+decode({ok, S, _H, Body}) ->
+    Decoded = case Body of
+        <<>> -> #{};
+        _ -> try json:decode(Body) catch _:_ -> Body end
+    end,
+    {S, Decoded};
+decode(Other) ->
+    error({http, Other}).

--- a/clients/barrel-lite/README.md
+++ b/clients/barrel-lite/README.md
@@ -45,6 +45,11 @@ In the browser, storage defaults to OPFS and `multiTab` uses Web Locks plus
 BroadcastChannel (one tab per origin owns the store; others proxy to it). In
 Node and tests, storage defaults to memory and there is a single instance.
 
+`remote.url` is the base the client builds every route from, so it may include a
+sub-path when the server is embedded under one (for example
+`url: "https://host/barrel"` when barrel is mounted at `/barrel` in a host livery
+app; see the [embedding guide](../../docs/guides/embedding-barrel-server.md)).
+
 ## Vector search
 
 Pull each document's embedding to the browser and run brute-force cosine

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Start here.
 - [Record mode](guides/record-mode.md): policy-driven vector indexing over documents.
 - [Query with BQL](guides/query-bql.md): one query language over documents, vectors, and keyword search.
 - [Run the REST server](guides/rest-server.md): `barrel_server` over HTTP.
+- [Embed the barrel server in a livery app](guides/embedding-barrel-server.md): mount barrel's routes into a host livery service, under a sub-path.
 - [Synchronization](guides/synchronization.md): replication between databases.
 - [Timeline](guides/timeline.md): branch a database, work in isolation, merge back (incl. PITR).
 - [Encryption at rest](guides/encryption.md): per-database keys over every store and index file.

--- a/docs/guides/embedding-barrel-server.md
+++ b/docs/guides/embedding-barrel-server.md
@@ -1,0 +1,75 @@
+# Embed the barrel server in a livery app
+
+`barrel_server_api` exposes barrel's REST/sync routes as a plain `livery` route
+list so another Erlang application can serve them from its **own** livery service,
+optionally under a sub-path, with its own authentication. Read this when you want
+`barrel-lite` (or any HTTP client) to reach barrel through a host app's endpoint
+instead of running the standalone `barrel_server` listener.
+
+## When to use it
+
+- You already run a `livery` service and want to add barrel's `/db` + `/_sync`
+  surface to it, e.g. under `/barrel`.
+- You want the host app to own auth/CORS rather than barrel's built-in bearer/CORS.
+- For a turnkey standalone HTTP server instead, run `barrel_server` directly (see
+  [rest-server](rest-server.md)).
+
+## How
+
+Start `barrel` and `barrel_spaces`, then mount barrel's router into yours. The DB
+surface needs no `barrel_server` supervisor — the handlers are stateless.
+
+```erlang
+%% 1. Point barrel at a data dir and start it (not barrel_server).
+application:set_env(barrel_docdb, data_dir, "/var/lib/myapp/barrel"),
+{ok, _} = application:ensure_all_started(barrel),
+{ok, _} = application:ensure_all_started(barrel_spaces),
+
+%% 2. Mount barrel's default DB surface under /barrel, into your router.
+BarrelRouter = barrel_server_api:router(),
+Router = livery_router:nest(<<"/barrel">>, BarrelRouter, MyHostRouter),
+
+%% 3. Serve it. Your middleware owns auth; barrel ships none here.
+{ok, _} = livery:start_service(#{
+    http       => #{port => 8080},
+    router     => Router,
+    middleware => MyAuthStack
+}).
+```
+
+`barrel-lite` then points at the sub-path — no client change:
+
+```ts
+const db = openBarrel({ url: "https://host/barrel", db: "mydb" });
+```
+
+## Selecting routes
+
+`routes/0` (and `router/0`) return the default DB surface: the `db`, `sync`,
+`timeline`, and `search` groups — what barrel-lite drives. Pass `groups` to widen
+or narrow it; `mcp` and the `spaces`/`handoffs` agent layer are opt-in.
+
+```erlang
+barrel_server_api:routes().                              %% DB surface (default)
+barrel_server_api:routes(#{groups => [db, sync]}).       %% just docs + sync wire
+barrel_server_api:routes(#{groups => all}).              %% everything
+barrel_server_api:router(#{prefix => <<"/barrel">>}).    %% pre-nested router
+```
+
+Groups: `meta` (`/`, `/health`), `db`, `sync`, `timeline`, `search`, `spaces`,
+`mcp`. Unknown names raise `{unknown_route_group, Name}`.
+
+## Notes
+
+- The host owns auth. `barrel_server_api` returns routes only; wrap them with your
+  own middleware (`livery_router:layer/2` over the barrel subtree, or a
+  service-wide stack). barrel's built-in bearer/CORS live in the standalone
+  `barrel_server` service and are not applied here.
+- Set `barrel_docdb`'s `data_dir` yourself (the `barrel_server` app's config
+  mapping does not run when you don't start that app). Server-wide open options
+  come from `{barrel_server, open_opts, Map}` if set.
+- The `mcp` group needs the MCP registrar and live-query bridge running; start the
+  `barrel_server` application with the HTTP listener disabled for those, and note
+  that `/mcp` under a sub-path is not yet verified. The DB surface needs neither.
+- Route paths, request/response shapes, and the changes/SSE behavior are identical
+  to the standalone server — see [rest-server](rest-server.md).


### PR DESCRIPTION
## Why

To use barrel-lite (and any HTTP client) against another Erlang app, a host livery service needs to serve barrel's REST/sync routes itself, ideally under a sub-path, with the host owning auth. Until now barrel's route table was private to `barrel_server_http`.

## What

- New `barrel_server_api`: exposes barrel's routes as a grouped livery route list (`routes/0,1`) and compiled router (`router/0,1`). Groups: `meta`, `db`, `sync`, `timeline`, `search`, `spaces`, `mcp`. Default is the DB surface barrel-lite needs; `spaces`/`mcp` are opt-in. `router/1` takes `prefix` for sub-path mounting.
- `barrel_server_http:routes/0` delegates to it. The standalone service (handlers, middleware, listener) is unchanged.
- Host owns auth: the embeddable API ships no middleware, so nothing needed to become prefix-aware. The DB surface needs no barrel_server supervisor (handlers are stateless).
- barrel-lite already builds every URL from its base, so a sub-path works with no client change.

## Docs

New guide `docs/guides/embedding-barrel-server.md`, index + app-README pointers, and a barrel-lite note that `remote.url` may include a sub-path.

## Verification

- `barrel_server_embed_SUITE`: 6/6 (sub-path routing, doc CRUD + `_sync/info` under `/barrel`, host-owned auth 401, default excludes the agent layer).
- `barrel_server_SUITE` regression: 17/17.
- `rebar3 as server compile` (warnings-as-errors) and `xref` clean for barrel_server.