### PR TITLE
feat(server): signed-request + mTLS auth and H1/H2/H3 serving for the sync wire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the Barrel umbrella are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and each app
 is versioned independently under [Semantic Versioning](https://semver.org/).
 
+## [2026-07-17] Sync-wire auth hardening + multi-protocol serving
+
+`barrel_server` gains opt-in Ed25519 signed-request auth and an mTLS transport
+gate for the replication wire (bearer stays the default and is unchanged), and
+serves HTTP/1.1, HTTP/2, and HTTP/3 via a new `listeners` config. The signing
+helpers ship in `barrel_docdb` (`barrel_sync_sig`), used by both the server
+verifier and the replication client. H3 is TLS-serving but not yet a client-cert
+gate; mapping a client cert to an identity needs a livery change and is deferred.
+
+| App | Version | Change |
+|-----|---------|--------|
+| barrel_server | 1.2.0 | signed-request + mTLS auth (opt-in); H1/H2/H3 serving |
+| barrel_docdb | 1.1.0 | `barrel_sync_sig`; transport signing + `ssl_options` |
+
 ## [2026-07-14] Embeddable server + GitHub CI
 
 The umbrella is tagged `v1.1.0`. `barrel_server` gains an embeddable route API:

--- a/apps/barrel_docdb/CHANGELOG.md
+++ b/apps/barrel_docdb/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-07-17
+
+### Added
+- `barrel_sync_sig`: Ed25519 signing helpers for the replication wire (canonical
+  string, sign/verify, `Authorization: Signature` parsing), shared by the server
+  verifier and the client.
+- `barrel_rep_transport_http` endpoints gain optional `signing` (Ed25519 signed
+  requests) and `ssl_options` (mTLS client cert), plus the `sync_signing` and
+  `sync_ssl` app-env equivalents. Bearer auth is unchanged when neither is set.
+
 ## [1.0.0] - 2026-07-10
 
 First stable release. The `barrel_docdb` API is frozen: it will not break

--- a/apps/barrel_docdb/rebar.config
+++ b/apps/barrel_docdb/rebar.config
@@ -144,7 +144,7 @@
 
 %% Release configuration
 {relx, [
-    {release, {barrel_docdb, "1.0.0"}, [
+    {release, {barrel_docdb, "1.1.0"}, [
         barrel_docdb,
         sasl,
         instrument,

--- a/apps/barrel_docdb/src/barrel_docdb.app.src
+++ b/apps/barrel_docdb/src/barrel_docdb.app.src
@@ -1,6 +1,6 @@
 {application, barrel_docdb, [
     {description, "Erlang document database with MVCC, queries, and replication"},
-    {vsn, "1.0.0"},
+    {vsn, "1.1.0"},
     {registered, [barrel_docdb_sup]},
     {mod, {barrel_docdb_app, []}},
     {applications, [

--- a/apps/barrel_docdb/src/barrel_rep_transport_http.erl
+++ b/apps/barrel_docdb/src/barrel_rep_transport_http.erl
@@ -41,6 +41,11 @@
 -type endpoint() :: #{
     url := binary(),
     auth => #{token := binary()},
+    %% Ed25519 signed-request auth (see barrel_sync_sig). Takes precedence
+    %% over `auth' when set. priv_key is a 32-byte raw Ed25519 key.
+    signing => #{key_id := binary(), priv_key := binary()},
+    %% hackney ssl_options for mTLS (honored on https URLs).
+    ssl_options => [term()],
     pool => atom(),
     connect_timeout => pos_integer(),
     recv_timeout => pos_integer(),
@@ -269,7 +274,10 @@ get_attachment_stream(Endpoint, DocId, Name) ->
         {ok, ConnPid} ->
             case hackney:send_request(
                      ConnPid,
-                     {get, url_path(Url), base_headers(Endpoint), <<>>}) of
+                     {get, url_path(Url),
+                      base_headers(Endpoint, <<"GET">>, url_path(Url),
+                                   barrel_sync_sig:content_sha256(<<>>)),
+                      <<>>}) of
                 {ok, 200, RespHeaders, ConnPid2} ->
                     ok = barrel_hlc:maybe_sync_from_header(
                         header_value(?HLC_HEADER, RespHeaders)),
@@ -311,12 +319,16 @@ att_read_fun(ClientRef) ->
 put_attachment(Endpoint, DocId, Name, Meta, ReadFun) ->
     #{content_type := ContentType, digest := Digest,
       origin_hlc := Origin} = Meta,
+    AttUrl = att_url(Endpoint, DocId, Name),
+    %% The attachment body is streamed (never in memory here), so its
+    %% content-address `Digest' is the signed content hash; body integrity
+    %% rides the content-addressed store (422 digest_mismatch).
     Headers = [{<<"content-type">>, att_content_type(ContentType)},
                {?DIGEST_HEADER, Digest},
                {?ORIGIN_HEADER,
                 base64:encode(barrel_hlc:encode(Origin))}
-               | base_headers(Endpoint)],
-    case hackney:request(put, att_url(Endpoint, DocId, Name), Headers,
+               | base_headers(Endpoint, <<"PUT">>, url_path(AttUrl), Digest)],
+    case hackney:request(put, AttUrl, Headers,
                          stream, stream_opts(Endpoint)) of
         {ok, ClientRef} ->
             att_send_loop(ReadFun, ClientRef);
@@ -413,12 +425,15 @@ req(Endpoint, Method, PathSuffix, BodyTerm) ->
 req(#{url := BaseUrl} = Endpoint, Method, PathSuffix, BodyTerm,
     ExtraHeaders) ->
     Url = iolist_to_binary([BaseUrl, <<"/_sync">>, PathSuffix]),
-    Headers = [{<<"content-type">>, <<"application/json">>}
-               | ExtraHeaders] ++ base_headers(Endpoint),
     Body = case BodyTerm of
         undefined -> <<>>;
         _ -> iolist_to_binary(json:encode(BodyTerm))
     end,
+    ContentHash = barrel_sync_sig:content_sha256(Body),
+    Headers = [{<<"content-type">>, <<"application/json">>}
+               | ExtraHeaders]
+              ++ base_headers(Endpoint, method_bin(Method), url_path(Url),
+                              ContentHash),
     HttpOpts = [with_body | stream_opts(Endpoint)],
     case hackney:request(Method, Url, Headers, Body, HttpOpts) of
         {ok, Status, RespHeaders, RespBody} ->
@@ -429,25 +444,69 @@ req(#{url := BaseUrl} = Endpoint, Method, PathSuffix, BodyTerm,
             {error, {transport, Reason}}
     end.
 
-base_headers(Endpoint) ->
+%% HLC + auth + endpoint headers. `Method' is the uppercase verb, `Path'
+%% the request path (matching what the server signs), `ContentHash' the
+%% hex SHA-256 of the body (or the attachment digest).
+base_headers(Endpoint, Method, Path, ContentHash) ->
     [{?HLC_HEADER,
       base64:encode(barrel_hlc:encode(barrel_hlc:get_hlc()))}]
-    ++ auth_headers(Endpoint)
+    ++ auth_headers(Endpoint, Method, Path, ContentHash)
     ++ maps:get(headers, Endpoint, []).
 
 stream_opts(Endpoint) ->
-    [{pool, maps:get(pool, Endpoint, barrel_rep)},
-     {connect_timeout, maps:get(connect_timeout, Endpoint, 5000)},
-     {recv_timeout, maps:get(recv_timeout, Endpoint, 30000)}].
+    Base = [{pool, maps:get(pool, Endpoint, barrel_rep)},
+            {connect_timeout, maps:get(connect_timeout, Endpoint, 5000)},
+            {recv_timeout, maps:get(recv_timeout, Endpoint, 30000)}],
+    case ssl_options(Endpoint) of
+        [] -> Base;
+        Opts -> [{ssl_options, Opts} | Base]
+    end.
 
-auth_headers(#{auth := #{token := Token}}) ->
+%% Signed requests take precedence over bearer when configured; otherwise
+%% fall back to the (unchanged) bearer resolution.
+auth_headers(Endpoint, Method, Path, ContentHash) ->
+    case signing_config(Endpoint) of
+        #{key_id := KeyId, priv_key := PrivKey} ->
+            TsMs = erlang:system_time(millisecond),
+            Auth = barrel_sync_sig:sign(KeyId, PrivKey, Method, Path,
+                                        ContentHash, TsMs),
+            [{<<"authorization">>, Auth},
+             {<<"x-barrel-content-sha256">>, ContentHash}];
+        undefined ->
+            bearer_headers(Endpoint)
+    end.
+
+bearer_headers(#{auth := #{token := Token}}) ->
     [{<<"authorization">>, <<"Bearer ", Token/binary>>}];
-auth_headers(#{url := Url}) ->
+bearer_headers(#{url := Url}) ->
     Tokens = application:get_env(barrel_docdb, sync_auth, #{}),
     case maps:get(origin(Url), Tokens, undefined) of
         undefined -> [];
         Token -> [{<<"authorization">>, <<"Bearer ", Token/binary>>}]
     end.
+
+%% Signing config from the endpoint, else the app env
+%% `{barrel_docdb, sync_signing, #{Origin => #{key_id, priv_key}}}'
+%% (mirrors sync_auth; private keys never persist in task configs).
+signing_config(#{signing := Signing}) when is_map(Signing) ->
+    Signing;
+signing_config(#{url := Url}) ->
+    Cfg = application:get_env(barrel_docdb, sync_signing, #{}),
+    maps:get(origin(Url), Cfg, undefined).
+
+%% ssl_options from the endpoint, else app env
+%% `{barrel_docdb, sync_ssl, #{Origin => SslOptions}}'.
+ssl_options(#{ssl_options := Opts}) ->
+    Opts;
+ssl_options(#{url := Url}) ->
+    Cfg = application:get_env(barrel_docdb, sync_ssl, #{}),
+    maps:get(origin(Url), Cfg, []).
+
+method_bin(get) -> <<"GET">>;
+method_bin(post) -> <<"POST">>;
+method_bin(put) -> <<"PUT">>;
+method_bin(delete) -> <<"DELETE">>;
+method_bin(M) when is_binary(M) -> M.
 
 origin(Url) ->
     case binary:match(Url, <<"/db/">>) of

--- a/apps/barrel_docdb/src/barrel_sync_sig.erl
+++ b/apps/barrel_docdb/src/barrel_sync_sig.erl
@@ -1,0 +1,137 @@
+%%%-------------------------------------------------------------------
+%%% @doc Ed25519 signed-request auth for the barrel sync wire (protocol).
+%%%
+%%% Shared, pure helpers used by both ends of the wire: the client signer
+%%% ({@link barrel_rep_transport_http}, same app) and the server verifier
+%%% (`barrel_server_auth', which depends on barrel_docdb). It lives here,
+%%% the sync wire's home, so both sides share one canonical string.
+%%%
+%%% A request is authenticated by an Ed25519 signature over:
+%%% ```
+%%%   ts | keyId | METHOD | path | content_sha256_hex
+%%% '''
+%%% `ts' is milliseconds since the epoch (decimal ASCII); `content_sha256'
+%%% is the lowercase hex SHA-256 of the request body, carried in the
+%%% `x-barrel-content-sha256' header so the verifier never reads the body
+%%% (streamed attachments can be large). The signature travels in an
+%%% `Authorization: Signature keyId="..",ts="..",sig="base64"' header.
+%%%
+%%% This mirrors the retired barrel_memory peer-auth scheme, fixing its
+%%% two weaknesses: the body is bound end to end (the handler re-hashes it
+%%% against the signed header), and a missing/unknown key fails closed
+%%% here (never open). Replay protection is a server-side concern
+%%% (`barrel_server_sig_cache'); this module is pure.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_sync_sig).
+
+-export([content_sha256/1,
+         canonical/5,
+         sign/6,
+         parse_auth/1,
+         verify/6]).
+
+-type parsed() :: #{key_id := binary(), ts := integer(),
+                    sig := binary()}.
+-export_type([parsed/0]).
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Lowercase hex SHA-256 of a body (the value for
+%% `x-barrel-content-sha256').
+-spec content_sha256(iodata()) -> binary().
+content_sha256(Body) ->
+    binary:encode_hex(crypto:hash(sha256, Body), lowercase).
+
+%% @doc The canonical signing string. `Method' is the uppercase verb,
+%% `Path' the request path (no scheme/host/query), `ContentHashHex' the
+%% value of `x-barrel-content-sha256'.
+-spec canonical(binary(), binary(), binary(), binary(), binary()) ->
+    binary().
+canonical(TsBin, KeyId, Method, Path, ContentHashHex)
+        when is_binary(TsBin) ->
+    <<TsBin/binary, "|", KeyId/binary, "|", Method/binary, "|",
+      Path/binary, "|", ContentHashHex/binary>>.
+
+%% @doc Build the `Authorization: Signature ...' header value for a
+%% request. `PrivKey' is a 32-byte raw Ed25519 private key.
+-spec sign(binary(), binary(), binary(), binary(), binary(), integer()) ->
+    binary().
+sign(KeyId, PrivKey, Method, Path, ContentHashHex, TsMs) ->
+    TsBin = integer_to_binary(TsMs),
+    Canonical = canonical(TsBin, KeyId, Method, Path, ContentHashHex),
+    Sig = crypto:sign(eddsa, none, Canonical, [PrivKey, ed25519]),
+    SigB64 = base64:encode(Sig),
+    <<"Signature keyId=\"", KeyId/binary, "\",ts=\"", TsBin/binary,
+      "\",sig=\"", SigB64/binary, "\"">>.
+
+%% @doc Parse an `Authorization' header value. Returns `not_signature'
+%% for anything that is not the Signature scheme (e.g. Bearer), so the
+%% caller can fall through to other auth. Malformed Signature headers
+%% return `{error, malformed}'.
+-spec parse_auth(binary() | undefined) ->
+    {ok, parsed()} | not_signature | {error, malformed}.
+parse_auth(<<"Signature ", Rest/binary>>) ->
+    parse_params(Rest);
+parse_auth(_Other) ->
+    not_signature.
+
+%% @doc Verify a parsed signature against the configured signers and a
+%% skew window. Pure: replay is checked separately by the caller.
+%% `Signers' maps keyId to a 32-byte raw Ed25519 public key.
+-spec verify(binary(), binary(), binary(), parsed(), map(), integer()) ->
+    ok | {error, unknown_key | bad_signature | stale}.
+verify(Method, Path, ContentHashHex,
+       #{key_id := KeyId, ts := TsMs, sig := Sig}, Signers, SkewMs) ->
+    case maps:get(KeyId, Signers, undefined) of
+        undefined ->
+            {error, unknown_key};
+        PubKey ->
+            TsBin = integer_to_binary(TsMs),
+            Canonical = canonical(TsBin, KeyId, Method, Path, ContentHashHex),
+            case crypto:verify(eddsa, none, Canonical, Sig,
+                               [PubKey, ed25519]) of
+                true -> check_skew(TsMs, SkewMs);
+                false -> {error, bad_signature}
+            end
+    end.
+
+%%====================================================================
+%% Internal
+%%====================================================================
+
+check_skew(TsMs, SkewMs) ->
+    Now = erlang:system_time(millisecond),
+    case abs(Now - TsMs) =< SkewMs of
+        true -> ok;
+        false -> {error, stale}
+    end.
+
+parse_params(Bin) ->
+    try
+        Pairs = [split_kv(P) || P <- binary:split(Bin, <<",">>, [global])],
+        Map = maps:from_list(Pairs),
+        KeyId = maps:get(<<"keyId">>, Map),
+        TsMs = binary_to_integer(maps:get(<<"ts">>, Map)),
+        Sig = base64:decode(maps:get(<<"sig">>, Map)),
+        {ok, #{key_id => KeyId, ts => TsMs, sig => Sig}}
+    catch
+        _:_ -> {error, malformed}
+    end.
+
+%% `keyId="node1"' -> {<<"keyId">>, <<"node1">>}; tolerant of surrounding
+%% whitespace, strict about the quoted value.
+split_kv(Pair) ->
+    Trimmed = string:trim(Pair),
+    [K, QuotedV] = binary:split(Trimmed, <<"=">>),
+    V = unquote(QuotedV),
+    {K, V}.
+
+unquote(<<"\"", Rest/binary>>) ->
+    Size = byte_size(Rest) - 1,
+    <<V:Size/binary, "\"">> = Rest,
+    V;
+unquote(V) ->
+    V.

--- a/apps/barrel_docdb/test/barrel_sync_sig_tests.erl
+++ b/apps/barrel_docdb/test/barrel_sync_sig_tests.erl
@@ -1,0 +1,88 @@
+%%%-------------------------------------------------------------------
+%%% @doc Unit tests for the sync-wire signing helpers.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_sync_sig_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(METHOD, <<"POST">>).
+-define(PATH, <<"/db/mydb/_sync/changes">>).
+
+keypair() ->
+    crypto:generate_key(eddsa, ed25519).
+
+roundtrip_test() ->
+    {Pub, Priv} = keypair(),
+    KeyId = <<"node1">>,
+    Signers = #{KeyId => Pub},
+    CH = barrel_sync_sig:content_sha256(<<"{\"since\":0}">>),
+    Ts = erlang:system_time(millisecond),
+    Auth = barrel_sync_sig:sign(KeyId, Priv, ?METHOD, ?PATH, CH, Ts),
+    {ok, Parsed} = barrel_sync_sig:parse_auth(Auth),
+    ?assertEqual(ok,
+        barrel_sync_sig:verify(?METHOD, ?PATH, CH, Parsed, Signers, 300000)).
+
+unknown_key_test() ->
+    {_Pub, Priv} = keypair(),
+    KeyId = <<"node1">>,
+    CH = barrel_sync_sig:content_sha256(<<>>),
+    Ts = erlang:system_time(millisecond),
+    Auth = barrel_sync_sig:sign(KeyId, Priv, ?METHOD, ?PATH, CH, Ts),
+    {ok, Parsed} = barrel_sync_sig:parse_auth(Auth),
+    ?assertEqual({error, unknown_key},
+        barrel_sync_sig:verify(?METHOD, ?PATH, CH, Parsed, #{}, 300000)).
+
+%% A different content hash than was signed fails verification (this is
+%% how a tampered body is caught: the handler re-derives the hash).
+bad_signature_test() ->
+    {Pub, Priv} = keypair(),
+    KeyId = <<"node1">>,
+    Signers = #{KeyId => Pub},
+    CH = barrel_sync_sig:content_sha256(<<"real">>),
+    Ts = erlang:system_time(millisecond),
+    Auth = barrel_sync_sig:sign(KeyId, Priv, ?METHOD, ?PATH, CH, Ts),
+    {ok, Parsed} = barrel_sync_sig:parse_auth(Auth),
+    Tampered = barrel_sync_sig:content_sha256(<<"tampered">>),
+    ?assertEqual({error, bad_signature},
+        barrel_sync_sig:verify(?METHOD, ?PATH, Tampered, Parsed, Signers,
+                               300000)).
+
+%% A different path than was signed also fails (binds method+path).
+wrong_path_test() ->
+    {Pub, Priv} = keypair(),
+    KeyId = <<"node1">>,
+    Signers = #{KeyId => Pub},
+    CH = barrel_sync_sig:content_sha256(<<>>),
+    Ts = erlang:system_time(millisecond),
+    Auth = barrel_sync_sig:sign(KeyId, Priv, ?METHOD, ?PATH, CH, Ts),
+    {ok, Parsed} = barrel_sync_sig:parse_auth(Auth),
+    ?assertEqual({error, bad_signature},
+        barrel_sync_sig:verify(?METHOD, <<"/db/other/_sync/changes">>, CH,
+                               Parsed, Signers, 300000)).
+
+stale_test() ->
+    {Pub, Priv} = keypair(),
+    KeyId = <<"node1">>,
+    Signers = #{KeyId => Pub},
+    CH = barrel_sync_sig:content_sha256(<<>>),
+    OldTs = erlang:system_time(millisecond) - 600000,
+    Auth = barrel_sync_sig:sign(KeyId, Priv, ?METHOD, ?PATH, CH, OldTs),
+    {ok, Parsed} = barrel_sync_sig:parse_auth(Auth),
+    ?assertEqual({error, stale},
+        barrel_sync_sig:verify(?METHOD, ?PATH, CH, Parsed, Signers, 300000)).
+
+parse_bearer_test() ->
+    ?assertEqual(not_signature,
+                 barrel_sync_sig:parse_auth(<<"Bearer some-token">>)),
+    ?assertEqual(not_signature, barrel_sync_sig:parse_auth(undefined)).
+
+parse_malformed_test() ->
+    ?assertEqual({error, malformed},
+                 barrel_sync_sig:parse_auth(<<"Signature nonsense">>)).
+
+content_sha256_test() ->
+    %% known vector: sha256("") lowercase hex
+    ?assertEqual(
+        <<"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855">>,
+        barrel_sync_sig:content_sha256(<<>>)).

--- a/apps/barrel_server/CHANGELOG.md
+++ b/apps/barrel_server/CHANGELOG.md
@@ -3,6 +3,23 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.0] - 2026-07-17
+
+### Added
+- Signed-request auth for the sync wire: Ed25519 signatures over
+  `ts|keyId|method|path|sha256(body)`, with replay protection and a skew window.
+  Enabled by `auth => #{accept => [..., signed], signers => #{KeyId => PubKey}}`.
+- mTLS transport gate: TLS listeners with `verify => verify_peer` refuse a client
+  without a CA-signed certificate (`accept => [mtls]`).
+- Multi-protocol serving: `listeners => #{http, https, http3}` serves HTTP/1.1,
+  HTTP/2, and HTTP/3; a shared `tls` config drives the TLS listeners. See the
+  [synchronization guide](https://github.com/barrel-db/barrel/blob/main/docs/guides/synchronization.md).
+
+### Changed
+- The `auth` key is unchanged without an `accept` list (bearer-only, as before);
+  the new methods are opt-in and additive. H3 is TLS-serving but not yet a
+  client-cert gate; mapping a client cert to an identity needs a livery change.
+
 ## [1.1.0] - 2026-07-14
 
 ### Added

--- a/apps/barrel_server/README.md
+++ b/apps/barrel_server/README.md
@@ -43,8 +43,22 @@ All keys live in the `barrel_server` app env. Set them in `sys.config`, or with
     {max_body, 1073741824},
     %% Options passed to barrel:open_db/2 when a database opens lazily.
     {open_opts, #{}},
-    %% Bearer auth. Omit the key entirely to leave the server open.
-    {auth, #{tokens => [<<"secret-one">>, <<"secret-two">>]}},
+    %% Auth. Omit the key entirely to leave the server open. Without an
+    %% `accept' key this is bearer-only (unchanged). With `accept' it opts
+    %% into bearer | signed (Ed25519) | mtls; see the synchronization guide.
+    {auth, #{accept  => [bearer, signed],
+             tokens  => [<<"secret-one">>, <<"secret-two">>],
+             signers => #{<<"node1">> => <<"...32 raw bytes...">>},
+             skew_ms => 300000}},
+    %% Listeners. Omit for a single cleartext HTTP/1.1 on http_port; set to
+    %% serve HTTP/2 and HTTP/3 and TLS (https/http3 and `tls => true' on http
+    %% require the `tls' config below).
+    {listeners, #{http => #{port => 8443, tls => true},
+                  https => #{port => 8444},
+                  http3 => #{port => 8444}}},
+    %% Shared TLS for the TLS listeners. `verify => verify_peer' = mTLS gate.
+    {tls, #{certfile => "server.pem", keyfile => "server.key",
+            cacertfile => "ca.pem", verify => verify_peer}},
     %% CORS. Omit to emit no CORS headers.
     {cors, #{origins => '*'}},
     %% MCP endpoint. Enabled by default when the key is absent.

--- a/apps/barrel_server/src/barrel_server.app.src
+++ b/apps/barrel_server/src/barrel_server.app.src
@@ -1,6 +1,6 @@
 {application, barrel_server, [
     {description, "Multi-protocol server for the barrel edge database (REST/JSON over livery)"},
-    {vsn, "1.1.0"},
+    {vsn, "1.2.0"},
     {registered, [barrel_server_sup]},
     {mod, {barrel_server_app, []}},
     {applications, [

--- a/apps/barrel_server/src/barrel_server_auth.erl
+++ b/apps/barrel_server/src/barrel_server_auth.erl
@@ -29,20 +29,57 @@
 -export([call/3]).
 
 %% @doc Middleware state from the app env; undefined = no auth.
+%%
+%% A config WITHOUT an `accept' key is legacy and behaves exactly as
+%% before (bearer only; empty/invalid = open). A config WITH `accept'
+%% opts into the multi-method system (bearer | signed | mtls) and is
+%% always installed (fail-closed on misconfiguration).
 -spec state_from_env() -> map() | undefined.
 state_from_env() ->
     case application:get_env(barrel_server, auth, undefined) of
         undefined ->
             undefined;
-        #{tokens := Tokens} when is_list(Tokens), Tokens =/= [] ->
-            #{hashes => [crypto:hash(sha256, T) || T <- Tokens]};
-        #{token := Token} when is_binary(Token) ->
-            #{hashes => [crypto:hash(sha256, Token)]};
+        Cfg when is_map(Cfg) ->
+            case maps:is_key(accept, Cfg) of
+                false -> legacy_state(Cfg);
+                true -> multi_state(Cfg)
+            end;
         Other ->
             logger:warning("ignoring invalid barrel_server auth config: ~p",
                            [Other]),
             undefined
     end.
+
+%% Legacy bearer-only config: byte-for-byte the previous behavior.
+legacy_state(#{tokens := Tokens}) when is_list(Tokens), Tokens =/= [] ->
+    base_state([crypto:hash(sha256, T) || T <- Tokens], #{}, [bearer], 300000);
+legacy_state(#{token := Token}) when is_binary(Token) ->
+    base_state([crypto:hash(sha256, Token)], #{}, [bearer], 300000);
+legacy_state(Other) ->
+    logger:warning("ignoring invalid barrel_server auth config: ~p", [Other]),
+    undefined.
+
+%% New-style config: accept => [bearer|signed|mtls], optional signers and
+%% skew. Unknown accept methods are dropped; an empty accept locks the
+%% server (every request 401s) rather than falling open.
+multi_state(Cfg) ->
+    Accept = [M || M <- maps:get(accept, Cfg, [bearer]),
+                   lists:member(M, [bearer, signed, mtls])],
+    Hashes = token_hashes(Cfg),
+    Signers = maps:get(signers, Cfg, #{}),
+    SkewMs = maps:get(skew_ms, Cfg, 300000),
+    base_state(Hashes, Signers, Accept, SkewMs).
+
+token_hashes(#{tokens := Tokens}) when is_list(Tokens) ->
+    [crypto:hash(sha256, T) || T <- Tokens];
+token_hashes(#{token := Token}) when is_binary(Token) ->
+    [crypto:hash(sha256, Token)];
+token_hashes(_) ->
+    [].
+
+base_state(Hashes, Signers, Accept, SkewMs) ->
+    #{hashes => Hashes, signers => Signers,
+      accept => Accept, skew_ms => SkewMs}.
 
 %% @doc The configured token hashes (undefined = open server). The
 %% MCP auth provider checks server bearers against the same set.
@@ -50,10 +87,11 @@ state_from_env() ->
 hashes() ->
     case state_from_env() of
         undefined -> undefined;
+        #{hashes := []} -> undefined;
         #{hashes := Hashes} -> Hashes
     end.
 
-call(Req, Next, #{hashes := Hashes}) ->
+call(Req, Next, State) ->
     case livery_req:path(Req) of
         <<"/health">> ->
             Next(Req);
@@ -63,23 +101,67 @@ call(Req, Next, #{hashes := Hashes}) ->
             %% tokens plus capability tokens
             Next(Req);
         Path ->
+            %% Capability tokens (bsp_...) are a scoped principal for the
+            %% agent layer and are handled as before, independent of the
+            %% global `accept' set. Everything else must satisfy one of
+            %% the accepted global methods.
             case livery_ext:bearer_token(Req) of
-                undefined ->
-                    unauthorized();
                 <<"bsp_", _/binary>> = Token ->
                     capability(Req, Next, Token, Path);
-                Token ->
-                    Hash = crypto:hash(sha256, Token),
-                    case lists:any(
-                             fun(Expected) ->
-                                 crypto:hash_equals(Hash, Expected)
-                             end,
-                             Hashes) of
+                _ ->
+                    case authorized(Req, State) of
                         true -> Next(Req);
                         false -> unauthorized()
                     end
             end
     end.
+
+%% True if any accepted global method authenticates the request.
+authorized(Req, #{accept := Accept} = State) ->
+    (lists:member(signed, Accept) andalso try_signed(Req, State))
+        orelse (lists:member(bearer, Accept) andalso try_bearer(Req, State))
+        orelse (lists:member(mtls, Accept) andalso mtls_ok(Req)).
+
+%% Ed25519 signed request: verify the signature, then consume it against
+%% the replay cache. Any failure (no header, unknown key, bad signature,
+%% stale timestamp, replay, or cache down) is a decline.
+try_signed(Req, #{signers := Signers, skew_ms := SkewMs}) ->
+    case barrel_sync_sig:parse_auth(
+             livery_req:header(<<"authorization">>, Req, undefined)) of
+        {ok, #{key_id := KeyId, ts := Ts, sig := Sig} = Parsed} ->
+            Method = livery_req:method(Req),
+            Path = livery_req:path(Req),
+            ContentHash = livery_req:header(<<"x-barrel-content-sha256">>,
+                                            Req, <<>>),
+            case barrel_sync_sig:verify(Method, Path, ContentHash,
+                                          Parsed, Signers, SkewMs) of
+                ok ->
+                    barrel_server_sig_cache:check_and_insert(
+                        {KeyId, Ts, Sig}, 2 * SkewMs) =:= ok;
+                {error, _} ->
+                    false
+            end;
+        _ ->
+            false
+    end.
+
+%% Constant-time global bearer check (bsp_ tokens never reach here).
+try_bearer(Req, #{hashes := Hashes}) ->
+    case livery_ext:bearer_token(Req) of
+        Token when is_binary(Token) ->
+            Hash = crypto:hash(sha256, Token),
+            lists:any(fun(Expected) -> crypto:hash_equals(Hash, Expected) end,
+                      Hashes);
+        _ ->
+            false
+    end.
+
+%% mTLS transport gate: a request that arrived over TLS is authenticated,
+%% relying on the listener's `fail_if_no_peer_cert' so arrival implies a
+%% verified client cert. H1-TLS surfaces `tls => #{}'; H2/H3 surface no
+%% tls today (see the companion livery change), so this is H1-only.
+mtls_ok(Req) ->
+    livery_req:tls(Req) =/= undefined.
 
 %% Capability tokens: agent-layer surface (rights enforced per route
 %% in the handlers), or the /db surface scoped to the granted space.

--- a/apps/barrel_server/src/barrel_server_http.erl
+++ b/apps/barrel_server/src/barrel_server_http.erl
@@ -61,16 +61,14 @@
 
 -spec start_link() -> {ok, pid()} | {error, term()}.
 start_link() ->
-    Port = application:get_env(barrel_server, http_port, 8080),
-    %% Request body ceiling (livery >= 0.5.1: one authoritative knob,
-    %% graceful abort past it); must clear the largest attachment
-    %% expected over _sync. JSON handlers stay bounded by
-    %% livery_body:read_all's own 16 MiB cap.
-    MaxBody = application:get_env(barrel_server, max_body,
-                                  1024 * 1024 * 1024),
+    %% Listener map (H1/H2/H3 + TLS/mTLS) from the app env; with no
+    %% `listeners' key this is a single cleartext H1 on `http_port'.
+    %% Request body ceiling (livery >= 0.5.1) rides in each listener; it
+    %% must clear the largest attachment expected over _sync (JSON
+    %% handlers stay bounded by livery_body:read_all's own 16 MiB cap).
     Router = livery_router:compile(routes()),
-    livery:start_service(#{
-        http => #{port => Port, max_body => MaxBody},
+    Listeners = barrel_server_listeners:service_listeners(),
+    livery:start_service(Listeners#{
         router => Router,
         middleware => middleware()
     }).

--- a/apps/barrel_server/src/barrel_server_listeners.erl
+++ b/apps/barrel_server/src/barrel_server_listeners.erl
@@ -1,0 +1,92 @@
+%%%-------------------------------------------------------------------
+%%% @doc Build the livery listener map for barrel_server (H1/H2/H3, TLS,
+%%% mTLS) from the app env.
+%%%
+%%% With no `listeners' key the server behaves exactly as before: a single
+%%% cleartext HTTP/1.1 listener on `http_port'. A `listeners' map opts into
+%%% multi-protocol serving:
+%%% ```
+%%%   {barrel_server, listeners, #{http  => #{port => 8080},
+%%%                                https => #{port => 8443},
+%%%                                http3 => #{port => 8443}}}
+%%% '''
+%%% `https' (H2) and `http3' (H3) require TLS, from a shared config:
+%%% ```
+%%%   {barrel_server, tls, #{certfile, keyfile, cacertfile, verify}}
+%%% '''
+%%% The `http' (H1) listener stays cleartext unless its entry sets
+%%% `tls => true' (used for the sync-wire mTLS gate, since the replication
+%%% client speaks HTTP/1.1). mTLS is requested with `verify => verify_peer'
+%%% + `cacertfile'; because livery/h1/h2 drop a top-level `verify', the
+%%% real knobs are packed into `ssl_opts'. H3 is TLS-serving only; its
+%%% client-cert gate is not yet complete (see the companion livery change).
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_server_listeners).
+
+-export([service_listeners/0]).
+
+-define(DEFAULT_MAX_BODY, (1024 * 1024 * 1024)).
+
+%% @doc The `#{http => .., https => .., http3 => ..}' portion of the
+%% `livery:start_service/1' map (router and middleware are added by the
+%% caller).
+-spec service_listeners() -> map().
+service_listeners() ->
+    MaxBody = application:get_env(barrel_server, max_body, ?DEFAULT_MAX_BODY),
+    case application:get_env(barrel_server, listeners, undefined) of
+        undefined ->
+            Port = application:get_env(barrel_server, http_port, 8080),
+            #{http => #{port => Port, max_body => MaxBody}};
+        Map when is_map(Map) ->
+            Tls = application:get_env(barrel_server, tls, undefined),
+            maps:map(fun(Proto, Cfg) -> listener(Proto, Cfg, MaxBody, Tls) end,
+                     Map)
+    end.
+
+%%====================================================================
+%% Internal
+%%====================================================================
+
+listener(http, Cfg, MaxBody, Tls) ->
+    Base = #{port => maps:get(port, Cfg, 8080), max_body => MaxBody},
+    case maps:get(tls, Cfg, false) of
+        true -> add_tls(Base, require_tls(http, Tls));
+        false -> Base
+    end;
+listener(https, Cfg, MaxBody, Tls) ->
+    Base = #{port => maps:get(port, Cfg, 8443), max_body => MaxBody},
+    add_tls(Base, require_tls(https, Tls));
+listener(http3, Cfg, MaxBody, Tls) ->
+    Base = #{port => maps:get(port, Cfg, 8443), max_body => MaxBody},
+    add_h3_tls(Base, require_tls(http3, Tls)).
+
+require_tls(Proto, undefined) ->
+    error({barrel_server, {tls_config_required, Proto}});
+require_tls(_Proto, Tls) when is_map(Tls) ->
+    Tls.
+
+%% H1/H2 over OTP ssl. `transport => ssl' turns the H1 listener into TLS
+%% (H2 is TLS by default); mTLS bits ride in `ssl_opts'.
+add_tls(Base, #{certfile := Cert, keyfile := Key} = Tls) ->
+    M = Base#{transport => ssl, cert => Cert, key => Key},
+    case ssl_opts(Tls) of
+        [] -> M;
+        Opts -> M#{ssl_opts => Opts}
+    end.
+
+%% H3/QUIC: serve TLS. A real client-cert gate (fail_if_no_peer_cert +
+%% chain validation) is deferred to the companion livery/quic change, so
+%% we only wire cert/key here.
+add_h3_tls(Base, #{certfile := Cert, keyfile := Key}) ->
+    Base#{cert => Cert, key => Key}.
+
+%% verify_peer => a mutual-TLS gate: OTP ssl refuses a client that offers
+%% no cert (fail_if_no_peer_cert) or one that does not chain to cacertfile.
+%% Operator-supplied ssl_opts win.
+ssl_opts(#{verify := verify_peer} = Tls) ->
+    CA = maps:get(cacertfile, Tls),
+    [{verify, verify_peer}, {fail_if_no_peer_cert, true}, {cacertfile, CA}]
+        ++ maps:get(ssl_opts, Tls, []);
+ssl_opts(Tls) ->
+    maps:get(ssl_opts, Tls, []).

--- a/apps/barrel_server/src/barrel_server_sig_cache.erl
+++ b/apps/barrel_server/src/barrel_server_sig_cache.erl
@@ -1,0 +1,81 @@
+%%%-------------------------------------------------------------------
+%%% @doc Replay cache for signed sync requests.
+%%%
+%%% A bounded, public ETS set keyed by `{KeyId, Ts, Sig}'. The verifier
+%%% ({@link barrel_server_auth}) calls {@link check_and_insert/2} on the
+%%% hot path: a first sighting inserts and returns `ok'; a repeat within
+%%% the window returns `{error, replayed}'. This closes the replay gap the
+%%% retired barrel_memory peer-auth scheme left open (it had only a
+%%% timestamp window).
+%%%
+%%% This gen_server owns the table and sweeps expired entries; the atomic
+%%% `ets:insert_new/2' means the check needs no server round-trip. If the
+%%% table is absent (server not started), the check fails closed.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_server_sig_cache).
+-behaviour(gen_server).
+
+-export([start_link/0, check_and_insert/2]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
+
+-define(TABLE, ?MODULE).
+-define(DEFAULT_SWEEP_MS, 60000).
+
+%%====================================================================
+%% API
+%%====================================================================
+
+-spec start_link() -> {ok, pid()} | {error, term()}.
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+%% @doc Record a request signature. `TtlMs' bounds how long the entry is
+%% retained (use twice the accepted skew). Returns `ok' the first time a
+%% `Key' is seen, `{error, replayed}' on a repeat, and `{error, no_cache}'
+%% if the cache is not running (fail closed).
+-spec check_and_insert(term(), pos_integer()) ->
+    ok | {error, replayed | no_cache}.
+check_and_insert(Key, TtlMs) ->
+    Expiry = erlang:system_time(millisecond) + TtlMs,
+    try ets:insert_new(?TABLE, {Key, Expiry}) of
+        true -> ok;
+        false -> {error, replayed}
+    catch
+        error:badarg -> {error, no_cache}
+    end.
+
+%%====================================================================
+%% gen_server
+%%====================================================================
+
+init([]) ->
+    _ = ets:new(?TABLE, [named_table, public, set,
+                         {read_concurrency, true},
+                         {write_concurrency, true}]),
+    SweepMs = application:get_env(barrel_server, sig_replay_sweep_ms,
+                                  ?DEFAULT_SWEEP_MS),
+    schedule_sweep(SweepMs),
+    {ok, #{sweep_ms => SweepMs}}.
+
+handle_call(_Req, _From, State) ->
+    {reply, {error, unknown_call}, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(sweep, #{sweep_ms := SweepMs} = State) ->
+    Now = erlang:system_time(millisecond),
+    %% delete every entry whose expiry is at or before now
+    _ = ets:select_delete(?TABLE, [{{'_', '$1'}, [{'=<', '$1', Now}], [true]}]),
+    schedule_sweep(SweepMs),
+    {noreply, State};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%%====================================================================
+%% Internal
+%%====================================================================
+
+schedule_sweep(SweepMs) ->
+    erlang:send_after(SweepMs, self(), sweep).

--- a/apps/barrel_server/src/barrel_server_sup.erl
+++ b/apps/barrel_server/src/barrel_server_sup.erl
@@ -25,6 +25,12 @@ start_link() ->
 init([]) ->
     SupFlags = #{strategy => one_for_one, intensity => 5, period => 10},
     Children = [
+        #{id => barrel_server_sig_cache,
+          start => {barrel_server_sig_cache, start_link, []},
+          restart => permanent,
+          shutdown => 5000,
+          type => worker,
+          modules => [barrel_server_sig_cache]},
         #{id => barrel_server_mcp_live,
           start => {barrel_server_mcp_live, start_link, []},
           restart => permanent,

--- a/apps/barrel_server/src/barrel_server_sync.erl
+++ b/apps/barrel_server/src/barrel_server_sync.erl
@@ -555,15 +555,40 @@ with_json(Req, Fun) ->
     end.
 
 read_json(Req) ->
+    case read_raw(Req) of
+        {ok, Bin} ->
+            case content_hash_ok(Req, Bin) of
+                ok -> decode_json(Bin);
+                {error, _} = Err -> Err
+            end;
+        {error, _} = Err ->
+            Err
+    end.
+
+read_raw(Req) ->
     case livery_req:body(Req) of
         empty ->
-            {ok, #{}};
+            {ok, <<>>};
         {buffered, Io} ->
-            decode_json(iolist_to_binary(Io));
+            {ok, iolist_to_binary(Io)};
         {stream, Reader} ->
             case livery_body:read_all(Reader) of
-                {ok, Bin, _R2} -> decode_json(Bin);
+                {ok, Bin, _R2} -> {ok, Bin};
                 {error, Reason, _R2} -> {error, Reason}
+            end
+    end.
+
+%% End-to-end body binding for signed requests: when the client signed an
+%% `x-barrel-content-sha256' (verified by barrel_server_auth), the body
+%% must hash to it. Absent header = not a signed request; no check.
+content_hash_ok(Req, Bin) ->
+    case livery_req:header(<<"x-barrel-content-sha256">>, Req, undefined) of
+        undefined ->
+            ok;
+        Declared ->
+            case barrel_sync_sig:content_sha256(Bin) of
+                Declared -> ok;
+                _ -> {error, content_hash_mismatch}
             end
     end.
 

--- a/apps/barrel_server/test/barrel_server_mtls_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_mtls_SUITE.erl
@@ -1,0 +1,146 @@
+%%%-------------------------------------------------------------------
+%%% @doc Multi-protocol serving (H1/H2/H3) and the mTLS transport gate.
+%%%
+%%% Boots barrel_server with an H1-over-TLS listener requiring client
+%%% certs (`verify_peer' + `fail_if_no_peer_cert'), plus H2 and H3
+%%% listeners, and `accept => [mtls]'. Verifies: all three listeners bind;
+%%% a client presenting a CA-signed cert authenticates; a client with no
+%%% cert is refused at the TLS handshake. Requires `openssl' (skips
+%%% otherwise). The sync client speaks HTTP/1.1, so the gate is exercised
+%%% on H1-TLS.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_server_mtls_SUITE).
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([t_listeners_bind/1, t_mtls_client_authenticates/1,
+         t_certless_refused/1]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-define(DB, "mdb").
+
+all() ->
+    [t_listeners_bind, t_mtls_client_authenticates, t_certless_refused].
+
+init_per_suite(Config) ->
+    case os:find_executable("openssl") of
+        false ->
+            {skip, "openssl not available"};
+        _ ->
+            Dir = ?config(priv_dir, Config),
+            ok = gen_certs(Dir),
+            application:load(barrel_server),
+            application:set_env(barrel_server, data_dir, Dir),
+            application:set_env(barrel_server, listeners,
+                                #{http => #{port => 0, tls => true},
+                                  https => #{port => 0},
+                                  http3 => #{port => 0}}),
+            application:set_env(barrel_server, tls,
+                                #{certfile => f(Dir, "server.pem"),
+                                  keyfile => f(Dir, "server.key"),
+                                  cacertfile => f(Dir, "ca.pem"),
+                                  verify => verify_peer}),
+            application:set_env(barrel_server, auth, #{accept => [mtls]}),
+            {ok, _} = application:ensure_all_started(barrel_server),
+            {ok, _} = application:ensure_all_started(hackney),
+            Listeners = listeners(),
+            [{dir, Dir}, {listeners, Listeners} | Config]
+    end.
+
+end_per_suite(Config) ->
+    case ?config(dir, Config) of
+        undefined -> ok;
+        _ ->
+            application:stop(barrel_server),
+            application:unset_env(barrel_server, listeners),
+            application:unset_env(barrel_server, tls),
+            application:unset_env(barrel_server, auth)
+    end,
+    ok.
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+t_listeners_bind(Config) ->
+    L = ?config(listeners, Config),
+    ?assertMatch(#{h1 := _, h2 := _, h3 := _}, L),
+    ok.
+
+t_mtls_client_authenticates(Config) ->
+    Base = tls_base(Config),
+    Dir = ?config(dir, Config),
+    {201, _} = req(put, Base ++ "/db/" ++ ?DB, client_ssl(Dir)),
+    {200, _} = req(get, Base ++ "/db/" ++ ?DB, client_ssl(Dir)),
+    ok.
+
+%% No client certificate: the listener's fail_if_no_peer_cert rejects at
+%% the TLS handshake, so the request never reaches the app.
+t_certless_refused(Config) ->
+    Base = tls_base(Config),
+    Dir = ?config(dir, Config),
+    Res = hackney:request(get, list_to_binary(Base ++ "/db/" ++ ?DB),
+                          [], <<>>,
+                          [with_body, {ssl_options, no_cert_ssl(Dir)}]),
+    ?assertMatch({error, _}, Res),
+    ok.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+listeners() ->
+    Children = supervisor:which_children(barrel_server_sup),
+    {_, Pid, _, _} = lists:keyfind(barrel_server_http, 1, Children),
+    livery:which_listeners(Pid).
+
+tls_base(Config) ->
+    #{h1 := Port} = ?config(listeners, Config),
+    "https://127.0.0.1:" ++ integer_to_list(Port).
+
+%% present the client cert and trust the test CA (which signed the server
+%% cert, SAN IP:127.0.0.1) so the server-cert check passes; the point
+%% under test is the server verifying us.
+client_ssl(Dir) ->
+    [{certfile, f(Dir, "client.pem")},
+     {keyfile, f(Dir, "client.key")},
+     {cacertfile, f(Dir, "ca.pem")},
+     {verify, verify_peer}].
+
+%% trust the server but present no client cert: the server rejects.
+no_cert_ssl(Dir) ->
+    [{cacertfile, f(Dir, "ca.pem")},
+     {verify, verify_peer}].
+
+req(Method, Url, SslOpts) ->
+    {ok, S, _H, RB} = hackney:request(Method, list_to_binary(Url), [], <<>>,
+                                      [with_body, {ssl_options, SslOpts}]),
+    {S, RB}.
+
+f(Dir, Name) -> filename:join(Dir, Name).
+
+gen_certs(Dir) ->
+    CA = f(Dir, "ca.pem"), CAK = f(Dir, "ca.key"),
+    SV = f(Dir, "server.pem"), SVK = f(Dir, "server.key"),
+    CL = f(Dir, "client.pem"), CLK = f(Dir, "client.key"),
+    SCsr = f(Dir, "server.csr"), CCsr = f(Dir, "client.csr"),
+    Ext = f(Dir, "san.ext"),
+    ok = file:write_file(Ext, "subjectAltName=IP:127.0.0.1\n"),
+    sh("openssl req -x509 -newkey rsa:2048 -nodes -keyout " ++ CAK ++
+       " -out " ++ CA ++ " -days 2 -subj /CN=barrel-test-ca"),
+    sh("openssl req -newkey rsa:2048 -nodes -keyout " ++ SVK ++
+       " -out " ++ SCsr ++ " -subj /CN=127.0.0.1"),
+    sh("openssl x509 -req -in " ++ SCsr ++ " -CA " ++ CA ++ " -CAkey " ++ CAK ++
+       " -CAcreateserial -out " ++ SV ++ " -days 2 -extfile " ++ Ext),
+    sh("openssl req -newkey rsa:2048 -nodes -keyout " ++ CLK ++
+       " -out " ++ CCsr ++ " -subj /CN=peer-node1"),
+    sh("openssl x509 -req -in " ++ CCsr ++ " -CA " ++ CA ++ " -CAkey " ++ CAK ++
+       " -CAcreateserial -out " ++ CL ++ " -days 2"),
+    true = filelib:is_regular(CL),
+    ok.
+
+sh(Cmd) ->
+    _ = os:cmd(Cmd ++ " 2>/dev/null"),
+    ok.

--- a/apps/barrel_server/test/barrel_server_signed_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_signed_SUITE.erl
@@ -1,0 +1,148 @@
+%%%-------------------------------------------------------------------
+%%% @doc Ed25519 signed-request auth over the REST/sync wire, with
+%%% bearer dual-accept and replay protection.
+%%%
+%%% Boots barrel_server with `accept => [bearer, signed]' and exercises
+%%% both principals plus the failure modes the retired peer-auth scheme
+%%% missed: replay, tampered body, stale timestamp, unknown key. The
+%%% bearer-only (legacy) behavior is covered by barrel_server_auth_SUITE.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_server_signed_SUITE).
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([
+    t_bearer_authenticates/1,
+    t_signed_authenticates/1,
+    t_no_auth_rejected/1,
+    t_unknown_key_rejected/1,
+    t_stale_rejected/1,
+    t_replay_rejected/1,
+    t_tampered_body_rejected/1
+]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-define(TOKEN, <<"secret-bearer">>).
+-define(KEYID, <<"node1">>).
+-define(DB, "sdb").
+
+all() ->
+    [t_bearer_authenticates, t_signed_authenticates, t_no_auth_rejected,
+     t_unknown_key_rejected, t_stale_rejected, t_replay_rejected,
+     t_tampered_body_rejected].
+
+init_per_suite(Config) ->
+    {Pub, Priv} = crypto:generate_key(eddsa, ed25519),
+    application:load(barrel_server),
+    application:set_env(barrel_server, data_dir, ?config(priv_dir, Config)),
+    application:set_env(barrel_server, http_port, 0),
+    application:set_env(barrel_server, auth,
+                        #{accept => [bearer, signed],
+                          tokens => [?TOKEN],
+                          signers => #{?KEYID => Pub},
+                          skew_ms => 300000}),
+    {ok, _} = application:ensure_all_started(barrel_server),
+    {ok, _} = application:ensure_all_started(hackney),
+    Base = "http://127.0.0.1:" ++ integer_to_list(discover_port()),
+    {201, _} = send(put, Base, <<"/db/", ?DB, "">>, bearer(), <<>>),
+    [{base, Base}, {priv, Priv} | Config].
+
+end_per_suite(_Config) ->
+    application:stop(barrel_server),
+    application:unset_env(barrel_server, auth),
+    ok.
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+t_bearer_authenticates(Config) ->
+    B = ?config(base, Config),
+    {200, _} = send(get, B, <<"/db/", ?DB, "">>, bearer(), <<>>),
+    ok.
+
+t_signed_authenticates(Config) ->
+    B = ?config(base, Config),
+    H = build_signed(get, <<"/db/", ?DB, "">>, <<>>, ?config(priv, Config),
+                     now_ms()),
+    {200, _} = send(get, B, <<"/db/", ?DB, "">>, H, <<>>),
+    ok.
+
+t_no_auth_rejected(Config) ->
+    B = ?config(base, Config),
+    {401, _} = send(get, B, <<"/db/", ?DB, "">>, [], <<>>),
+    ok.
+
+t_unknown_key_rejected(Config) ->
+    B = ?config(base, Config),
+    {_OtherPub, OtherPriv} = crypto:generate_key(eddsa, ed25519),
+    %% a key the server does not know, even though the signature is valid
+    H = build_signed_as(<<"ghost">>, get, <<"/db/", ?DB, "">>, <<>>,
+                        OtherPriv, now_ms()),
+    {401, _} = send(get, B, <<"/db/", ?DB, "">>, H, <<>>),
+    ok.
+
+t_stale_rejected(Config) ->
+    B = ?config(base, Config),
+    H = build_signed(get, <<"/db/", ?DB, "">>, <<>>, ?config(priv, Config),
+                     now_ms() - 600000),
+    {401, _} = send(get, B, <<"/db/", ?DB, "">>, H, <<>>),
+    ok.
+
+%% A byte-identical signed request replayed within the window is refused.
+t_replay_rejected(Config) ->
+    B = ?config(base, Config),
+    Path = <<"/db/", ?DB, "/_sync/info">>,
+    H = build_signed(get, Path, <<>>, ?config(priv, Config), now_ms()),
+    {200, _} = send(get, B, Path, H, <<>>),
+    {401, _} = send(get, B, Path, H, <<>>),
+    ok.
+
+%% Signature is valid (over the declared content hash) but the body does
+%% not hash to it: the handler rejects. Tampering the header instead would
+%% break the signature (401); tampering the body alone is 400.
+t_tampered_body_rejected(Config) ->
+    B = ?config(base, Config),
+    Path = <<"/db/", ?DB, "/_sync/changes">>,
+    Signed = <<"{\"since\":\"first\"}">>,
+    Sent = <<"{\"since\":\"tampered\"}">>,
+    H = build_signed(post, Path, Signed, ?config(priv, Config), now_ms()),
+    {400, _} = send(post, B, Path, H, Sent),
+    ok.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+now_ms() -> erlang:system_time(millisecond).
+
+bearer() -> [{<<"authorization">>, <<"Bearer ", ?TOKEN/binary>>}].
+
+build_signed(Method, Path, SignBody, Priv, Ts) ->
+    build_signed_as(?KEYID, Method, Path, SignBody, Priv, Ts).
+
+build_signed_as(KeyId, Method, Path, SignBody, Priv, Ts) ->
+    CH = barrel_sync_sig:content_sha256(SignBody),
+    Auth = barrel_sync_sig:sign(KeyId, Priv, method_bin(Method), Path, CH, Ts),
+    [{<<"authorization">>, Auth},
+     {<<"x-barrel-content-sha256">>, CH},
+     {<<"content-type">>, <<"application/json">>}].
+
+send(Method, Base, Path, Headers, Body) ->
+    Url = iolist_to_binary([Base, Path]),
+    {ok, S, _H, RB} = hackney:request(Method, Url, Headers, Body,
+                                      [with_body]),
+    {S, RB}.
+
+method_bin(get) -> <<"GET">>;
+method_bin(post) -> <<"POST">>;
+method_bin(put) -> <<"PUT">>;
+method_bin(delete) -> <<"DELETE">>.
+
+discover_port() ->
+    Children = supervisor:which_children(barrel_server_sup),
+    {_, Pid, _, _} = lists:keyfind(barrel_server_http, 1, Children),
+    #{h1 := Port} = livery:which_listeners(Pid),
+    Port.

--- a/docs/features.md
+++ b/docs/features.md
@@ -33,17 +33,17 @@ them; each underlying app stays usable on its own.
 | FAISS index backend | Opt-in | `barrel_faiss`; needs the FAISS C++ library, excluded from the default build (`rebar3 as faiss`). |
 | Changes feed | Ready | `changes/2`, `subscribe/2`; HLC cursor via `hlc_encode/1`. |
 | BQL queries | Ready | PartiQL dialect over docs, vectors, and BM25; live SUBSCRIBE queries. See [query-bql](guides/query-bql.md). |
-| Synchronization / replication | Ready | Same VM and over HTTP (`/db/:db/_sync/*`); documents, attachments, channels, continuous tasks. Vectors rebuild locally. See [synchronization](guides/synchronization.md). |
+| Synchronization / replication | Ready | Same VM and over HTTP (`/db/:db/_sync/*`); documents, attachments, channels, continuous tasks. Bearer, Ed25519 signed-request, and mTLS auth (opt-in; bearer is the default). Vectors rebuild locally. See [synchronization](guides/synchronization.md). |
 | Timeline (branch, PITR, merge) | Ready | O(1) forks, point-in-time rewind, merge back as sync. See [timeline](guides/timeline.md). |
 | Audit and provenance | Ready | Retained history log; actor/session/source on writes; past bodies by version. See [audit-provenance](guides/audit-provenance.md). |
 | Document TTL | Ready | `expires_at` write option, lazy expiry, opt-in sweeper (`ttl_sweep_interval`). |
 | Encryption at rest | Opt-in | Per-database keys via `barrel_keyprovider`; EncryptedEnv plus a sector cipher for flat files. See [encryption](guides/encryption.md). |
-| REST/JSON server | Opt-in | `barrel_server` over `livery`, `rebar3 as server`. See [rest-server](guides/rest-server.md). |
+| REST/JSON server | Opt-in | `barrel_server` over `livery`, `rebar3 as server`; serves HTTP/1.1 (default) plus opt-in HTTP/2 and HTTP/3 over TLS. See [rest-server](guides/rest-server.md). |
 | Agent layer (spaces, capabilities, sessions, handoffs) | Ready | `barrel_spaces`; capability bearers on REST and MCP. See [spaces](guides/spaces.md). |
 | MCP endpoint (tools, resources, live queries) | Opt-in | `/mcp` in `barrel_server`, on by default there. See [mcp](guides/mcp.md). |
 | Browser client (barrel-lite) | Ready | Offline-first TypeScript client (`clients/barrel-lite`): OPFS store, HLC-stamped writes, sync over the wire (polling or continuous SSE), multi-tab, attachment sync, a local BQL subset matching the server, and vector search (embedding pull + brute-force cosine top-k over the synced set, with server `/search` delegation; no ANN in the browser). See [barrel-lite](guides/barrel-lite.md). |
 | CORS + capability tokens on `/db` | Ready | CORS middleware and `bsp_` bearers scoped to their space's `/db` routes, so browsers can sync. See [rest-server](guides/rest-server.md). |
-| gRPC, HTTP/3, WebTransport, unix socket, OpenAPI | Planned | Later transports on `barrel_server`. |
+| gRPC, WebTransport, unix socket, OpenAPI | Planned | Later transports on `barrel_server`. |
 | SQL API, agentfs | Planned | Later. |
 
 ## Where things run

--- a/docs/guides/rest-server.md
+++ b/docs/guides/rest-server.md
@@ -1,9 +1,11 @@
 # Run the REST server
 
-`barrel_server` exposes the `barrel` database over HTTP/1.1 and HTTP/2 (REST/JSON)
-using `livery`. It holds no database logic: every handler calls the `barrel`
-module through a database lifecycle manager. Read this when you want to reach a
-barrel database over the network instead of embedding it.
+`barrel_server` exposes the `barrel` database as a REST/JSON API using `livery`.
+By default it serves cleartext HTTP/1.1; HTTP/2 and HTTP/3 (over TLS) are opt-in
+via the `listeners` config (see [synchronization](synchronization.md)). It holds
+no database logic: every handler calls the `barrel` module through a database
+lifecycle manager. Read this when you want to reach a barrel database over the
+network instead of embedding it.
 
 ## When to use it
 
@@ -92,6 +94,14 @@ tokens answer 401. `/mcp` authenticates through its own provider covering
 both kinds. See [spaces](spaces.md), [mcp](mcp.md), and
 [barrel-lite](barrel-lite.md).
 
+The bearer behavior above is unchanged and is what you get with no extra
+config. Two stronger methods are **opt-in**, added by an `accept` list on the
+same `auth` key (its absence leaves everything exactly as described above):
+Ed25519 **signed requests** (replay-protected, no TLS required) and an **mTLS**
+transport gate. `accept => [bearer, signed]` accepts either, so a fleet can
+roll over node by node. See the [synchronization guide](synchronization.md) for
+the config and the client side.
+
 ## CORS
 
 Browser clients need CORS. Unconfigured, no CORS headers are sent; set an
@@ -144,5 +154,7 @@ $ curl localhost:8080/db/mydb/changes
 - Optimistic concurrency: `PUT /db/:db/doc/:id` with a `_rev` in the body that
   is not the current winner answers 409 `{"error":"conflict"}`.
 - Replication over the wire ships today (the `/db/:db/_sync/*` endpoints; see
-  [synchronization](synchronization.md)). gRPC, HTTP/3, WebTransport, a
-  unix-socket adapter, and OpenAPI are later phases.
+  [synchronization](synchronization.md)), with bearer, Ed25519 signed-request,
+  and mTLS auth (all opt-in; bearer is the default). HTTP/2 and HTTP/3 serving
+  ship (opt-in via `listeners`); note H3 is TLS-serving but not yet a client-cert
+  gate. gRPC, WebTransport, a unix-socket adapter, and OpenAPI are later phases.

--- a/docs/guides/synchronization.md
+++ b/docs/guides/synchronization.md
@@ -90,6 +90,63 @@ application:set_env(barrel_docdb, sync_auth,
                     #{<<"http://edge-1.example.com:8080">> => <<"s3cret">>}).
 ```
 
+## How (signed requests)
+
+Bearer tokens replay without TLS. For per-request Ed25519 authentication, add
+`accept` (the list of accepted methods) and `signers` (keyId to 32-byte raw
+public key). Each request is signed over `ts|keyId|method|path|sha256(body)`,
+with replay protection and a skew window. `accept => [bearer, signed]` accepts
+both, so a fleet rolls over node by node; `accept => [bearer]` (or no `accept`)
+is exactly the bearer-only behavior above.
+
+```erlang
+%% server: know each peer's public key
+application:set_env(barrel_server, auth,
+                    #{accept  => [bearer, signed],
+                      signers => #{<<"node1">> => PubKey32},
+                      skew_ms => 300000}).
+
+%% client: sign with the matching private key (endpoint or origin env)
+Signed = Endpoint#{signing => #{key_id => <<"node1">>, priv_key => Priv32}},
+%% or
+application:set_env(barrel_docdb, sync_signing,
+                    #{<<"https://edge-1.example.com:8443">> =>
+                          #{key_id => <<"node1">>, priv_key => Priv32}}).
+```
+
+Generate a key pair with `crypto:generate_key(eddsa, ed25519)`. Signing takes
+precedence over a bearer token on the same endpoint. Private keys are never
+written into persisted task configs.
+
+## How (TLS and mTLS)
+
+`barrel_server` serves cleartext HTTP/1.1 by default. Configure listeners to add
+HTTP/2 and HTTP/3, and TLS. Setting `verify => verify_peer` makes a listener a
+mutual-TLS gate: a client without a CA-signed certificate is refused at the
+handshake. The replication client speaks HTTP/1.1, so run the sync gate on an
+H1-over-TLS listener (`tls => true` on the `http` entry).
+
+```erlang
+application:set_env(barrel_server, listeners,
+                    #{http  => #{port => 8443, tls => true},  %% H1 over TLS
+                      https => #{port => 8444},               %% H2
+                      http3 => #{port => 8444}}),             %% H3
+application:set_env(barrel_server, tls,
+                    #{certfile => "server.pem", keyfile => "server.key",
+                      cacertfile => "ca.pem", verify => verify_peer}),
+application:set_env(barrel_server, auth, #{accept => [mtls]}).
+
+%% client: present its cert (endpoint or origin env)
+Mtls = Endpoint#{ssl_options => [{certfile, "client.pem"},
+                                 {keyfile, "client.key"},
+                                 {cacertfile, "ca.pem"}]}.
+```
+
+Notes: H1-TLS and H2 are full mTLS gates (OTP `ssl`). H3 serves over TLS but is
+not yet a client-cert gate (a QUIC-level change is pending); do not rely on H3
+for mTLS. Mapping a client cert to an identity/allowed-db needs a livery change
+and is not available yet.
+
 ## How (selective replication)
 
 Filters apply at the source. Path and query filters compose with AND:

--- a/rebar.config
+++ b/rebar.config
@@ -93,7 +93,7 @@
             {apps, [barrel_server]}
         ]},
         {relx, [
-            {release, {barrel_server, "1.1.0"}, [
+            {release, {barrel_server, "1.2.0"}, [
                 barrel_server,
                 sasl,
                 runtime_tools,


### PR DESCRIPTION
The sync wire authenticates with bearer tokens only, which replay without TLS. This raises it to the signed-request security level our internal deployments need, and lets barrel_server serve HTTP/2 and HTTP/3 next to HTTP/1.1.

It adds two opt-in ways to authenticate a peer: per-request Ed25519 signatures (replay-protected, no TLS required) and a mutual-TLS transport gate. Both can roll out node by node via dual-accept, so nothing changes until you enable it. Bearer stays the default and cleartext HTTP/1.1 is still the out-of-the-box behavior.

Mapping a client certificate to an identity, and a real client-cert gate over HTTP/3, need a change in livery and are tracked separately.

Not released here (no tag or publish).