### PR TITLE
fix(docdb): delete_db leaks files for a closed per-db-data_dir database (#3)

### DIFF
--- a/apps/barrel_docdb/CHANGELOG.md
+++ b/apps/barrel_docdb/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   requests) and `ssl_options` (mTLS client cert), plus the `sync_signing` and
   `sync_ssl` app-env equivalents. Bearer auth is unchanged when neither is set.
 
+### Fixed
+- `delete_db/1` on a closed database created with a per-db `data_dir` no longer
+  silently returns `ok` while leaking the files: the `data_dir` is remembered so
+  the files are located and removed after close (#3). Default-`data_dir` deletes
+  stay idempotent.
+
 ## [1.0.0] - 2026-07-10
 
 First stable release. The `barrel_docdb` API is frozen: it will not break

--- a/apps/barrel_docdb/src/barrel_docdb.erl
+++ b/apps/barrel_docdb/src/barrel_docdb.erl
@@ -55,6 +55,10 @@
 
 -include("barrel_docdb.hrl").
 
+%% Durable, node-global control-plane database (node id, per-db data_dir
+%% index, etc.). Not replicated.
+-define(SYSTEM_DB, <<"_barrel_system">>).
+
 %% Database lifecycle
 -export([
     create_db/1,
@@ -264,7 +268,13 @@ create_db(Name, Opts) when is_binary(Name) ->
                 {ok, _Pid} ->
                     {error, already_exists};
                 {error, not_found} ->
-                    barrel_db_sup:start_db(Name, Opts)
+                    case barrel_db_sup:start_db(Name, Opts) of
+                        {ok, _Pid} = Ok ->
+                            register_db_dir(Name, Opts),
+                            Ok;
+                        Err ->
+                            Err
+                    end
             end;
         {error, _} = Err ->
             Err
@@ -370,9 +380,14 @@ close_db(Pid) when is_pid(Pid) ->
 delete_db(Name) when is_binary(Name) ->
     delete_db(Name, #{}).
 
-%% @doc Delete a database, locating a CLOSED database's files under
-%% `data_dir' (the option, else the app env default). Open databases
-%% are stopped first, using their actual path.
+%% @doc Delete a database, locating a CLOSED database's files under its
+%% `data_dir'. Resolution order: the `data_dir' option, else the dir
+%% remembered when the db was created with a per-db `data_dir' (see
+%% {@link create_db/2}), else the app env default. Open databases are
+%% stopped first, using their actual path.
+%%
+%% Databases created before per-db `data_dir' was remembered have no
+%% record; pass their `data_dir' explicitly via this function.
 -spec delete_db(binary(), map()) -> ok | {error, term()}.
 delete_db(Name, Opts) when is_binary(Name), is_map(Opts) ->
     case validate_db_name(Name) of
@@ -383,7 +398,7 @@ delete_db(Name, Opts) when is_binary(Name), is_map(Opts) ->
     end.
 
 do_delete_db(Name, Opts) ->
-    case get_db(Name) of
+    Result = case get_db(Name) of
         {ok, Pid} ->
             {ok, Info} = barrel_db_server:info(Pid),
             DbPath = maps:get(db_path, Info),
@@ -391,15 +406,13 @@ do_delete_db(Name, Opts) ->
             %% Remove data directory via stdlib (no shell, no injection).
             del_db_dir(DbPath);
         {error, not_found} ->
-            %% Not open: remove the on-disk files where they would
-            %% live. Databases created under a data_dir that is
-            %% neither the option nor the app env cannot be located;
-            %% pass delete_db/2 with their data_dir.
-            DefaultDataDir = application:get_env(barrel_docdb, data_dir,
-                                                 "/tmp/barrel_data"),
-            DataDir = maps:get(data_dir, Opts, DefaultDataDir),
+            %% Not open: resolve the on-disk location from the option,
+            %% the remembered per-db data_dir, or the app env default.
+            DataDir = closed_db_data_dir(Name, Opts),
             del_db_dir(filename:join(DataDir, binary_to_list(Name)))
-    end.
+    end,
+    forget_db_dir(Name),
+    Result.
 
 del_db_dir(DbPath) ->
     case file:del_dir_r(DbPath) of
@@ -407,6 +420,101 @@ del_db_dir(DbPath) ->
         {error, enoent} -> ok;
         {error, _} = Err -> Err
     end.
+
+%%====================================================================
+%% Per-db data_dir index (#3)
+%%
+%% A database can live in any directory (the `data_dir' option is
+%% arbitrary), so once it is closed its files cannot be found from the
+%% name alone. We remember `name -> data_dir' in the durable, node-global
+%% ?SYSTEM_DB so delete_db/1 can still locate and remove the files. The
+%% default data_dir needs no entry; internal dbs (`_' prefix) are skipped
+%% so the system db itself never recurses.
+%%====================================================================
+
+db_dir_key(Name) -> <<"_dbdir:", Name/binary>>.
+
+register_db_dir(<<"_", _/binary>>, _Opts) ->
+    ok;
+register_db_dir(Name, Opts) ->
+    case maps:get(data_dir, Opts, undefined) of
+        undefined ->
+            ok;
+        DataDir ->
+            DirBin = unicode:characters_to_binary(DataDir),
+            try put_system_doc(db_dir_key(Name),
+                               #{<<"data_dir">> => DirBin}) of
+                ok ->
+                    ok;
+                Other ->
+                    warn_db_dir(Name, Other)
+            catch
+                Class:Reason ->
+                    warn_db_dir(Name, {Class, Reason})
+            end
+    end.
+
+warn_db_dir(Name, Reason) ->
+    logger:warning("barrel_docdb: could not record data_dir for ~ts: ~p",
+                   [Name, Reason]),
+    ok.
+
+%% Resolve a closed db's data_dir: explicit option, else the recorded
+%% per-db dir, else the global default.
+closed_db_data_dir(Name, Opts) ->
+    case maps:get(data_dir, Opts, undefined) of
+        undefined ->
+            case lookup_db_dir(Name) of
+                {ok, DataDir} -> DataDir;
+                not_found -> default_data_dir()
+            end;
+        DataDir ->
+            DataDir
+    end.
+
+lookup_db_dir(Name) ->
+    case system_db_available() of
+        true ->
+            try get_local_doc(?SYSTEM_DB, db_dir_key(Name)) of
+                {ok, #{<<"data_dir">> := DirBin}} ->
+                    {ok, unicode:characters_to_list(DirBin)};
+                _ ->
+                    not_found
+            catch
+                _:_ -> not_found
+            end;
+        false ->
+            not_found
+    end.
+
+forget_db_dir(<<"_", _/binary>>) ->
+    ok;
+forget_db_dir(Name) ->
+    case system_db_available() of
+        true ->
+            try delete_local_doc(?SYSTEM_DB, db_dir_key(Name))
+            catch _:_ -> ok
+            end,
+            ok;
+        false ->
+            ok
+    end.
+
+%% True when the ?SYSTEM_DB can be read without materializing it: open,
+%% or present on disk (opened on demand). A default-only node that never
+%% recorded a per-db dir never creates it.
+system_db_available() ->
+    case get_db(?SYSTEM_DB) of
+        {ok, _} ->
+            true;
+        {error, not_found} ->
+            SysPath = filename:join(default_data_dir(),
+                                    binary_to_list(?SYSTEM_DB)),
+            filelib:is_dir(SysPath) andalso ensure_system_db() =:= ok
+    end.
+
+default_data_dir() ->
+    application:get_env(barrel_docdb, data_dir, "/tmp/barrel_data").
 
 %% @doc Get database information.
 %%
@@ -1799,8 +1907,6 @@ fold_local_docs(Db, Prefix, Fun, Acc0) ->
 %% System documents are global (not per-database) and stored in a
 %% special _barrel_system database. They're used for global configuration
 %% like replication tasks, node settings, etc.
-
--define(SYSTEM_DB, <<"_barrel_system">>).
 
 %% @doc Ensure the system database exists.
 %% Called automatically by system_doc operations.

--- a/apps/barrel_docdb/test/barrel_delete_db_SUITE.erl
+++ b/apps/barrel_docdb/test/barrel_delete_db_SUITE.erl
@@ -1,0 +1,89 @@
+%%%-------------------------------------------------------------------
+%%% @doc delete_db locates a closed database's files, including one
+%%% created with a per-db data_dir (issue #3).
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_delete_db_SUITE).
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([
+    t_delete_closed_per_db_data_dir/1,
+    t_delete_default_idempotent/1,
+    t_delete_with_explicit_data_dir/1,
+    t_delete_open_db/1
+]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+all() ->
+    [t_delete_closed_per_db_data_dir, t_delete_default_idempotent,
+     t_delete_with_explicit_data_dir, t_delete_open_db].
+
+init_per_suite(Config) ->
+    application:load(barrel_docdb),
+    Default = filename:join(?config(priv_dir, Config), "default"),
+    application:set_env(barrel_docdb, data_dir, Default),
+    {ok, _} = application:ensure_all_started(barrel_docdb),
+    Config.
+
+end_per_suite(_Config) ->
+    application:stop(barrel_docdb),
+    ok.
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+%% The repro from #3: a closed db created with a per-db data_dir is
+%% deleted by delete_db/1 (no data_dir) and its files are gone.
+t_delete_closed_per_db_data_dir(Config) ->
+    PerDb = perdir(Config, "perdb1"),
+    Name = <<"mydb">>,
+    {ok, _} = barrel_docdb:create_db(Name, #{data_dir => PerDb}),
+    {ok, _} = barrel_docdb:put_doc(Name, #{<<"id">> => <<"doc1">>}),
+    DbPath = filename:join(PerDb, binary_to_list(Name)),
+    ?assert(filelib:is_dir(DbPath)),
+    ok = barrel_docdb:close_db(Name),
+    ok = barrel_docdb:delete_db(Name),
+    ?assertNot(filelib:is_dir(DbPath)),
+    ok.
+
+%% A default-data_dir db stays idempotent: delete twice, both ok.
+t_delete_default_idempotent(_Config) ->
+    Name = <<"defdb">>,
+    {ok, _} = barrel_docdb:create_db(Name),
+    ok = barrel_docdb:close_db(Name),
+    ok = barrel_docdb:delete_db(Name),
+    ok = barrel_docdb:delete_db(Name),
+    ok.
+
+%% The explicit-data_dir workaround still works for a closed db.
+t_delete_with_explicit_data_dir(Config) ->
+    PerDb = perdir(Config, "perdb2"),
+    Name = <<"exdb">>,
+    {ok, _} = barrel_docdb:create_db(Name, #{data_dir => PerDb}),
+    ok = barrel_docdb:close_db(Name),
+    DbPath = filename:join(PerDb, binary_to_list(Name)),
+    ?assert(filelib:is_dir(DbPath)),
+    ok = barrel_docdb:delete_db(Name, #{data_dir => PerDb}),
+    ?assertNot(filelib:is_dir(DbPath)),
+    ok.
+
+%% Deleting an OPEN per-db db still removes the files (actual path).
+t_delete_open_db(Config) ->
+    PerDb = perdir(Config, "perdb3"),
+    Name = <<"opendb">>,
+    {ok, _} = barrel_docdb:create_db(Name, #{data_dir => PerDb}),
+    DbPath = filename:join(PerDb, binary_to_list(Name)),
+    ?assert(filelib:is_dir(DbPath)),
+    ok = barrel_docdb:delete_db(Name),
+    ?assertNot(filelib:is_dir(DbPath)),
+    ok.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+perdir(Config, Sub) ->
+    filename:join(?config(priv_dir, Config), Sub).


### PR DESCRIPTION
Deleting a database that was created with a per-db `data_dir` and then closed returned `ok` but left the files on disk. Once closed there's no process to ask for the real path, so `delete_db` fell back to the global `data_dir`, missed the files, and reported the miss as success.

Since a database can live in any directory, the fix remembers each per-db `data_dir` in the durable node-global `_barrel_system` store when the database is created, and `delete_db/1` consults it to find and remove the files after close. Databases on the default `data_dir` are untouched and repeat-deletes stay idempotent; databases created before this change still take an explicit `data_dir` via `delete_db/2`.

Closes #3