### PR TITLE
fix(docdb): subscribe/branch silently no-op on the create_db pid (#4)

### DIFF
--- a/apps/barrel_docdb/CHANGELOG.md
+++ b/apps/barrel_docdb/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   silently returns `ok` while leaking the files: the `data_dir` is remembered so
   the files are located and removed after close (#3). Default-`data_dir` deletes
   stay idempotent.
+- `subscribe/2,3`, `subscribe_query/2,3`, `branch_db/3`, `list_branches/1`, and
+  `merge_branch/2` now accept the pid returned by `create_db/2` (resolved to the
+  name), like the document functions, and return `{error, invalid_db_ref}` for a
+  dead or non-database pid instead of silently doing nothing (#4).
 
 ## [1.0.0] - 2026-07-10
 

--- a/apps/barrel_docdb/src/barrel_docdb.erl
+++ b/apps/barrel_docdb/src/barrel_docdb.erl
@@ -257,6 +257,10 @@ create_db(Name) ->
 %% }).
 %% '''
 %%
+%% The returned pid and the database name are interchangeable across the
+%% API (documents, subscriptions, branches, ...); the name is the stable
+%% identity, the pid a convenience.
+%%
 %% @param Name The database name as a binary
 %% @param Opts Configuration options map
 %% @returns `{ok, Pid}' on success, `{error, already_exists}' if database exists
@@ -320,24 +324,38 @@ validate_db_name_chars(_) ->
 open_db(Name) when is_binary(Name) ->
     get_db(Name).
 
-%% @doc Fork a database into a new branch (timeline). See
+%% @doc Fork a database into a new branch (timeline). `Parent' is the
+%% database name or the pid returned by create_db/2. See
 %% barrel_timeline:branch_db/3 for the options.
--spec branch_db(binary(), binary(), map()) ->
+-spec branch_db(binary() | pid(), binary(), map()) ->
     {ok, pid()} | {error, term()}.
 branch_db(Parent, BranchName, Opts) ->
-    barrel_timeline:branch_db(Parent, BranchName, Opts).
+    case resolve_db_name(Parent) of
+        {ok, ParentName} ->
+            barrel_timeline:branch_db(ParentName, BranchName, Opts);
+        {error, _} = Err ->
+            Err
+    end.
 
 %% @doc The OPEN branches of a database (a branch that exists on disk
-%% but is not running is not listed).
--spec list_branches(binary()) -> [binary()].
+%% but is not running is not listed). `Parent' is the database name or
+%% the pid from create_db/2; an unknown reference lists nothing.
+-spec list_branches(binary() | pid()) -> [binary()].
 list_branches(Parent) ->
-    barrel_timeline:list_branches(Parent).
+    case resolve_db_name(Parent) of
+        {ok, ParentName} -> barrel_timeline:list_branches(ParentName);
+        {error, _} -> []
+    end.
 
-%% @doc Merge a branch's edits back into its parent. See
+%% @doc Merge a branch's edits back into its parent. `Branch' is the
+%% branch database name or the pid from create_db/2. See
 %% barrel_timeline:merge_branch/2.
--spec merge_branch(binary(), map()) -> {ok, map()} | {error, term()}.
+-spec merge_branch(binary() | pid(), map()) -> {ok, map()} | {error, term()}.
 merge_branch(Branch, Opts) ->
-    barrel_timeline:merge_branch(Branch, Opts).
+    case resolve_db_name(Branch) of
+        {ok, BranchName} -> barrel_timeline:merge_branch(BranchName, Opts);
+        {error, _} = Err -> Err
+    end.
 
 %% @doc Close a database.
 %%
@@ -2105,9 +2123,10 @@ new_hlc() ->
 %% @param Pattern MQTT-style path pattern to match
 %% @returns `{ok, SubRef}' on success, `{error, invalid_pattern}' if pattern is invalid
 %% @see unsubscribe/1
--spec subscribe(db_name(), binary()) -> {ok, reference()} | {error, term()}.
-subscribe(DbName, Pattern) ->
-    subscribe(DbName, Pattern, #{}).
+-spec subscribe(binary() | pid(), binary()) ->
+    {ok, reference()} | {error, term()}.
+subscribe(Db, Pattern) ->
+    subscribe(Db, Pattern, #{}).
 
 %% @doc Subscribe to document changes with options.
 %%
@@ -2116,15 +2135,19 @@ subscribe(DbName, Pattern) ->
 %% == Options ==
 %% Currently no options are supported (reserved for future use).
 %%
-%% @param DbName The database name
+%% @param Db The database name or the pid returned by create_db/2
 %% @param Pattern MQTT-style path pattern to match
 %% @param Opts Options map (reserved for future use)
 %% @returns `{ok, SubRef}' on success, `{error, invalid_pattern}' if pattern is invalid
 %% @see subscribe/2
 %% @see unsubscribe/1
--spec subscribe(db_name(), binary(), map()) -> {ok, reference()} | {error, term()}.
-subscribe(DbName, Pattern, _Opts) ->
-    barrel_sub:subscribe(DbName, Pattern, self()).
+-spec subscribe(binary() | pid(), binary(), map()) ->
+    {ok, reference()} | {error, term()}.
+subscribe(Db, Pattern, _Opts) ->
+    case resolve_db_name(Db) of
+        {ok, DbName} -> barrel_sub:subscribe(DbName, Pattern, self());
+        {error, _} = Err -> Err
+    end.
 
 %% @doc Unsubscribe from document change notifications.
 %%
@@ -2181,25 +2204,28 @@ unsubscribe(SubRef) ->
 %% @returns `{ok, SubRef}' on success, `{error, Reason}' on failure
 %% @see subscribe_query/3
 %% @see unsubscribe_query/1
--spec subscribe_query(db_name(), barrel_query:query_spec()) ->
+-spec subscribe_query(binary() | pid(), barrel_query:query_spec()) ->
     {ok, reference()} | {error, term()}.
-subscribe_query(DbName, Query) ->
-    subscribe_query(DbName, Query, #{}).
+subscribe_query(Db, Query) ->
+    subscribe_query(Db, Query, #{}).
 
 %% @doc Subscribe to document changes matching a query with options.
 %%
 %% Same as {@link subscribe_query/2} but with additional options.
 %%
-%% @param DbName The database name
+%% @param Db The database name or the pid returned by create_db/2
 %% @param Query Query specification
 %% @param Opts Options (reserved for future use)
 %% @returns `{ok, SubRef}' on success, `{error, Reason}' on failure
 %% @see subscribe_query/2
 %% @see unsubscribe_query/1
--spec subscribe_query(db_name(), barrel_query:query_spec(), map()) ->
+-spec subscribe_query(binary() | pid(), barrel_query:query_spec(), map()) ->
     {ok, reference()} | {error, term()}.
-subscribe_query(DbName, Query, _Opts) ->
-    barrel_query_sub:subscribe(DbName, Query, self()).
+subscribe_query(Db, Query, _Opts) ->
+    case resolve_db_name(Db) of
+        {ok, DbName} -> barrel_query_sub:subscribe(DbName, Query, self());
+        {error, _} = Err -> Err
+    end.
 
 %% @doc Unsubscribe from query-based change notifications.
 %%
@@ -2224,19 +2250,35 @@ unsubscribe_query(SubRef) ->
 %% Internal Functions
 %%====================================================================
 
-%% @private Extract database name from pid or binary
+%% @private Extract a database name from a pid or binary, for metrics
+%% labels. Falls back to <<"unknown">> when a pid cannot be resolved.
 -spec db_name(binary() | pid()) -> binary().
-db_name(Name) when is_binary(Name) ->
-    Name;
-db_name(Pid) when is_pid(Pid) ->
-    %% For pid, we need to look up the name - use unknown for metrics if not found
-    case process_info(Pid, registered_name) of
-        {registered_name, _} ->
-            %% Try to find name from persistent_term
-            <<"unknown">>;
-        _ ->
-            <<"unknown">>
+db_name(Ref) ->
+    case resolve_db_name(Ref) of
+        {ok, Name} -> Name;
+        {error, _} -> <<"unknown">>
     end.
+
+%% @private Resolve a database reference (name or the pid returned by
+%% create_db/2) to its name. A pid is reverse-looked-up in the registry;
+%% a dead or non-database pid yields `{error, invalid_db_ref}' so that
+%% name-only calls (subscribe, branch_db, ...) fail fast instead of
+%% silently no-op'ing (see #4).
+-spec resolve_db_name(binary() | pid()) ->
+    {ok, binary()} | {error, invalid_db_ref}.
+resolve_db_name(Name) when is_binary(Name) ->
+    {ok, Name};
+resolve_db_name(Pid) when is_pid(Pid) ->
+    find_db_name(Pid, persistent_term:get());
+resolve_db_name(_Other) ->
+    {error, invalid_db_ref}.
+
+find_db_name(_Pid, []) ->
+    {error, invalid_db_ref};
+find_db_name(Pid, [{{barrel_db, Name}, Pid} | _]) when is_binary(Name) ->
+    {ok, Name};
+find_db_name(Pid, [_ | Rest]) ->
+    find_db_name(Pid, Rest).
 
 %% @private Get database pid by name
 -spec get_db(binary()) -> {ok, pid()} | {error, not_found}.

--- a/apps/barrel_docdb/test/barrel_db_ref_SUITE.erl
+++ b/apps/barrel_docdb/test/barrel_db_ref_SUITE.erl
@@ -1,0 +1,104 @@
+%%%-------------------------------------------------------------------
+%%% @doc Name-only functions accept the pid returned by create_db/2
+%%% (resolved to the name), and fail fast on a dead/foreign pid instead
+%%% of silently no-op'ing (issue #4).
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_db_ref_SUITE).
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([
+    t_subscribe_by_pid_fires/1,
+    t_subscribe_by_name_fires/1,
+    t_subscribe_dead_pid_errors/1,
+    t_branch_by_pid/1,
+    t_list_branches_by_pid/1
+]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+all() ->
+    [t_subscribe_by_pid_fires, t_subscribe_by_name_fires,
+     t_subscribe_dead_pid_errors, t_branch_by_pid, t_list_branches_by_pid].
+
+init_per_suite(Config) ->
+    application:load(barrel_docdb),
+    application:set_env(barrel_docdb, data_dir,
+                        filename:join(?config(priv_dir, Config), "data")),
+    {ok, _} = application:ensure_all_started(barrel_docdb),
+    Config.
+
+end_per_suite(_Config) ->
+    application:stop(barrel_docdb),
+    ok.
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+%% #4 repro: subscribing with the pid from create_db/2 now delivers
+%% changes (previously a silent no-op).
+t_subscribe_by_pid_fires(_Config) ->
+    Name = uname(<<"ref_pid_">>),
+    {ok, Pid} = barrel_docdb:create_db(Name),
+    {ok, _Ref} = barrel_docdb:subscribe(Pid, <<"type/#">>),
+    put_user(Name),
+    expect_change(Name),
+    ok = barrel_docdb:delete_db(Name).
+
+%% Subscribing by name still works (regression).
+t_subscribe_by_name_fires(_Config) ->
+    Name = uname(<<"ref_name_">>),
+    {ok, _} = barrel_docdb:create_db(Name),
+    {ok, _Ref} = barrel_docdb:subscribe(Name, <<"type/#">>),
+    put_user(Name),
+    expect_change(Name),
+    ok = barrel_docdb:delete_db(Name).
+
+%% A dead/removed pid fails fast rather than no-op'ing.
+t_subscribe_dead_pid_errors(_Config) ->
+    Name = uname(<<"ref_dead_">>),
+    {ok, Pid} = barrel_docdb:create_db(Name),
+    ok = barrel_docdb:close_db(Name),
+    ?assertEqual({error, invalid_db_ref},
+                 barrel_docdb:subscribe(Pid, <<"type/#">>)),
+    ok = barrel_docdb:delete_db(Name).
+
+%% branch_db accepts the pid.
+t_branch_by_pid(_Config) ->
+    Name = uname(<<"ref_branch_">>),
+    {ok, Pid} = barrel_docdb:create_db(Name),
+    Branch = uname(<<"ref_branchchild_">>),
+    ?assertMatch({ok, _}, barrel_docdb:branch_db(Pid, Branch, #{})),
+    ok = barrel_docdb:delete_db(Branch),
+    ok = barrel_docdb:delete_db(Name).
+
+%% list_branches accepts the pid.
+t_list_branches_by_pid(_Config) ->
+    Name = uname(<<"ref_lb_">>),
+    {ok, Pid} = barrel_docdb:create_db(Name),
+    Branch = uname(<<"ref_lbchild_">>),
+    {ok, _} = barrel_docdb:branch_db(Pid, Branch, #{}),
+    ?assert(lists:member(Branch, barrel_docdb:list_branches(Pid))),
+    ok = barrel_docdb:delete_db(Branch),
+    ok = barrel_docdb:delete_db(Name).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+uname(Prefix) ->
+    iolist_to_binary([Prefix,
+                      integer_to_binary(erlang:unique_integer([positive]))]).
+
+put_user(Name) ->
+    {ok, _} = barrel_docdb:put_doc(
+        Name, #{<<"id">> => <<"u1">>, <<"type">> => <<"user">>}).
+
+expect_change(Name) ->
+    receive
+        {barrel_change, Name, _Change} -> ok
+    after 2000 ->
+        ct:fail("no change notification delivered")
+    end.


### PR DESCRIPTION
`create_db/2` returns `{ok, Pid}`, which invites passing that pid to the rest of the API. The document functions accept a name or a pid, but `subscribe/2,3`, `subscribe_query/2,3`, `branch_db/3`, `list_branches/1`, and `merge_branch/2` route by name and silently did nothing when handed the pid — a very hard-to-diagnose no-op.

These now resolve the reference (name or pid) to the database name at the entry, the same way the document functions do, so a pid works everywhere. A dead or non-database pid returns `{error, invalid_db_ref}` instead of no-op'ing. Names are unaffected. The specs and docs are widened to *name or pid*.

Closes #4