### PR TITLE
fix(docdb): list-valued path queries mean membership (#5)

### DIFF
--- a/apps/barrel_docdb/CHANGELOG.md
+++ b/apps/barrel_docdb/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `barrel_rep_transport_http` endpoints gain optional `signing` (Ed25519 signed
   requests) and `ssl_options` (mTLS client cert), plus the `sync_signing` and
   `sync_ssl` app-env equivalents. Bearer auth is unchanged when neither is set.
+- BQL infix array membership: `tags CONTAINS 'x'` and `'x' IN tags`, both
+  equivalent to the existing `CONTAINS(tags, 'x')` function form.
 
 ### Fixed
 - `delete_db/1` on a closed database created with a per-db `data_dir` no longer
@@ -24,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `merge_branch/2` now accept the pid returned by `create_db/2` (resolved to the
   name), like the document functions, and return `{error, invalid_db_ref}` for a
   dead or non-database pid instead of silently doing nothing (#4).
+- `find/2` with `{path, [field], V}` against a list-valued field now means
+  membership (V is an element of the list) and returns well-formed rows instead
+  of a mangled `#{id => <<" ...">>, deleted => true}` row. Lists are indexed by
+  membership path (`[field, element]`, no positional index); positional access
+  (`{path, [field, N], V}`) still works via scan. Documents written before the
+  upgrade keep stale positional index entries and are not matched by membership
+  until reindexed; such entries no longer corrupt query results (#5).
 
 ## [1.0.0] - 2026-07-10
 

--- a/apps/barrel_docdb/src/barrel_ars.erl
+++ b/apps/barrel_docdb/src/barrel_ars.erl
@@ -5,7 +5,9 @@
 %%% Based on barrel_ars_view.erl from barrel apps branch.
 %%%
 %%% Path format: [field1, field2, ..., value]
-%%% For arrays, index position is included: [field, 0, nested_field, value]
+%%% Arrays are indexed by MEMBERSHIP: each element contributes
+%%% [field, ..., element] with no positional index, so a path query on the
+%%% field matches any member (#5).
 %%%
 %%% Example:
 %%% ```
@@ -125,19 +127,21 @@ analyze_doc(Doc, RevPath, Acc) ->
 analyze_value(V, RevPath, Acc) when is_map(V) ->
     analyze_doc(V, RevPath, Acc);
 analyze_value(V, RevPath, Acc) when is_list(V) ->
-    analyze_list(V, RevPath, 0, Acc);
+    analyze_list(V, RevPath, Acc);
 analyze_value(V, RevPath, Acc) ->
     %% Leaf value - reverse path and add truncated value at end
     Path = lists:reverse([short(V) | RevPath]),
     [{Path, <<>>} | Acc].
 
-%% @private Analyze a list/array with index tracking
--spec analyze_list(list(), [term()], non_neg_integer(), [{[term()], <<>>}]) ->
+%% @private Analyze a list/array as MEMBERSHIP: index each element at the
+%% field path WITHOUT its positional index (#5), so a path query on the
+%% field matches any member. Duplicate elements collapse to one path.
+-spec analyze_list(list(), [term()], [{[term()], <<>>}]) ->
     [{[term()], <<>>}].
-analyze_list([Item | Rest], RevPath, Index, Acc) ->
-    Acc1 = analyze_value(Item, [Index | RevPath], Acc),
-    analyze_list(Rest, RevPath, Index + 1, Acc1);
-analyze_list([], _RevPath, _Index, Acc) ->
+analyze_list([Item | Rest], RevPath, Acc) ->
+    Acc1 = analyze_value(Item, RevPath, Acc),
+    analyze_list(Rest, RevPath, Acc1);
+analyze_list([], _RevPath, Acc) ->
     Acc.
 
 %%====================================================================

--- a/apps/barrel_docdb/src/barrel_bql_parser.yrl
+++ b/apps/barrel_docdb/src/barrel_bql_parser.yrl
@@ -11,7 +11,7 @@ Nonterminals
     statement select_stmt select_list proj_list projection
     from_clause source opt_alias fn_args fn_arg
     opt_where expr and_expr not_expr predicate operand
-    literal literal_list
+    literal literal_list in_rhs
     path_expr path_rest path_key
     opt_order order_list order_item opt_dir
     opt_limit opt_offset opt_subscribe.
@@ -112,10 +112,9 @@ predicate -> operand is 'not' null : {is_null, token_loc('$2'), '$1', true}.
 predicate -> operand is missing : {is_missing, token_loc('$2'), '$1', false}.
 predicate -> operand is 'not' missing :
     {is_missing, token_loc('$2'), '$1', true}.
-predicate -> operand in '(' literal_list ')' :
-    {in, token_loc('$2'), '$1', lists:reverse('$4'), false}.
-predicate -> operand 'not' in '(' literal_list ')' :
-    {in, token_loc('$3'), '$1', lists:reverse('$5'), true}.
+predicate -> operand in in_rhs : mk_in(token_loc('$2'), '$1', '$3', false).
+predicate -> operand 'not' in in_rhs :
+    mk_in(token_loc('$3'), '$1', '$4', true).
 predicate -> operand like string :
     {like, token_loc('$2'), '$1', string_value('$3'), false}.
 predicate -> operand 'not' like string :
@@ -126,6 +125,8 @@ predicate -> operand 'not' between operand 'and' operand :
     {between, token_loc('$3'), '$1', '$4', '$6', true}.
 predicate -> contains '(' path_expr ',' literal ')' :
     {contains, token_loc('$1'), '$3', '$5'}.
+predicate -> path_expr contains literal :
+    {contains, token_loc('$2'), '$1', '$3'}.
 
 operand -> path_expr : '$1'.
 operand -> literal : '$1'.
@@ -142,6 +143,12 @@ literal -> null : {lit, token_loc('$1'), null}.
 
 literal_list -> literal : ['$1'].
 literal_list -> literal_list ',' literal : ['$3' | '$1'].
+
+%% IN right-hand side: a parenthesized set (scalar `in') or a bare path
+%% (array membership, #5). Unified under one nonterminal so `in' stays
+%% LALR(1)-clean (the '(' vs ident choice is one-token lookahead).
+in_rhs -> '(' literal_list ')' : {set, lists:reverse('$2')}.
+in_rhs -> path_expr : {member, '$1'}.
 
 %%--------------------------------------------------------------------
 %% Paths: a.b, a[0], a[*], and any keyword after a dot
@@ -221,3 +228,16 @@ string_value({string, _Loc, S}) -> S.
 token_loc(Token) -> element(2, Token).
 
 path_loc({path, Loc, _Components}) -> Loc.
+
+%% Unify the two IN right-hand sides (#5). A parenthesized set stays a
+%% scalar `in'; a bare path is array membership, i.e. `X IN arr' ==
+%% `arr CONTAINS X', reusing the `contains' node ('not' wraps the negated
+%% form). Membership requires a literal element for now.
+mk_in(Loc, {lit, _, _} = Lit, {member, Path}, false) ->
+    {contains, Loc, Path, Lit};
+mk_in(Loc, {lit, _, _} = Lit, {member, Path}, true) ->
+    {'not', Loc, {contains, Loc, Path, Lit}};
+mk_in(Loc, Operand, {set, Literals}, Negated) ->
+    {in, Loc, Operand, Literals, Negated};
+mk_in(Loc, _Operand, {member, _Path}, _Negated) ->
+    return_error(Loc, "membership (IN <array>) requires a literal element").

--- a/apps/barrel_docdb/src/barrel_query.erl
+++ b/apps/barrel_docdb/src/barrel_query.erl
@@ -9,6 +9,7 @@
 %%% #{
 %%%     where => [
 %%%         {path, [<<"type">>], <<"user">>},           % equality
+%%%         {path, [<<"tags">>], <<"erlang">>},         % list => membership
 %%%         {path, [<<"org_id">>], '?Org'},              % bind variable
 %%%         {compare, [<<"age">>], '>', 18},            % comparison
 %%%         {'and', [...]},                              % conjunction
@@ -1557,9 +1558,11 @@ find_index_conditions(Conditions) ->
 find_index_conditions([], Acc) ->
     lists:reverse(Acc);
 find_index_conditions([{path, Path, Value} | Rest], Acc) ->
-    case is_logic_var(Value) of
+    case is_logic_var(Value) orelse path_has_index(Path) of
         true ->
-            %% Variable binding - can't use for initial index lookup
+            %% Variable binding, or a positional (integer) path which has
+            %% no membership value-index entry (#5) - can't seed an index
+            %% lookup; leave it to the residual matcher on a full scan.
             find_index_conditions(Rest, Acc);
         false ->
             %% Concrete value - good for index
@@ -2170,7 +2173,11 @@ classify_scan_query(Conditions, Plan) ->
     case {Conditions, NeedsBodyForQuery} of
         {[{path, Path, Value}], false} ->
             %% Pure equality - only if value is concrete (not a logic var)
-            case is_logic_var(Value) of
+            %% and the path is all field names. A positional segment
+            %% (integer) has no value-index entry since lists index by
+            %% membership (#5), so fall to a full scan where the residual
+            %% matcher walks the document.
+            case is_logic_var(Value) orelse path_has_index(Path) of
                 true -> needs_body;
                 false -> {pure_equality, Path, Value}
             end;
@@ -2197,8 +2204,9 @@ classify_scan_query(Conditions, Plan) ->
 
 %% @doc Check if all conditions can be evaluated using index
 all_index_conditions([]) -> true;
-all_index_conditions([{path, _, Value} | Rest]) ->
-    case is_logic_var(Value) of
+all_index_conditions([{path, Path, Value} | Rest]) ->
+    %% A positional (integer) path has no membership value-index entry (#5).
+    case is_logic_var(Value) orelse path_has_index(Path) of
         true -> false;
         false -> all_index_conditions(Rest)
     end;
@@ -2213,6 +2221,13 @@ all_index_conditions([{compare, _, Op, Value} | Rest])
         false -> all_index_conditions(Rest)
     end;
 all_index_conditions(_) -> false.
+
+%% @doc True if a path contains a positional (integer) segment. Lists are
+%% indexed by membership (#5), so such paths have no value-index entry and
+%% must be resolved by a full scan / the residual matcher.
+-spec path_has_index([term()]) -> boolean().
+path_has_index(Path) ->
+    lists:any(fun erlang:is_integer/1, Path).
 
 %% @doc Check if projections require document body
 needs_body_for_projection(['*']) -> false;
@@ -2240,7 +2255,9 @@ classify_scan_query_adaptive(StoreRef, DbName, Conditions, Plan) ->
     NeedsBodyForQuery = needs_body_for_projection(Projections),
     case {Conditions, NeedsBodyForQuery} of
         {[{path, Path, Value}], false} ->
-            case is_logic_var(Value) of
+            %% Positional (integer) paths have no value-index entry under
+            %% membership indexing (#5); scan instead.
+            case is_logic_var(Value) orelse path_has_index(Path) of
                 true ->
                     needs_body;
                 false ->
@@ -2568,9 +2585,10 @@ collect_scan_docids(StoreRef, DbName, Conditions, _Snapshot, MaxCount) ->
             end
     end.
 
-%% @private Check if a condition can use index for intersection
-is_index_condition({path, _Path, Value}) ->
-    not is_logic_var(Value);
+%% @private Check if a condition can use index for intersection. A
+%% positional (integer) path has no membership value-index entry (#5).
+is_index_condition({path, Path, Value}) ->
+    not is_logic_var(Value) andalso not path_has_index(Path);
 is_index_condition({compare, _Path, _Op, Value}) ->
     not is_logic_var(Value);
 is_index_condition({prefix, _Path, _Prefix}) ->
@@ -3287,9 +3305,12 @@ maybe_fetch_docs_chunked(DbName, DocIds, true, DecoderFun) ->
                         Fun -> Fun(CborBin)
                     end,
                     {true, #{<<"id">> => DocId, <<"doc">> => Doc}};
-                   ({DocId, not_found}) ->
-                    %% Doc deleted - return ID only with deleted flag
-                    {true, #{<<"id">> => DocId, <<"deleted">> => true}};
+                   ({_DocId, not_found}) ->
+                    %% No live body for this index hit: a stale/orphaned
+                    %% index entry (e.g. a pre-membership list entry, #5),
+                    %% not a live document - skip it rather than emit a
+                    %% mangled/tombstone row.
+                    false;
                    ({_DocId, {error, _}}) ->
                     false
                 end,
@@ -3373,9 +3394,19 @@ match_condition(Doc, {path, Path, Value}, _Bindings, BoundVars) ->
                     %% Bind the variable
                     {true, BoundVars#{Value => DocValue}};
                 false ->
-                    case DocValue =:= Value of
-                        true -> {true, BoundVars};
-                        false -> false
+                    %% Membership for list fields (#5): a path query on a
+                    %% list field matches when Value is a member; scalars
+                    %% keep whole-value equality (the `Value' pattern).
+                    case DocValue of
+                        List when is_list(List) ->
+                            case lists:member(Value, List) of
+                                true -> {true, BoundVars};
+                                false -> false
+                            end;
+                        Value ->
+                            {true, BoundVars};
+                        _ ->
+                            false
                     end
             end;
         not_found ->

--- a/apps/barrel_docdb/test/barrel_ars_SUITE.erl
+++ b/apps/barrel_docdb/test/barrel_ars_SUITE.erl
@@ -132,10 +132,11 @@ analyze_arrays(_Config) ->
         <<"tags">> => [<<"a">>, <<"b">>, <<"c">>]
     },
     Paths = barrel_ars:analyze(Doc),
+    %% #5: arrays index by membership (no positional index)
     Expected = lists:sort([
-        {[<<"tags">>, 0, <<"a">>], <<>>},
-        {[<<"tags">>, 1, <<"b">>], <<>>},
-        {[<<"tags">>, 2, <<"c">>], <<>>}
+        {[<<"tags">>, <<"a">>], <<>>},
+        {[<<"tags">>, <<"b">>], <<>>},
+        {[<<"tags">>, <<"c">>], <<>>}
     ]),
     ?assertEqual(Expected, lists:sort(Paths)).
 
@@ -147,11 +148,13 @@ analyze_arrays_with_objects(_Config) ->
         ]
     },
     Paths = barrel_ars:analyze(Doc),
+    %% #5: array-of-objects indexes by membership (no positional index),
+    %% so both elements' fields collapse onto the same field paths.
     Expected = lists:sort([
-        {[<<"items">>, 0, <<"sku">>, <<"ABC">>], <<>>},
-        {[<<"items">>, 0, <<"qty">>, 2], <<>>},
-        {[<<"items">>, 1, <<"sku">>, <<"XYZ">>], <<>>},
-        {[<<"items">>, 1, <<"qty">>, 1], <<>>}
+        {[<<"items">>, <<"sku">>, <<"ABC">>], <<>>},
+        {[<<"items">>, <<"qty">>, 2], <<>>},
+        {[<<"items">>, <<"sku">>, <<"XYZ">>], <<>>},
+        {[<<"items">>, <<"qty">>, 1], <<>>}
     ]),
     ?assertEqual(Expected, lists:sort(Paths)).
 
@@ -187,21 +190,24 @@ analyze_complex_doc(_Config) ->
         <<"e">> => [#{<<"a">> => 1}, #{<<"b">> => 2, <<"c">> => 3}]
     },
     Paths = barrel_ars:analyze(Doc),
+    %% #5: lists index by membership (no positional index). `c.b' and `d'
+    %% are string lists; `e' is a list of objects whose fields collapse
+    %% onto membership paths.
     Expected = lists:sort([
         {[<<"a">>, 1], <<>>},
         {[<<"b">>, <<"2">>], <<>>},
         {[<<"c">>, <<"a">>, 1], <<>>},
-        {[<<"c">>, <<"b">>, 0, <<"a">>], <<>>},
-        {[<<"c">>, <<"b">>, 1, <<"b">>], <<>>},
-        {[<<"c">>, <<"b">>, 2, <<"c">>], <<>>},
+        {[<<"c">>, <<"b">>, <<"a">>], <<>>},
+        {[<<"c">>, <<"b">>, <<"b">>], <<>>},
+        {[<<"c">>, <<"b">>, <<"c">>], <<>>},
         {[<<"c">>, <<"c">>, <<"a">>, 1], <<>>},
         {[<<"c">>, <<"c">>, <<"b">>, 2], <<>>},
-        {[<<"d">>, 0, <<"a">>], <<>>},
-        {[<<"d">>, 1, <<"b">>], <<>>},
-        {[<<"d">>, 2, <<"c">>], <<>>},
-        {[<<"e">>, 0, <<"a">>, 1], <<>>},
-        {[<<"e">>, 1, <<"b">>, 2], <<>>},
-        {[<<"e">>, 1, <<"c">>, 3], <<>>}
+        {[<<"d">>, <<"a">>], <<>>},
+        {[<<"d">>, <<"b">>], <<>>},
+        {[<<"d">>, <<"c">>], <<>>},
+        {[<<"e">>, <<"a">>, 1], <<>>},
+        {[<<"e">>, <<"b">>, 2], <<>>},
+        {[<<"e">>, <<"c">>, 3], <<>>}
     ]),
     ?assertEqual(Expected, lists:sort(Paths)).
 

--- a/apps/barrel_docdb/test/barrel_ars_index_SUITE.erl
+++ b/apps/barrel_docdb/test/barrel_ars_index_SUITE.erl
@@ -182,11 +182,11 @@ index_doc_with_arrays(Config) ->
     Results = fold_all_paths(StoreRef, DbName, [<<"tags">>]),
     ?assertEqual(3, length(Results)),
 
-    %% Verify paths include array indices
+    %% #5: arrays index by membership (no positional index).
     Paths = [P || {P, _} <- Results],
-    ?assert(lists:member([<<"tags">>, 0, <<"a">>], Paths)),
-    ?assert(lists:member([<<"tags">>, 1, <<"b">>], Paths)),
-    ?assert(lists:member([<<"tags">>, 2, <<"c">>], Paths)),
+    ?assert(lists:member([<<"tags">>, <<"a">>], Paths)),
+    ?assert(lists:member([<<"tags">>, <<"b">>], Paths)),
+    ?assert(lists:member([<<"tags">>, <<"c">>], Paths)),
 
     ok.
 

--- a/apps/barrel_docdb/test/barrel_bql_SUITE.erl
+++ b/apps/barrel_docdb/test/barrel_bql_SUITE.erl
@@ -154,6 +154,11 @@ basic_execution(_Config) ->
         ids("SELECT * FROM db WHERE type = 'user' AND NOT status = 'active'")),
     ?assertEqual([<<"post:1">>, <<"post:3">>, <<"user:1">>],
         ids("SELECT * FROM db WHERE CONTAINS(tags, 'erlang')")),
+    %% #5: infix CONTAINS and `IN <array>' are the same membership
+    ?assertEqual([<<"post:1">>, <<"post:3">>, <<"user:1">>],
+        ids("SELECT * FROM db WHERE tags CONTAINS 'erlang'")),
+    ?assertEqual([<<"post:1">>, <<"post:3">>, <<"user:1">>],
+        ids("SELECT * FROM db WHERE 'erlang' IN tags")),
     ?assertEqual([<<"user:2">>],
         ids("SELECT * FROM db WHERE type = 'user' AND age BETWEEN 20 AND 26")),
     ?assertEqual([<<"post:2">>, <<"post:3">>],

--- a/apps/barrel_docdb/test/barrel_list_membership_SUITE.erl
+++ b/apps/barrel_docdb/test/barrel_list_membership_SUITE.erl
@@ -1,0 +1,113 @@
+%%%-------------------------------------------------------------------
+%%% @doc find/2 path queries on list-valued fields mean membership and
+%%% return well-formed rows (issue #5).
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_list_membership_SUITE).
+
+-export([all/0, init_per_suite/1, end_per_suite/1,
+         init_per_testcase/2, end_per_testcase/2]).
+-export([
+    t_ars_membership_paths/1,
+    t_find_membership/1,
+    t_find_non_member_empty/1,
+    t_find_contains_op/1,
+    t_find_positional/1,
+    t_find_scalar_equality/1
+]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-define(DB, <<"lmdb">>).
+
+all() ->
+    [t_ars_membership_paths, t_find_membership, t_find_non_member_empty,
+     t_find_contains_op, t_find_positional, t_find_scalar_equality].
+
+init_per_suite(Config) ->
+    application:load(barrel_docdb),
+    application:set_env(barrel_docdb, data_dir, ?config(priv_dir, Config)),
+    {ok, _} = application:ensure_all_started(barrel_docdb),
+    Config.
+
+end_per_suite(_Config) ->
+    application:stop(barrel_docdb),
+    ok.
+
+init_per_testcase(_TC, Config) ->
+    {ok, _} = barrel_docdb:create_db(?DB),
+    {ok, _} = barrel_docdb:put_doc(?DB, #{
+        <<"id">> => <<"obs_0001">>,
+        <<"tags">> => [<<"postgres">>, <<"pooling">>],
+        <<"kind">> => <<"note">>}),
+    {ok, _} = barrel_docdb:put_doc(?DB, #{
+        <<"id">> => <<"obs_0002">>,
+        <<"tags">> => [<<"redis">>],
+        <<"kind">> => <<"note">>}),
+    Config.
+
+end_per_testcase(_TC, _Config) ->
+    ok = barrel_docdb:delete_db(?DB),
+    ok.
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+%% Lists are analyzed as membership paths (no positional index).
+t_ars_membership_paths(_Config) ->
+    Paths = [P || {P, _} <-
+                 barrel_ars:analyze(#{<<"tags">> =>
+                                          [<<"postgres">>, <<"pooling">>]})],
+    ?assert(lists:member([<<"tags">>, <<"postgres">>], Paths)),
+    ?assert(lists:member([<<"tags">>, <<"pooling">>], Paths)),
+    ?assertNot(lists:any(fun(P) -> lists:any(fun erlang:is_integer/1, P) end,
+                         Paths)),
+    ok.
+
+%% The exact repro from #5: membership returns one well-formed row (an id
+%% with a doc, no space prefix, no spurious deleted flag).
+t_find_membership(_Config) ->
+    {ok, Rows, _} = barrel_docdb:find(
+        ?DB, #{where => [{path, [<<"tags">>], <<"postgres">>}]}),
+    ?assertMatch([_], Rows),
+    [Row] = Rows,
+    ?assertEqual(<<"obs_0001">>, maps:get(<<"id">>, Row)),
+    ?assert(maps:is_key(<<"doc">>, Row)),
+    ?assertNot(maps:is_key(<<"deleted">>, Row)),
+    ok.
+
+t_find_non_member_empty(_Config) ->
+    {ok, Rows, _} = barrel_docdb:find(
+        ?DB, #{where => [{path, [<<"tags">>], <<"nope">>}]}),
+    ?assertEqual([], Rows),
+    ok.
+
+%% The explicit {contains, ...} condition works too.
+t_find_contains_op(_Config) ->
+    {ok, Rows, _} = barrel_docdb:find(
+        ?DB, #{where => [{contains, [<<"tags">>], <<"pooling">>}]}),
+    ?assertEqual([<<"obs_0001">>], ids(Rows)),
+    ok.
+
+%% Positional access still works (via scan).
+t_find_positional(_Config) ->
+    {ok, Rows, _} = barrel_docdb:find(
+        ?DB, #{where => [{path, [<<"tags">>, 0], <<"postgres">>}]}),
+    ?assertEqual([<<"obs_0001">>], ids(Rows)),
+    ok.
+
+%% Scalar equality is unchanged.
+t_find_scalar_equality(_Config) ->
+    {ok, Rows, _} = barrel_docdb:find(
+        ?DB, #{where => [{path, [<<"kind">>], <<"note">>}]}),
+    ?assertEqual([<<"obs_0001">>, <<"obs_0002">>], ids(Rows)),
+    ok.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+ids(Rows) ->
+    lists:sort([maps:get(<<"id">>, R) || R <- Rows]).

--- a/docs/guides/query-bql.md
+++ b/docs/guides/query-bql.md
@@ -65,6 +65,11 @@ LIMIT 10 OFFSET 20
   `BETWEEN a AND b`, `IS [NOT] NULL`, `IS [NOT] MISSING`,
   `CONTAINS(path, value)`, `AND`, `OR`, `NOT`. Comparisons only match
   same-typed values (both numbers or both strings).
+- Array membership: `d.tags CONTAINS 'erlang'` (infix) and
+  `'erlang' IN d.tags` both test whether the list at `d.tags` contains
+  the value; they are equivalent to `CONTAINS(d.tags, 'erlang')`. `IN`
+  with a parenthesized list, `d.status IN ('a', 'b')`, is still
+  scalar set membership.
 - `$name` parameters bind scalars from the `params` map.
 - `WHERE id = 'x'`, id ranges, and `id LIKE 'prefix%'` become
   primary-key scans.


### PR DESCRIPTION
Querying a list-valued field by value came back broken: `find(db, #{where => [{path, [<<"tags">>], <<"postgres">>}]})` returned a mangled row with a space-prefixed id, no document, and a spurious deleted flag, instead of the document that has `postgres` in its tags.

The analyzer was folding the array index into the index path, and that stray byte threw off where the document id started in the value-index key. The fix indexes lists by membership so the write and read sides agree: a member lookup finds the document, positional access still works through a scan, and any leftover pre-fix index entry is skipped rather than surfaced as a tombstone.

Also adds the infix membership spellings people expect in BQL: `tags CONTAINS 'x'` and `'x' IN tags`, both equivalent to the existing `CONTAINS(tags, 'x')`.

Documents written before this upgrade keep their old positional entries and are not matched by membership until reindexed; they no longer corrupt results in the meantime.

Closes #5