### PR TITLE
harden vector NIFs against malformed and adversarial input

### DIFF
--- a/apps/barrel_faiss/c_src/faiss_index.cpp
+++ b/apps/barrel_faiss/c_src/faiss_index.cpp
@@ -8,10 +8,15 @@
 #include <faiss/impl/IDSelector.h>
 
 #include <cstring>
+#include <cstdint>
 #include <mutex>
 #include <vector>
 
 namespace faiss_nif {
+
+// Upper bound on search top-k, to reject result buffers that would overflow
+// or demand an unreasonable allocation.
+static const int64_t SEARCH_MAX_K = 1000000;
 
 ErlNifResourceType* INDEX_RESOURCE_TYPE = nullptr;
 
@@ -39,12 +44,18 @@ int init_resources(ErlNifEnv* env) {
     return INDEX_RESOURCE_TYPE ? 0 : -1;
 }
 
-// Helper to get metric type from atom
-static faiss::MetricType get_metric(ErlNifEnv* env, ERL_NIF_TERM term) {
+// Helper to get metric type from atom. Returns false for an unknown atom
+// (rather than silently defaulting to L2 and producing wrong results).
+static bool get_metric(ErlNifEnv* env, ERL_NIF_TERM term, faiss::MetricType* out) {
     if (enif_is_identical(term, ATOM_INNER_PRODUCT)) {
-        return faiss::METRIC_INNER_PRODUCT;
+        *out = faiss::METRIC_INNER_PRODUCT;
+        return true;
     }
-    return faiss::METRIC_L2;
+    if (enif_is_identical(term, ATOM_L2)) {
+        *out = faiss::METRIC_L2;
+        return true;
+    }
+    return false;
 }
 
 // Phase 1: new/2 - create flat index
@@ -54,7 +65,10 @@ ERL_NIF_TERM nif_new(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
         return enif_make_badarg(env);
     }
 
-    faiss::MetricType metric = get_metric(env, argv[1]);
+    faiss::MetricType metric;
+    if (!get_metric(env, argv[1], &metric)) {
+        return enif_make_badarg(env);
+    }
 
     try {
         faiss::Index* index = new faiss::IndexFlat(dimension, metric);
@@ -87,11 +101,16 @@ ERL_NIF_TERM nif_index_factory(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv
     if (!enif_inspect_binary(env, argv[1], &desc_bin)) {
         return enif_make_badarg(env);
     }
-    std::string description(reinterpret_cast<char*>(desc_bin.data), desc_bin.size);
 
-    faiss::MetricType metric = get_metric(env, argv[2]);
+    faiss::MetricType metric;
+    if (!get_metric(env, argv[2], &metric)) {
+        return enif_make_badarg(env);
+    }
 
     try {
+        // Construct inside the try: a pathological Description could make
+        // the std::string ctor throw, which must not escape the NIF.
+        std::string description(reinterpret_cast<char*>(desc_bin.data), desc_bin.size);
         faiss::Index* index = faiss::index_factory(dimension, description.c_str(), metric);
 
         IndexResource* res = static_cast<IndexResource*>(
@@ -245,22 +264,31 @@ ERL_NIF_TERM nif_search(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
     int64_t nq = query_bin.size / vector_size;
     const float* queries = reinterpret_cast<const float*>(query_bin.data);
 
-    std::vector<float> distances(nq * k);
-    std::vector<int64_t> labels(nq * k);
+    // Guard the result-buffer size: k is caller-supplied and unbounded, so
+    // nq * k can overflow or demand a multi-TB allocation. Reject before
+    // allocating (an over-large std::vector would otherwise throw outside
+    // the try below and abort the VM across the C ABI).
+    if (nq > 0 && (k > SEARCH_MAX_K ||
+                   k > static_cast<int64_t>(SIZE_MAX / sizeof(int64_t)) / nq)) {
+        return make_error(env, "k_too_large");
+    }
 
+    size_t total = static_cast<size_t>(nq) * static_cast<size_t>(k);
+
+    ERL_NIF_TERM dist_term = 0, labels_term = 0;
     try {
+        std::vector<float> distances(total);
+        std::vector<int64_t> labels(total);
+
         res->index->search(nq, queries, k, distances.data(), labels.data());
+
+        unsigned char* dist_buf = enif_make_new_binary(env, total * sizeof(float), &dist_term);
+        unsigned char* labels_buf = enif_make_new_binary(env, total * sizeof(int64_t), &labels_term);
+        memcpy(dist_buf, distances.data(), total * sizeof(float));
+        memcpy(labels_buf, labels.data(), total * sizeof(int64_t));
     } catch (const std::exception& e) {
         return make_error(env, e.what());
     }
-
-    // Return as binaries
-    ERL_NIF_TERM dist_term, labels_term;
-    unsigned char* dist_buf = enif_make_new_binary(env, nq * k * sizeof(float), &dist_term);
-    unsigned char* labels_buf = enif_make_new_binary(env, nq * k * sizeof(int64_t), &labels_term);
-
-    memcpy(dist_buf, distances.data(), nq * k * sizeof(float));
-    memcpy(labels_buf, labels.data(), nq * k * sizeof(int64_t));
 
     return enif_make_tuple3(env, ATOM_OK, dist_term, labels_term);
 }
@@ -400,7 +428,6 @@ ERL_NIF_TERM nif_write_index(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]
     if (!enif_inspect_binary(env, argv[1], &path_bin)) {
         return enif_make_badarg(env);
     }
-    std::string path(reinterpret_cast<char*>(path_bin.data), path_bin.size);
 
     std::shared_lock<std::shared_mutex> lock(res->rw_mutex);
     if (!res->index) {
@@ -408,6 +435,7 @@ ERL_NIF_TERM nif_write_index(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]
     }
 
     try {
+        std::string path(reinterpret_cast<char*>(path_bin.data), path_bin.size);
         faiss::write_index(res->index, path.c_str());
         return ATOM_OK;
     } catch (const std::exception& e) {
@@ -421,9 +449,9 @@ ERL_NIF_TERM nif_read_index(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     if (!enif_inspect_binary(env, argv[0], &path_bin)) {
         return enif_make_badarg(env);
     }
-    std::string path(reinterpret_cast<char*>(path_bin.data), path_bin.size);
 
     try {
+        std::string path(reinterpret_cast<char*>(path_bin.data), path_bin.size);
         faiss::Index* index = faiss::read_index(path.c_str());
 
         IndexResource* res = static_cast<IndexResource*>(

--- a/apps/barrel_faiss/c_src/faiss_nif.cpp
+++ b/apps/barrel_faiss/c_src/faiss_nif.cpp
@@ -52,6 +52,11 @@ static int on_upgrade(ErlNifEnv* env, void** priv_data, void** old_priv_data, ER
     if (faiss_nif::init_atoms(env) != 0) {
         return -1;
     }
+    // Re-open the resource type (RT_TAKEOVER) so post-upgrade index ops and
+    // destructors resolve into the new library instead of the unloaded one.
+    if (faiss_nif::init_resources(env) != 0) {
+        return -1;
+    }
     return 0;
 }
 
@@ -59,7 +64,7 @@ static ErlNifFunc nif_funcs[] = {
     // Phase 1: Index management
     {"new", 2, faiss_nif::nif_new, 0},
     {"index_factory", 3, faiss_nif::nif_index_factory, 0},
-    {"close", 1, faiss_nif::nif_close, 0},
+    {"close", 1, faiss_nif::nif_close, ERL_NIF_DIRTY_JOB_CPU_BOUND},
     {"dimension", 1, faiss_nif::nif_dimension, 0},
     {"is_trained", 1, faiss_nif::nif_is_trained, 0},
     {"ntotal", 1, faiss_nif::nif_ntotal, 0},

--- a/apps/barrel_vectordb/c_src/barrel_vectordb_distance.c
+++ b/apps/barrel_vectordb/c_src/barrel_vectordb_distance.c
@@ -192,7 +192,7 @@ ERL_NIF_TERM nif_dot_product(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]
 
     double result = do_dot_product(a, b, n);
 
-    return enif_make_double(env, result);
+    return make_finite_double(env, result);
 }
 
 /**
@@ -227,7 +227,7 @@ ERL_NIF_TERM nif_cosine_distance(ErlNifEnv* env, int argc, const ERL_NIF_TERM ar
     double cosine = dot / denom;
     double distance = 1.0 - cosine;
 
-    return enif_make_double(env, distance);
+    return make_finite_double(env, distance);
 }
 
 /**
@@ -253,7 +253,7 @@ ERL_NIF_TERM nif_cosine_distance_normalized(ErlNifEnv* env, int argc, const ERL_
     double dot = do_dot_product(a, b, n);
     double distance = 1.0 - dot;
 
-    return enif_make_double(env, distance);
+    return make_finite_double(env, distance);
 }
 
 /**
@@ -279,7 +279,7 @@ ERL_NIF_TERM nif_euclidean_distance(ErlNifEnv* env, int argc, const ERL_NIF_TERM
     double sq_dist = do_euclidean_distance_sq(a, b, n);
     double distance = sqrt(sq_dist);
 
-    return enif_make_double(env, distance);
+    return make_finite_double(env, distance);
 }
 
 /**

--- a/apps/barrel_vectordb/c_src/barrel_vectordb_nif.c
+++ b/apps/barrel_vectordb/c_src/barrel_vectordb_nif.c
@@ -41,8 +41,8 @@ static ErlNifFunc nif_funcs[] = {
     {"cosine_distance", 2, nif_cosine_distance, ERL_NIF_DIRTY_JOB_CPU_BOUND},
     {"cosine_distance_normalized", 2, nif_cosine_distance_normalized, ERL_NIF_DIRTY_JOB_CPU_BOUND},
     {"euclidean_distance", 2, nif_euclidean_distance, ERL_NIF_DIRTY_JOB_CPU_BOUND},
-    {"to_binary", 1, nif_to_binary, 0},
-    {"from_binary", 1, nif_from_binary, 0},
+    {"to_binary", 1, nif_to_binary, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+    {"from_binary", 1, nif_from_binary, ERL_NIF_DIRTY_JOB_CPU_BOUND},
     /* TurboQuant */
     {"tq_adc_distance", 3, nif_tq_adc_distance, ERL_NIF_DIRTY_JOB_CPU_BOUND},
     {"tq_batch_adc_distance", 3, nif_tq_batch_adc_distance, ERL_NIF_DIRTY_JOB_CPU_BOUND},

--- a/apps/barrel_vectordb/c_src/barrel_vectordb_nif_common.h
+++ b/apps/barrel_vectordb/c_src/barrel_vectordb_nif_common.h
@@ -16,6 +16,20 @@
 #endif
 
 /* Shared helpers */
+
+/* enif_make_double raises badarg on a non-finite value. Distances derived
+ * from crafted/corrupt binaries can be NaN/Inf, so map those to a defined
+ * finite extreme (NaN and +Inf sort as "far", -Inf as "near") rather than
+ * letting the NIF raise mid-compute. */
+static inline ERL_NIF_TERM make_finite_double(ErlNifEnv* env, double v) {
+    if (isnan(v)) {
+        v = 1.0e38;
+    } else if (isinf(v)) {
+        v = (v > 0) ? 1.0e38 : -1.0e38;
+    }
+    return enif_make_double(env, v);
+}
+
 static inline float dequantize_radius(uint16_t quant) {
     if (quant == 0) return 0.0f;
     float t = (float)quant / 65535.0f * logf(11.0f);

--- a/apps/barrel_vectordb/c_src/barrel_vectordb_turboquant.c
+++ b/apps/barrel_vectordb/c_src/barrel_vectordb_turboquant.c
@@ -233,12 +233,13 @@ ERL_NIF_TERM nif_tq_adc_distance(ErlNifEnv* env, int argc, const ERL_NIF_TERM ar
 
     int num_pairs = tables_bin.size / table_row_bytes;
 
-    /* Calculate code component sizes */
-    int radius_bytes = num_pairs * 2;
-    int angle_bits = num_pairs * bits;
-    int angle_bytes = (angle_bits + 7) / 8;
+    /* Calculate code component sizes (size_t so large tables cannot
+     * overflow the byte math and defeat the bounds check below) */
+    size_t radius_bytes = (size_t)num_pairs * 2;
+    size_t angle_bits = (size_t)num_pairs * bits;
+    size_t angle_bytes = (angle_bits + 7) / 8;
 
-    if (code_bin.size < TQ_HEADER_SIZE + radius_bytes + angle_bytes) {
+    if (code_bin.size < (size_t)TQ_HEADER_SIZE + radius_bytes + angle_bytes) {
         return enif_make_badarg(env);
     }
 
@@ -259,7 +260,7 @@ ERL_NIF_TERM nif_tq_adc_distance(ErlNifEnv* env, int argc, const ERL_NIF_TERM ar
 
     enif_free(angle_indices);
 
-    return enif_make_double(env, distance);
+    return make_finite_double(env, distance);
 }
 
 /**
@@ -290,10 +291,10 @@ ERL_NIF_TERM nif_tq_batch_adc_distance(ErlNifEnv* env, int argc, const ERL_NIF_T
     }
 
     int num_pairs = tables_bin.size / table_row_bytes;
-    int radius_bytes = num_pairs * 2;
-    int angle_bits = num_pairs * bits;
-    int angle_bytes = (angle_bits + 7) / 8;
-    size_t min_code_size = TQ_HEADER_SIZE + radius_bytes + angle_bytes;
+    size_t radius_bytes = (size_t)num_pairs * 2;
+    size_t angle_bits = (size_t)num_pairs * bits;
+    size_t angle_bytes = (angle_bits + 7) / 8;
+    size_t min_code_size = (size_t)TQ_HEADER_SIZE + radius_bytes + angle_bytes;
 
     const float* tables = (const float*)tables_bin.data;
 
@@ -301,6 +302,12 @@ ERL_NIF_TERM nif_tq_batch_adc_distance(ErlNifEnv* env, int argc, const ERL_NIF_T
     unsigned int list_len;
     if (!enif_get_list_length(env, argv[1], &list_len)) {
         return enif_make_badarg(env);
+    }
+
+    /* Empty batch: return [] without a zero-size alloc (enif_alloc(0)
+     * may return NULL and spuriously raise badarg) */
+    if (list_len == 0) {
+        return enif_make_list(env, 0);
     }
 
     /* Allocate result array */
@@ -339,7 +346,7 @@ ERL_NIF_TERM nif_tq_batch_adc_distance(ErlNifEnv* env, int argc, const ERL_NIF_T
         unpack_bits(angles_packed, bits, num_pairs, angle_indices);
 
         double distance = do_adc_distance(tables, table_row_floats, radii, angle_indices, num_pairs);
-        results[i] = enif_make_double(env, distance);
+        results[i] = make_finite_double(env, distance);
 
         list = tail;
         i++;

--- a/apps/barrel_vectordb/c_src/barrel_vectordb_turboquant_subspace.c
+++ b/apps/barrel_vectordb/c_src/barrel_vectordb_turboquant_subspace.c
@@ -227,31 +227,41 @@ ERL_NIF_TERM nif_tqs_adc_distance(ErlNifEnv* env, int argc, const ERL_NIF_TERM a
         const float* table_data = (const float*)tables_ptr;
         tables_ptr += table_size;
 
-        /* Calculate subspace dimensions */
-        int table_row_bytes = table_row_floats * sizeof(float);
+        /* Calculate subspace dimensions (size_t byte math so a large
+         * table cannot overflow and defeat the bounds check) */
+        size_t table_row_bytes = (size_t)table_row_floats * sizeof(float);
+        if (table_size % table_row_bytes != 0) {
+            return enif_make_badarg(env);
+        }
         int num_pairs = table_size / table_row_bytes;
         int subdim = num_pairs * 2;
 
         /* Calculate code component sizes */
-        int radius_bytes = num_pairs * 2;
-        int angle_bits = num_pairs * bits;
-        int angle_bytes = (angle_bits + 7) / 8;
-        int qjl_bytes = (subdim + 7) / 8;
-        int subspace_code_size = radius_bytes + angle_bytes + qjl_bytes;
+        size_t radius_bytes = (size_t)num_pairs * 2;
+        size_t angle_bits = (size_t)num_pairs * bits;
+        size_t angle_bytes = (angle_bits + 7) / 8;
+        size_t qjl_bytes = ((size_t)subdim + 7) / 8;
+        size_t subspace_code_size = radius_bytes + angle_bytes + qjl_bytes;
 
         if (code_ptr + subspace_code_size > code_bin.data + code_bin.size) {
             return enif_make_badarg(env);
         }
 
-        /* Parse radii and angles */
-        const uint16_t* radii = (const uint16_t*)code_ptr;
+        /* Copy radii into an aligned buffer: code_ptr can land on an odd
+         * offset when subspace_code_size is odd, so a uint16_t* cast would
+         * be an unaligned load (UB) */
         const uint8_t* angles_packed = code_ptr + radius_bytes;
 
-        /* Unpack angle indices */
         uint32_t* angle_indices = enif_alloc(num_pairs * sizeof(uint32_t));
         if (!angle_indices) {
             return enif_make_badarg(env);
         }
+        uint16_t* radii = enif_alloc(num_pairs * sizeof(uint16_t));
+        if (!radii) {
+            enif_free(angle_indices);
+            return enif_make_badarg(env);
+        }
+        memcpy(radii, code_ptr, radius_bytes);
         unpack_bits(angles_packed, bits, num_pairs, angle_indices);
 
         /* Compute squared distance for this subspace */
@@ -259,11 +269,12 @@ ERL_NIF_TERM nif_tqs_adc_distance(ErlNifEnv* env, int argc, const ERL_NIF_TERM a
                                                        radii, angle_indices, num_pairs);
         total_sq += subspace_sq;
 
+        enif_free(radii);
         enif_free(angle_indices);
         code_ptr += subspace_code_size;
     }
 
-    return enif_make_double(env, sqrt(total_sq > 0.0 ? total_sq : 0.0));
+    return make_finite_double(env, sqrt(total_sq > 0.0 ? total_sq : 0.0));
 }
 
 /**
@@ -290,6 +301,12 @@ ERL_NIF_TERM nif_tqs_batch_adc_distance(ErlNifEnv* env, int argc, const ERL_NIF_
         return enif_make_badarg(env);
     }
 
+    /* Empty batch: return [] without a zero-size alloc (enif_alloc(0)
+     * may return NULL and spuriously raise badarg) */
+    if (list_len == 0) {
+        return enif_make_list(env, 0);
+    }
+
     ERL_NIF_TERM* results = enif_alloc(list_len * sizeof(ERL_NIF_TERM));
     if (!results) {
         return enif_make_badarg(env);
@@ -304,9 +321,9 @@ ERL_NIF_TERM nif_tqs_batch_adc_distance(ErlNifEnv* env, int argc, const ERL_NIF_
         uint32_t size;
         int num_pairs;
         int subdim;
-        int radius_bytes;
-        int angle_bytes;
-        int code_size;
+        size_t radius_bytes;
+        size_t angle_bytes;
+        size_t code_size;
     } subspace_info_t;
 
     subspace_info_t* subspace_info = enif_alloc(m * sizeof(subspace_info_t));
@@ -315,36 +332,58 @@ ERL_NIF_TERM nif_tqs_batch_adc_distance(ErlNifEnv* env, int argc, const ERL_NIF_
         return enif_make_badarg(env);
     }
 
+    const uint8_t* tables_end = tables_bin.data + tables_bin.size;
     const uint8_t* tables_ptr = tables_bin.data;
     for (int s = 0; s < m; s++) {
+        /* Bounds-check the size prefix and table body before reading,
+         * as the single-shot path does. Without this a truncated or
+         * mismatched Tables binary reads out of bounds. */
+        if (tables_ptr + 4 > tables_end) {
+            enif_free(subspace_info);
+            enif_free(results);
+            return enif_make_badarg(env);
+        }
         uint32_t table_size = ((uint32_t)tables_ptr[0] << 24) |
                               ((uint32_t)tables_ptr[1] << 16) |
                               ((uint32_t)tables_ptr[2] << 8) |
                               ((uint32_t)tables_ptr[3]);
         tables_ptr += 4;
 
+        if (table_size > (size_t)(tables_end - tables_ptr)) {
+            enif_free(subspace_info);
+            enif_free(results);
+            return enif_make_badarg(env);
+        }
+
+        size_t table_row_bytes = (size_t)table_row_floats * sizeof(float);
+        if (table_size % table_row_bytes != 0) {
+            enif_free(subspace_info);
+            enif_free(results);
+            return enif_make_badarg(env);
+        }
+
         subspace_info[s].data = (const float*)tables_ptr;
         subspace_info[s].size = table_size;
         tables_ptr += table_size;
 
-        int table_row_bytes = table_row_floats * sizeof(float);
         int num_pairs = table_size / table_row_bytes;
         int subdim = num_pairs * 2;
 
         subspace_info[s].num_pairs = num_pairs;
         subspace_info[s].subdim = subdim;
-        subspace_info[s].radius_bytes = num_pairs * 2;
+        subspace_info[s].radius_bytes = (size_t)num_pairs * 2;
 
-        int angle_bits = num_pairs * bits;
+        size_t angle_bits = (size_t)num_pairs * bits;
         subspace_info[s].angle_bytes = (angle_bits + 7) / 8;
 
-        int qjl_bytes = (subdim + 7) / 8;
+        size_t qjl_bytes = ((size_t)subdim + 7) / 8;
         subspace_info[s].code_size = subspace_info[s].radius_bytes +
                                       subspace_info[s].angle_bytes + qjl_bytes;
     }
 
-    /* Find max num_pairs for buffer allocation */
-    int max_pairs = 0;
+    /* Find max num_pairs for buffer allocation (at least 1 so the
+     * scratch allocations below never call enif_alloc(0)) */
+    int max_pairs = 1;
     for (int s = 0; s < m; s++) {
         if (subspace_info[s].num_pairs > max_pairs) {
             max_pairs = subspace_info[s].num_pairs;
@@ -353,6 +392,15 @@ ERL_NIF_TERM nif_tqs_batch_adc_distance(ErlNifEnv* env, int argc, const ERL_NIF_
 
     uint32_t* angle_indices = enif_alloc(max_pairs * sizeof(uint32_t));
     if (!angle_indices) {
+        enif_free(subspace_info);
+        enif_free(results);
+        return enif_make_badarg(env);
+    }
+    /* Aligned radii scratch: code_ptr can land on an odd offset, so read
+     * radii through this buffer instead of an unaligned uint16_t* cast */
+    uint16_t* radii = enif_alloc(max_pairs * sizeof(uint16_t));
+    if (!radii) {
+        enif_free(angle_indices);
         enif_free(subspace_info);
         enif_free(results);
         return enif_make_badarg(env);
@@ -370,17 +418,28 @@ ERL_NIF_TERM nif_tqs_batch_adc_distance(ErlNifEnv* env, int argc, const ERL_NIF_
             code_bin.data[0] != TQS_VERSION ||
             code_bin.data[1] != (uint8_t)bits ||
             code_bin.data[2] != (uint8_t)m) {
+            enif_free(radii);
             enif_free(angle_indices);
             enif_free(subspace_info);
             enif_free(results);
             return enif_make_badarg(env);
         }
 
+        const uint8_t* code_end = code_bin.data + code_bin.size;
         const uint8_t* code_ptr = code_bin.data + TQS_HEADER_SIZE;
         double total_sq = 0.0;
 
         for (int s = 0; s < m; s++) {
-            const uint16_t* radii = (const uint16_t*)code_ptr;
+            /* Bounds-check this subspace's code slice before reading it */
+            if (subspace_info[s].code_size > (size_t)(code_end - code_ptr)) {
+                enif_free(radii);
+                enif_free(angle_indices);
+                enif_free(subspace_info);
+                enif_free(results);
+                return enif_make_badarg(env);
+            }
+
+            memcpy(radii, code_ptr, subspace_info[s].radius_bytes);
             const uint8_t* angles_packed = code_ptr + subspace_info[s].radius_bytes;
 
             unpack_bits(angles_packed, bits, subspace_info[s].num_pairs, angle_indices);
@@ -393,11 +452,12 @@ ERL_NIF_TERM nif_tqs_batch_adc_distance(ErlNifEnv* env, int argc, const ERL_NIF_
             code_ptr += subspace_info[s].code_size;
         }
 
-        results[i] = enif_make_double(env, sqrt(total_sq > 0.0 ? total_sq : 0.0));
+        results[i] = make_finite_double(env, sqrt(total_sq > 0.0 ? total_sq : 0.0));
         list = tail;
         i++;
     }
 
+    enif_free(radii);
     enif_free(angle_indices);
     enif_free(subspace_info);
 

--- a/apps/barrel_vectordb/test/barrel_vectordb_turboquant_subspace_tests.erl
+++ b/apps/barrel_vectordb/test/barrel_vectordb_turboquant_subspace_tests.erl
@@ -190,6 +190,38 @@ split_subvectors_test_() ->
         end}
     ].
 
+%% The batch ADC NIF must reject malformed Tables/Codes with badarg
+%% instead of reading out of bounds, and return [] for an empty batch.
+nif_safety_test_() ->
+    {ok, Config} = barrel_vectordb_turboquant_subspace:new(#{dimension => 768, m => 8}),
+    Query = [rand:uniform() - 0.5 || _ <- lists:seq(1, 768)],
+    Vec = [rand:uniform() - 0.5 || _ <- lists:seq(1, 768)],
+    Tables = barrel_vectordb_turboquant_subspace:precompute_tables(Config, Query),
+    Code = barrel_vectordb_turboquant_subspace:encode(Config, Vec),
+    <<_Ver:8, Bits:8, M:8, _:8, _/binary>> = Code,
+    Nif = fun(T, C) -> barrel_vectordb_nif:tqs_batch_adc_distance(T, C, Bits, M) end,
+    [
+        {"empty batch returns []", fun() ->
+            ?assertEqual([], Nif(Tables, []))
+        end},
+        {"valid batch returns one distance per code", fun() ->
+            [D1, D2] = Nif(Tables, [Code, Code]),
+            ?assert(is_float(D1) andalso is_float(D2)),
+            ?assert(D1 >= 0.0)
+        end},
+        {"truncated tables raise badarg, no crash", fun() ->
+            ?assertError(badarg, Nif(<<>>, [Code])),
+            ?assertError(badarg, Nif(<<0, 0, 0>>, [Code])),
+            ?assertError(badarg, Nif(<<255, 255, 255, 255>>, [Code]))
+        end},
+        {"truncated code raises badarg, no crash", fun() ->
+            HeaderOnly = binary:part(Code, 0, 4),
+            ?assertError(badarg, Nif(Tables, [HeaderOnly])),
+            Half = binary:part(Code, 0, max(4, byte_size(Code) div 2)),
+            ?assertError(badarg, Nif(Tables, [Half]))
+        end}
+    ].
+
 %% Performance comparison test (disabled by default, run manually)
 performance_comparison_test_() ->
     {timeout, 60, fun() ->

--- a/apps/barrel_vectordb/test/barrel_vectordb_turboquant_tests.erl
+++ b/apps/barrel_vectordb/test/barrel_vectordb_turboquant_tests.erl
@@ -10,6 +10,15 @@
 %% Test Generators
 %%====================================================================
 
+%% Empty batch must return [] rather than a zero-size-alloc badarg.
+tq_batch_empty_nif_test() ->
+    {ok, Config} = barrel_vectordb_turboquant:new(#{dimension => 128}),
+    Query = [rand:uniform() - 0.5 || _ <- lists:seq(1, 128)],
+    Tables = barrel_vectordb_turboquant:precompute_tables(Config, Query),
+    Vec = [rand:uniform() - 0.5 || _ <- lists:seq(1, 128)],
+    <<_V:8, Bits:8, _/binary>> = barrel_vectordb_turboquant:encode(Config, Vec),
+    ?assertEqual([], barrel_vectordb_nif:tq_batch_adc_distance(Tables, [], Bits)).
+
 turboquant_test_() ->
     {foreach,
      fun setup/0,


### PR DESCRIPTION
The batch subspace-ADC NIF trusted the Tables and Code binaries and read past their ends when either was truncated or mismatched (a segfault reachable from corrupt or crafted quantizer data). The FAISS search NIF built its result buffers from an unbounded `k` outside the try, so a large `k` aborted the whole VM instead of returning an error.

Both now validate sizes before allocating and reading. Rounds out the vector NIFs with aligned radii reads, dirty-scheduler list conversions, finite-safe distances, strict FAISS metric atoms, and resource re-open on upgrade.