### PR TITLE
make replication drain and task lifecycle robust

### DIFF
--- a/apps/barrel_docdb/src/barrel_rep.erl
+++ b/apps/barrel_docdb/src/barrel_rep.erl
@@ -307,20 +307,28 @@ do_replicate(Source, Target, SourceTransport, TargetTransport, Since,
             {ok, AccStats, Checkpoint};
 
         {ok, Changes, LastSeq} ->
-            %% Replicate this batch
-            case barrel_rep_alg:replicate(
-                     Source, Target, SourceTransport, TargetTransport,
-                     Changes) of
-                {ok, BatchStats} ->
-                    do_replicate_batch_done(
-                        Source, Target, SourceTransport, TargetTransport,
-                        BatchSize, CheckpointSize, Checkpoint, Filter,
-                        AccStats, DocsProcessed, Changes, LastSeq,
-                        BatchStats);
-                {error, _} = BatchError ->
-                    %% a target-side batch failure (network, auth) aborts
-                    %% the run with the error instead of crashing it
-                    BatchError
+            case barrel_rep_checkpoint:seq_advanced(Since, LastSeq) of
+                false ->
+                    %% A non-empty batch that did not advance the sequence
+                    %% means a non-conforming source. Abort instead of
+                    %% re-requesting the same point forever.
+                    {error, {no_progress, Since, LastSeq}};
+                true ->
+                    %% Replicate this batch
+                    case barrel_rep_alg:replicate(
+                             Source, Target, SourceTransport, TargetTransport,
+                             Changes) of
+                        {ok, BatchStats} ->
+                            do_replicate_batch_done(
+                                Source, Target, SourceTransport, TargetTransport,
+                                BatchSize, CheckpointSize, Checkpoint, Filter,
+                                AccStats, DocsProcessed, Changes, LastSeq,
+                                BatchStats);
+                        {error, _} = BatchError ->
+                            %% a target-side batch failure (network, auth)
+                            %% aborts the run with the error
+                            BatchError
+                    end
             end;
 
         {error, _} = Error ->

--- a/apps/barrel_docdb/src/barrel_rep_checkpoint.erl
+++ b/apps/barrel_docdb/src/barrel_rep_checkpoint.erl
@@ -24,6 +24,9 @@
 %% Seq wire codec (base64 of the 12-byte HLC; <<"first">> sentinel)
 -export([encode_seq/1, decode_seq/1]).
 
+%% Sequence ordering
+-export([seq_advanced/2]).
+
 %% Internal API for reading checkpoints
 -export([
     read_checkpoint_doc/3
@@ -95,6 +98,16 @@ get_last_seq(#checkpoint{last_seq = Seq}) ->
 -spec set_last_seq(barrel_hlc:timestamp() | first, checkpoint()) -> checkpoint().
 set_last_seq(Seq, #checkpoint{docs_processed = DocsProcessed} = Checkpoint) ->
     Checkpoint#checkpoint{last_seq = Seq, docs_processed = DocsProcessed + 1}.
+
+%% @doc True if `New' is strictly after `Old' in sequence order. `first'
+%% precedes every real sequence. A drain loop uses this to detect a source
+%% that returns a non-empty batch without advancing the sequence, which
+%% would otherwise loop forever re-requesting the same point.
+-spec seq_advanced(barrel_hlc:timestamp() | first,
+                   barrel_hlc:timestamp() | first) -> boolean().
+seq_advanced(_Old, first) -> false;
+seq_advanced(first, _New) -> true;
+seq_advanced(Old, New) -> barrel_hlc:compare(New, Old) =:= gt.
 
 %% @doc Check if checkpoint should be written and write it if needed
 -spec maybe_write_checkpoint(checkpoint()) -> checkpoint().

--- a/apps/barrel_docdb/src/barrel_rep_tasks.erl
+++ b/apps/barrel_docdb/src/barrel_rep_tasks.erl
@@ -49,7 +49,8 @@
 ]).
 
 %% gen_server callbacks
--export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
+-export([init/1, handle_call/3, handle_cast/2, handle_continue/2,
+         handle_info/2, terminate/2]).
 
 -define(SERVER, ?MODULE).
 -define(TASKS_DB, <<"_replication_tasks">>).
@@ -174,13 +175,26 @@ get_task_pid(TaskId) ->
 %%====================================================================
 
 init([]) ->
-    %% Ensure tasks database exists
-    ensure_tasks_db(),
-    %% Schedule task check
-    erlang:send_after(?CHECK_INTERVAL, self(), check_tasks),
-    %% Restore persisted tasks
-    State = restore_tasks(#state{}),
-    {ok, State}.
+    %% Trap exits so a task crash arrives as {'EXIT',...} (handled below)
+    %% rather than taking the manager down, and so a manager restart tears
+    %% its linked tasks down before restore re-creates them (otherwise old
+    %% tasks orphan and double on every restart).
+    process_flag(trap_exit, true),
+    %% Open the tasks db and restore off the boot path, so a slow or failing
+    %% store open cannot stall or crash the supervisor.
+    {ok, #state{}, {continue, startup}}.
+
+handle_continue(startup, State) ->
+    case ensure_tasks_db() of
+        ok ->
+            erlang:send_after(?CHECK_INTERVAL, self(), check_tasks),
+            {noreply, restore_tasks(State)};
+        {error, Reason} ->
+            logger:warning("barrel_rep_tasks: tasks db unavailable (~p); "
+                           "retrying", [Reason]),
+            erlang:send_after(?CHECK_INTERVAL, self(), startup_retry),
+            {noreply, State}
+    end.
 
 handle_call({start_task, Config}, _From, State) ->
     case do_start_task(Config, State) of
@@ -243,10 +257,6 @@ handle_cast({task_complete, TaskId}, State) ->
     NewRunning = maps:remove(TaskId, State#state.running),
     {noreply, State#state{running = NewRunning}};
 
-handle_cast({task_progress, TaskId, LastSeq}, State) ->
-    _ = update_task_seq(TaskId, LastSeq),
-    {noreply, State};
-
 handle_cast({task_error, TaskId, Reason}, State) ->
     _ = update_task_status(TaskId, failed,
                            #{<<"error">> => format_reason(Reason)}),
@@ -267,7 +277,12 @@ handle_info(check_tasks, State) ->
     erlang:send_after(?CHECK_INTERVAL, self(), check_tasks),
     {noreply, NewState};
 
-handle_info({'DOWN', _Ref, process, Pid, Reason}, State) ->
+handle_info(startup_retry, State) ->
+    {noreply, State, {continue, startup}};
+
+handle_info({'EXIT', Pid, Reason}, State) ->
+    %% A linked task process exited (crash, normal, or shutdown). The
+    %% manager's own supervisor exit is handled by gen_server, not here.
     NewState = handle_task_down(Pid, Reason, State),
     {noreply, NewState};
 
@@ -406,15 +421,13 @@ start_task_process(#{id := TaskId, config := Config} = Task, State) ->
     %% Get last sequence
     LastSeq = maps:get(last_seq, Task, first),
 
-    %% Spawn task process (use spawn + monitor, not spawn_link)
-    %% This prevents a crashing task from bringing down the gen_server
+    %% Link the task to the manager (which traps exits): the task dies
+    %% with the manager, and a task crash arrives as {'EXIT',...} without
+    %% taking the manager down.
     Self = self(),
-    Pid = spawn(fun() ->
+    Pid = spawn_link(fun() ->
         run_task(Self, TaskId, Config, SourceTransport, TargetTransport, LastSeq)
     end),
-
-    %% Monitor the process for crash detection
-    erlang:monitor(process, Pid),
 
     %% Update status
     _ = update_task_status(TaskId, running),
@@ -458,11 +471,13 @@ run_task(Parent, TaskId, Config, SourceTransport, TargetTransport, StartSeq) ->
                 run_direction(Ctx0, Target, Source, TargetTransport,
                               SourceTransport, StartSeq);
             both ->
-                %% Bidirectional: run both push and pull concurrently
-                %% This is simplified - for production we'd want separate checkpoints
-                Self = self(),
+                %% Bidirectional: run both push and pull concurrently.
+                %% Simplified (shared checkpoint). Both directions keep the
+                %% manager as their parent (Ctx0) so their progress/error
+                %% casts are actually read, not sent to this task process
+                %% where nothing receives them.
                 spawn_link(fun() ->
-                    run_direction(Ctx0#{parent := Self}, Source, Target,
+                    run_direction(Ctx0, Source, Target,
                                   SourceTransport, TargetTransport,
                                   StartSeq)
                 end),
@@ -518,15 +533,23 @@ run_task_loop(Ctx, Since) ->
             run_task_loop(wait_for_wake(Ctx), Since);
 
         {ok, Changes, LastSeq} ->
-            case replicate_batch(From, To, FromTransport, ToTransport,
-                                 Changes, WaitFor) of
-                ok ->
-                    %% Update checkpoint
-                    gen_server:cast(Parent,
-                                    {task_progress, TaskId, LastSeq}),
-                    run_task_loop(reset_pacing(Ctx), LastSeq);
-                {error, Reason} ->
-                    handle_loop_error(Ctx, Since, Reason)
+            case barrel_rep_checkpoint:seq_advanced(Since, LastSeq) of
+                false ->
+                    %% Non-empty batch that did not advance the sequence: a
+                    %% non-conforming source. Continuous backs off, one-shot
+                    %% fails, instead of spinning at 100% CPU forever.
+                    handle_loop_error(Ctx, Since, no_progress);
+                true ->
+                    case replicate_batch(From, To, FromTransport, ToTransport,
+                                         Changes, WaitFor) of
+                        ok ->
+                            %% Persist the checkpoint here in the task
+                            %% process, off the manager's message loop.
+                            _ = update_task_seq(TaskId, LastSeq),
+                            run_task_loop(reset_pacing(Ctx), LastSeq);
+                        {error, Reason} ->
+                            handle_loop_error(Ctx, Since, Reason)
+                    end
             end;
         {error, Reason} ->
             handle_loop_error(Ctx, Since, Reason)
@@ -692,8 +715,12 @@ ensure_tasks_db() ->
         {ok, _} ->
             ok;
         {error, not_found} ->
-            {ok, _} = barrel_docdb:create_db(?TASKS_DB),
-            ok
+            case barrel_docdb:create_db(?TASKS_DB) of
+                {ok, _} -> ok;
+                {error, _} = E -> E
+            end;
+        {error, _} = E ->
+            E
     end.
 
 restore_tasks(State) ->

--- a/apps/barrel_docdb/src/barrel_rep_transport_http.erl
+++ b/apps/barrel_docdb/src/barrel_rep_transport_http.erl
@@ -52,6 +52,11 @@
     headers => [{binary(), binary()}]
 }.
 
+%% Overall wall-clock budget for a single request. recv_timeout bounds
+%% each receive but not the whole request, so a slow-trickle peer could
+%% otherwise block a continuous task forever.
+-define(REQUEST_TIMEOUT, 300000).
+
 -define(HLC_HEADER, <<"x-barrel-hlc">>).
 -define(DIGEST_HEADER, <<"x-barrel-digest">>).
 -define(ORIGIN_HEADER, <<"x-barrel-att-origin">>).
@@ -435,13 +440,34 @@ req(#{url := BaseUrl} = Endpoint, Method, PathSuffix, BodyTerm,
               ++ base_headers(Endpoint, method_bin(Method), url_path(Url),
                               ContentHash),
     HttpOpts = [with_body | stream_opts(Endpoint)],
-    case hackney:request(Method, Url, Headers, Body, HttpOpts) of
+    Deadline = maps:get(request_timeout, Endpoint, ?REQUEST_TIMEOUT),
+    case bounded_request(Method, Url, Headers, Body, HttpOpts, Deadline) of
         {ok, Status, RespHeaders, RespBody} ->
             ok = barrel_hlc:maybe_sync_from_header(
                 header_value(?HLC_HEADER, RespHeaders)),
             {ok, Status, decode_body(RespBody)};
         {error, Reason} ->
             {error, {transport, Reason}}
+    end.
+
+%% Run hackney:request under an overall wall-clock deadline. hackney
+%% reclaims the pooled connection when the request process is killed, so a
+%% stalled peer cannot pin the calling task indefinitely.
+bounded_request(Method, Url, Headers, Body, HttpOpts, Deadline) ->
+    Parent = self(),
+    {Pid, Ref} = spawn_monitor(fun() ->
+        Parent ! {self(), hackney:request(Method, Url, Headers, Body, HttpOpts)}
+    end),
+    receive
+        {Pid, Result} ->
+            erlang:demonitor(Ref, [flush]),
+            Result;
+        {'DOWN', Ref, process, Pid, Reason} ->
+            {error, Reason}
+    after Deadline ->
+        exit(Pid, kill),
+        receive {'DOWN', Ref, process, Pid, _} -> ok after 0 -> ok end,
+        {error, request_timeout}
     end.
 
 %% HLC + auth + endpoint headers. `Method' is the uppercase verb, `Path'

--- a/apps/barrel_docdb/test/barrel_rep_SUITE.erl
+++ b/apps/barrel_docdb/test/barrel_rep_SUITE.erl
@@ -45,7 +45,8 @@ groups() ->
             replicate_multiple_docs,
             replicate_with_updates,
             replicate_deleted_doc,
-            replicate_checkpoint_persistence
+            replicate_checkpoint_persistence,
+            no_progress_seq_guard
         ]},
         {filtered_replication, [sequence], [
             replicate_with_query_filter,
@@ -470,6 +471,21 @@ replicate_checkpoint_persistence(_Config) ->
     ct:pal("Target has ~p changes", [length(TargetDocs)]),
     ?assert(length(TargetDocs) >= 8),
 
+    ok.
+
+%% The drain-loop progress guard: a non-empty batch must advance the
+%% sequence past what was requested, otherwise the loop would spin forever
+%% re-requesting the same point. `first' precedes every real sequence.
+no_progress_seq_guard(_Config) ->
+    T1 = barrel_hlc:now(),
+    T2 = barrel_hlc:now(),
+    ?assertEqual(gt, barrel_hlc:compare(T2, T1)),
+    ?assert(barrel_rep_checkpoint:seq_advanced(first, T1)),
+    ?assert(barrel_rep_checkpoint:seq_advanced(T1, T2)),
+    ?assertNot(barrel_rep_checkpoint:seq_advanced(T1, T1)),
+    ?assertNot(barrel_rep_checkpoint:seq_advanced(T2, T1)),
+    ?assertNot(barrel_rep_checkpoint:seq_advanced(T1, first)),
+    ?assertNot(barrel_rep_checkpoint:seq_advanced(first, first)),
     ok.
 
 %%====================================================================


### PR DESCRIPTION
A source that returned a non-empty batch without advancing its sequence sent the drain loop spinning at 100% CPU forever, re-requesting the same point. The loop now stops when the sequence does not move (continuous tasks back off, one-shot fails).

Replication tasks were bare-spawned and only monitored, so a manager restart orphaned them and doubled them each restart. They are now linked to the trap-exit manager and torn down with it, task startup and per-batch checkpointing move off the manager's message loop, the bidirectional child reports to the manager instead of a mailbox nothing reads, and a stalled HTTP peer can no longer pin a task past a request deadline.