### PR TITLE
release vector-store batches and scratch tables on every path

### DIFF
--- a/apps/barrel_vectordb/src/barrel_vectordb_bm25_disk.erl
+++ b/apps/barrel_vectordb/src/barrel_vectordb_bm25_disk.erl
@@ -189,6 +189,10 @@ open(Path, Opts) ->
                     DocStatsTable = ets:new(bm25_doc_stats, [set, public]),
                     TermStatsTable = ets:new(bm25_term_stats, [set, public]),
 
+                    %% Delete the tables if the rest of the open fails (corrupt
+                    %% block-max index, bad doc stats), so a failed open does
+                    %% not orphan these public ETS tables.
+                    try
                     %% Load block-max index
                     {ok, BlockmaxIndex} = barrel_vectordb_bm25_disk_file:read_blockmax_index(FileHandle),
 
@@ -216,7 +220,13 @@ open(Path, Opts) ->
                         disk_term_count = maps:get(term_count, Header, 0),
                         disk_total_tokens = maps:get(total_tokens, Header, 0),
                         blockmax_index = BlockmaxIndex
-                    }};
+                    }}
+                    catch
+                        Class:Reason:St ->
+                            ets:delete(DocStatsTable),
+                            ets:delete(TermStatsTable),
+                            erlang:raise(Class, Reason, St)
+                    end;
                 {error, _} = Error ->
                     barrel_vectordb_bm25_disk_file:close(FileHandle),
                     Error

--- a/apps/barrel_vectordb/src/barrel_vectordb_registry.erl
+++ b/apps/barrel_vectordb/src/barrel_vectordb_registry.erl
@@ -96,7 +96,16 @@ handle_call({register, Name, Pid}, _From, Mons) ->
     end;
 handle_call({unregister, Name}, _From, Mons) ->
     ets:delete(?TAB, Name),
-    {reply, ok, Mons}.
+    %% Drop the monitor too, or a process that registers and unregisters
+    %% many names accumulates live monitors until it finally dies.
+    Mons1 = case [R || {R, N} <- maps:to_list(Mons), N =:= Name] of
+        [Ref | _] ->
+            erlang:demonitor(Ref, [flush]),
+            maps:remove(Ref, Mons);
+        [] ->
+            Mons
+    end,
+    {reply, ok, Mons1}.
 
 handle_cast(_Msg, Mons) ->
     {noreply, Mons}.

--- a/apps/barrel_vectordb/src/barrel_vectordb_server.erl
+++ b/apps/barrel_vectordb/src/barrel_vectordb_server.erl
@@ -576,6 +576,9 @@ process_writes_atomic(Writes, #state{db = Db, cf_vectors = CfV, cf_metadata = Cf
                                       index = Index, index_module = Mod, dimension = Dim} = State) ->
     {ok, Batch} = rocksdb:batch(),
 
+    %% The off-heap batch object must be released on every path (commit,
+    %% error, or crash), not just left for GC.
+    try
     %% First, prepare all embeddings if needed (this is done before batch to avoid
     %% partial writes on embedding failures)
     case prepare_writes(Writes, State) of
@@ -653,6 +656,9 @@ process_writes_atomic(Writes, #state{db = Db, cf_vectors = CfV, cf_metadata = Cf
                         State),
                     {[ErrorReply | OkReplies], NewState}
             end
+    end
+    after
+        rocksdb:release_batch(Batch)
     end.
 
 %% Apply write to RocksDB batch only (no index update yet). Returns the vector(s)
@@ -1090,31 +1096,35 @@ do_add(Id, Text, Metadata, Vector, #state{db = Db, cf_vectors = CfV,
     VectorBin = encode_vector(Vector),
 
     {ok, Batch} = rocksdb:batch(),
-    ok = rocksdb:batch_put(Batch, CfV, Id, VectorBin),
-    DocPairs = put_docdata_to_batch(Docstore, Batch, CfM, CfT, Id, Text, Metadata),
+    try
+        ok = rocksdb:batch_put(Batch, CfV, Id, VectorBin),
+        DocPairs = put_docdata_to_batch(Docstore, Batch, CfM, CfT, Id, Text, Metadata),
 
-    %% Index updated in-memory only (rebuilt from vectors on startup)
-    case Mod:insert(Index, Id, Vector) of
-        {ok, NewIndex} ->
-            case rocksdb:write_batch(Db, Batch, []) of
-                ok ->
-                    case docstore_multi_put(Docstore, DocPairs) of
-                        ok ->
-                            %% Also add to BM25 index if enabled
-                            case bm25_add(BM25Index, Id, Text) of
-                                {ok, NewBM25Index} ->
-                                    {ok, State#state{index = NewIndex, bm25_index = NewBM25Index}};
-                                {error, Reason} ->
-                                    {error, {bm25_error, Reason}}
-                            end;
-                        {error, DsReason} ->
-                            {error, {docstore_error, DsReason}}
-                    end;
-                {error, Reason} ->
-                    {error, {db_error, Reason}}
-            end;
-        {error, Reason} ->
-            {error, Reason}
+        %% Index updated in-memory only (rebuilt from vectors on startup)
+        case Mod:insert(Index, Id, Vector) of
+            {ok, NewIndex} ->
+                case rocksdb:write_batch(Db, Batch, []) of
+                    ok ->
+                        case docstore_multi_put(Docstore, DocPairs) of
+                            ok ->
+                                %% Also add to BM25 index if enabled
+                                case bm25_add(BM25Index, Id, Text) of
+                                    {ok, NewBM25Index} ->
+                                        {ok, State#state{index = NewIndex, bm25_index = NewBM25Index}};
+                                    {error, Reason} ->
+                                        {error, {bm25_error, Reason}}
+                                end;
+                            {error, DsReason} ->
+                                {error, {docstore_error, DsReason}}
+                        end;
+                    {error, Reason} ->
+                        {error, {db_error, Reason}}
+                end;
+            {error, Reason} ->
+                {error, Reason}
+        end
+    after
+        rocksdb:release_batch(Batch)
     end.
 
 %% Get a document
@@ -1146,26 +1156,30 @@ do_delete(Id, #state{db = Db, cf_vectors = CfV, cf_metadata = CfM,
                      cf_text = CfT, cf_hnsw = CfH, index = Index, index_module = Mod,
                      bm25_index = BM25Index, docstore = Docstore} = State) ->
     {ok, Batch} = rocksdb:batch(),
-    ok = rocksdb:batch_delete(Batch, CfV, Id),
-    ok = delete_docdata_from_batch(Docstore, Batch, CfM, CfT, Id),
-    ok = rocksdb:batch_delete(Batch, CfH, Id),
+    try
+        ok = rocksdb:batch_delete(Batch, CfV, Id),
+        ok = delete_docdata_from_batch(Docstore, Batch, CfM, CfT, Id),
+        ok = rocksdb:batch_delete(Batch, CfH, Id),
 
-    case rocksdb:write_batch(Db, Batch, []) of
-        ok ->
-            case docstore_delete(Docstore, Id) of
-                ok ->
-                    case Mod:delete(Index, Id) of
-                        {ok, NewIndex} ->
-                            %% Also remove from BM25 index if enabled
-                            {ok, NewBM25Index} = bm25_remove(BM25Index, Id),
-                            {ok, State#state{index = NewIndex, bm25_index = NewBM25Index}};
-                        {error, Reason} -> {error, Reason}
-                    end;
-                {error, DsReason} ->
-                    {error, {docstore_error, DsReason}}
-            end;
-        {error, Reason} ->
-            {error, {db_error, Reason}}
+        case rocksdb:write_batch(Db, Batch, []) of
+            ok ->
+                case docstore_delete(Docstore, Id) of
+                    ok ->
+                        case Mod:delete(Index, Id) of
+                            {ok, NewIndex} ->
+                                %% Also remove from BM25 index if enabled
+                                {ok, NewBM25Index} = bm25_remove(BM25Index, Id),
+                                {ok, State#state{index = NewIndex, bm25_index = NewBM25Index}};
+                            {error, Reason} -> {error, Reason}
+                        end;
+                    {error, DsReason} ->
+                        {error, {docstore_error, DsReason}}
+                end;
+            {error, Reason} ->
+                {error, {db_error, Reason}}
+        end
+    after
+        rocksdb:release_batch(Batch)
     end.
 
 %% Peek at documents (sample without search)


### PR DESCRIPTION
Vector add and delete built a RocksDB write batch but never released the off-heap object, so under sustained ingest the batches accumulated between garbage collections (invisible to GC scheduling). Each is now released in an `after` clause on commit, error and crash alike, matching the docdb store layer.

Also: the name registry drops a name's monitor on unregister instead of holding it until the process dies, and a failed BM25 index open deletes the public ETS tables it created instead of orphaning them.

The DiskANN hot-layer compaction result is still dropped rather than installed; installing it correctly needs merge semantics to avoid losing writes that land during compaction, so it's left for a dedicated change.