### PR TITLE
close signed-upload, mTLS-gate and filter DoS gaps on the sync surface

### DIFF
--- a/apps/barrel_docdb/src/barrel_query.erl
+++ b/apps/barrel_docdb/src/barrel_query.erl
@@ -147,6 +147,11 @@
 %%====================================================================
 
 %% Target: ~1MB of doc data per chunk for good cache utilization
+%% Bounds regex backtracking so a catastrophic pattern (a hostile
+%% replication peer can supply the wire filter's raw regex) cannot pin a
+%% scheduler. Over the limit is treated as no match.
+-define(RE_MATCH_LIMIT, 100000).
+
 -define(TARGET_CHUNK_BYTES, 1048576).
 -define(MIN_CHUNK_SIZE, 50).
 -define(MAX_CHUNK_SIZE, 1000).
@@ -3484,9 +3489,11 @@ match_condition(Doc, {missing, Path}, _Bindings, BoundVars) ->
 match_condition(Doc, {regex, Path, Pattern}, _Bindings, BoundVars) ->
     case get_path_value(Doc, Path) of
         {ok, DocValue} when is_binary(DocValue) ->
-            case re:run(DocValue, Pattern) of
+            case re:run(DocValue, Pattern,
+                        [{match_limit, ?RE_MATCH_LIMIT},
+                         {match_limit_recursion, ?RE_MATCH_LIMIT}]) of
                 {match, _} -> {true, BoundVars};
-                nomatch -> false
+                _ -> false
             end;
         _ ->
             false

--- a/apps/barrel_docdb/src/barrel_query_sub.erl
+++ b/apps/barrel_docdb/src/barrel_query_sub.erl
@@ -27,6 +27,10 @@
 
 -include("barrel_docdb.hrl").
 
+%% Bounds regex backtracking so a hostile wire-filter pattern cannot pin a
+%% scheduler; over the limit is treated as no match.
+-define(RE_MATCH_LIMIT, 100000).
+
 %% API
 -export([
     start_link/0,
@@ -451,9 +455,11 @@ match_condition(Doc, {missing, Path}, _Bindings, BoundVars) ->
 match_condition(Doc, {regex, Path, Pattern}, _Bindings, BoundVars) ->
     case get_path_value(Doc, Path) of
         {ok, DocValue} when is_binary(DocValue) ->
-            case re:run(DocValue, Pattern) of
+            case re:run(DocValue, Pattern,
+                        [{match_limit, ?RE_MATCH_LIMIT},
+                         {match_limit_recursion, ?RE_MATCH_LIMIT}]) of
                 {match, _} -> {true, BoundVars};
-                nomatch -> false
+                _ -> false
             end;
         _ ->
             false

--- a/apps/barrel_docdb/src/barrel_rep_filter.erl
+++ b/apps/barrel_docdb/src/barrel_rep_filter.erl
@@ -12,6 +12,10 @@
 %% The same codec serializes filters for replication-task persistence.
 -module(barrel_rep_filter).
 
+%% Bounds and/or/not nesting from the wire so a hostile peer cannot force
+%% deep recursion (stack/CPU) with a pathological filter.
+-define(MAX_FILTER_DEPTH, 32).
+
 -export([to_wire/1, from_wire/1]).
 
 %%====================================================================
@@ -102,7 +106,8 @@ from_wire(Wire) when is_map(Wire) ->
                 Acc2;
             #{<<"where">> := Where} when is_list(Where) ->
                 Acc2#{query =>
-                          #{where => [cond_from_wire(C) || C <- Where]}};
+                          #{where => [cond_from_wire(C, ?MAX_FILTER_DEPTH)
+                                      || C <- Where]}};
             BadQ ->
                 throw({bad_filter, {query, BadQ}})
         end,
@@ -113,30 +118,32 @@ from_wire(Wire) when is_map(Wire) ->
 from_wire(Other) ->
     {error, {bad_filter, Other}}.
 
-cond_from_wire([<<"path">>, Path, Value]) ->
+cond_from_wire(_Cond, 0) ->
+    throw({bad_filter, too_deeply_nested});
+cond_from_wire([<<"path">>, Path, Value], _D) ->
     {path, path_from_wire(Path), value_from_wire(Value)};
-cond_from_wire([<<"compare">>, Path, Op, Value]) ->
+cond_from_wire([<<"compare">>, Path, Op, Value], _D) ->
     {compare, path_from_wire(Path), op_from_wire(Op),
      value_from_wire(Value)};
-cond_from_wire([<<"and">>, Conds]) when is_list(Conds) ->
-    {'and', [cond_from_wire(C) || C <- Conds]};
-cond_from_wire([<<"or">>, Conds]) when is_list(Conds) ->
-    {'or', [cond_from_wire(C) || C <- Conds]};
-cond_from_wire([<<"not">>, Cond]) ->
-    {'not', cond_from_wire(Cond)};
-cond_from_wire([<<"in">>, Path, Values]) when is_list(Values) ->
+cond_from_wire([<<"and">>, Conds], D) when is_list(Conds) ->
+    {'and', [cond_from_wire(C, D - 1) || C <- Conds]};
+cond_from_wire([<<"or">>, Conds], D) when is_list(Conds) ->
+    {'or', [cond_from_wire(C, D - 1) || C <- Conds]};
+cond_from_wire([<<"not">>, Cond], D) ->
+    {'not', cond_from_wire(Cond, D - 1)};
+cond_from_wire([<<"in">>, Path, Values], _D) when is_list(Values) ->
     {in, path_from_wire(Path), [value_from_wire(V) || V <- Values]};
-cond_from_wire([<<"contains">>, Path, Value]) ->
+cond_from_wire([<<"contains">>, Path, Value], _D) ->
     {contains, path_from_wire(Path), value_from_wire(Value)};
-cond_from_wire([<<"exists">>, Path]) ->
+cond_from_wire([<<"exists">>, Path], _D) ->
     {exists, path_from_wire(Path)};
-cond_from_wire([<<"missing">>, Path]) ->
+cond_from_wire([<<"missing">>, Path], _D) ->
     {missing, path_from_wire(Path)};
-cond_from_wire([<<"regex">>, Path, Pattern]) when is_binary(Pattern) ->
+cond_from_wire([<<"regex">>, Path, Pattern], _D) when is_binary(Pattern) ->
     {regex, path_from_wire(Path), Pattern};
-cond_from_wire([<<"prefix">>, Path, Prefix]) when is_binary(Prefix) ->
+cond_from_wire([<<"prefix">>, Path, Prefix], _D) when is_binary(Prefix) ->
     {prefix, path_from_wire(Path), Prefix};
-cond_from_wire(Other) ->
+cond_from_wire(Other, _D) ->
     throw({bad_filter, Other}).
 
 path_from_wire(Path) when is_list(Path), Path =/= [] ->

--- a/apps/barrel_docdb/test/barrel_rep_filter_tests.erl
+++ b/apps/barrel_docdb/test/barrel_rep_filter_tests.erl
@@ -117,3 +117,19 @@ seq_codec_test() ->
     Enc = barrel_rep_checkpoint:encode_seq(Hlc),
     ?assert(is_binary(Enc)),
     ?assertEqual(Hlc, barrel_rep_checkpoint:decode_seq(Enc)).
+
+%%--------------------------------------------------------------------
+%% Wire filter hardening
+%%--------------------------------------------------------------------
+
+%% A wire filter nested beyond the depth bound is rejected rather than
+%% driving unbounded recursion.
+filter_depth_bound_test() ->
+    Leaf = [<<"path">>, [<<"a">>], <<"x">>],
+    Nest = fun Nest(0, Acc) -> Acc;
+               Nest(N, Acc) -> Nest(N - 1, [<<"not">>, Acc])
+           end,
+    Shallow = #{<<"query">> => #{<<"where">> => [Nest(8, Leaf)]}},
+    ?assertMatch({ok, _}, barrel_rep_filter:from_wire(Shallow)),
+    Deep = #{<<"query">> => #{<<"where">> => [Nest(200, Leaf)]}},
+    ?assertMatch({error, {bad_filter, _}}, barrel_rep_filter:from_wire(Deep)).

--- a/apps/barrel_server/src/barrel_server_auth.erl
+++ b/apps/barrel_server/src/barrel_server_auth.erl
@@ -63,12 +63,34 @@ legacy_state(Other) ->
 %% skew. Unknown accept methods are dropped; an empty accept locks the
 %% server (every request 401s) rather than falling open.
 multi_state(Cfg) ->
-    Accept = [M || M <- maps:get(accept, Cfg, [bearer]),
-                   lists:member(M, [bearer, signed, mtls])],
+    Accept0 = [M || M <- maps:get(accept, Cfg, [bearer]),
+                    lists:member(M, [bearer, signed, mtls])],
+    Accept = drop_ungated_mtls(Accept0),
     Hashes = token_hashes(Cfg),
     Signers = maps:get(signers, Cfg, #{}),
     SkewMs = maps:get(skew_ms, Cfg, 300000),
     base_state(Hashes, Signers, Accept, SkewMs).
+
+%% mtls_ok trusts that a TLS connection carries a verified client cert,
+%% which only holds when the listener actually gates on it. If mtls is
+%% accepted but the tls env does not set `verify => verify_peer', drop mtls
+%% from the accepted set (fail closed) so a certless client is never
+%% authenticated as a trusted peer by a config gap.
+drop_ungated_mtls(Accept) ->
+    case lists:member(mtls, Accept) andalso not mtls_gate_configured() of
+        true ->
+            logger:warning("barrel_server: auth accepts mtls but tls has no "
+                           "verify_peer; disabling mtls auth"),
+            Accept -- [mtls];
+        false ->
+            Accept
+    end.
+
+mtls_gate_configured() ->
+    case application:get_env(barrel_server, tls, undefined) of
+        #{verify := verify_peer} -> true;
+        _ -> false
+    end.
 
 token_hashes(#{tokens := Tokens}) when is_list(Tokens) ->
     [crypto:hash(sha256, T) || T <- Tokens];

--- a/apps/barrel_server/src/barrel_server_http.erl
+++ b/apps/barrel_server/src/barrel_server_http.erl
@@ -904,8 +904,16 @@ encode_embedding_field(Doc) ->
 err_bin(Atom) when is_atom(Atom) -> atom_to_binary(Atom, utf8);
 err_bin(Other) -> iolist_to_binary(io_lib:format("~p", [Other])).
 
+-define(MAX_SEARCH_K, 10000).
+
 search_opts(Body) ->
-    K = maps:get(<<"k">>, Body, 10),
+    %% Clamp k so a request cannot ask the backend to build an unbounded
+    %% top-k result set.
+    K0 = maps:get(<<"k">>, Body, 10),
+    K = case is_integer(K0) andalso K0 > 0 of
+        true -> min(K0, ?MAX_SEARCH_K);
+        false -> 10
+    end,
     #{k => K}.
 
 search_reply({ok, Hits}) when is_list(Hits) ->

--- a/apps/barrel_server/src/barrel_server_sync.erl
+++ b/apps/barrel_server/src/barrel_server_sync.erl
@@ -331,9 +331,20 @@ put_att(Req) ->
     end).
 
 att_write_opts(Req) ->
-    Opts0 = case livery_req:header(?DIGEST_HEADER, Req, undefined) of
+    %% Bind the body to the SIGNED content hash. x-barrel-content-sha256 is
+    %% covered by the request signature (and equals the attachment digest on
+    %% a signed upload); x-barrel-digest alone is unsigned, so an on-path
+    %% attacker could rewrite it to match a forged body. Dropping or forging
+    %% the signed header breaks the signature, so the x-barrel-digest
+    %% fallback only applies to unsigned (bearer) requests.
+    Digest = case livery_req:header(<<"x-barrel-content-sha256">>, Req,
+                                    undefined) of
+        undefined -> livery_req:header(?DIGEST_HEADER, Req, undefined);
+        Signed -> Signed
+    end,
+    Opts0 = case Digest of
         undefined -> #{};
-        Digest -> #{expected_digest => Digest}
+        _ -> #{expected_digest => Digest}
     end,
     case livery_req:header(?ORIGIN_HEADER, Req, undefined) of
         undefined ->


### PR DESCRIPTION
A signed attachment upload only enforced the unsigned `x-barrel-digest` header. Since signed auth is usable over cleartext H1 by design, an on-path attacker could swap the body and rewrite that header (or drop it) while the signature over `x-barrel-content-sha256` still verified, forging attachment content. The writer now binds the body to the signed hash; dropping or forging it breaks the signature, so the old header only applies to unsigned requests.

mTLS auth trusted that any TLS connection carried a verified client cert, so `accept => [mtls]` on a listener without `verify_peer` authenticated certless clients. mtls is now dropped from the accepted set unless the tls config gates on it.

A replication peer's `changes` wire filter could supply a catastrophic-backtracking regex or a deeply nested and/or/not to pin a scheduler; regex matching is now bounded by a match limit and filter nesting is capped. Search `k` is clamped so a request cannot ask for an unbounded top-k.

The signed canonical still omits the query string (att_changes since/limit ride unsigned); binding it needs a lockstep canonical-format change and will come separately.