### PR TITLE
fail fast on reranker startup and bound the embed venv commands

### DIFF
--- a/apps/barrel_embed/src/barrel_embed_venv.erl
+++ b/apps/barrel_embed/src/barrel_embed_venv.erl
@@ -244,7 +244,10 @@ pip_install(VenvPath, Packages) ->
     Pip = filename:join(venv_bin_dir(VenvPath), "pip"),
     PackageStr = string:join(Packages, " "),
     Cmd = Pip ++ " install " ++ PackageStr,
-    case run_cmd(Cmd) of
+    %% Installing torch/sentence-transformers routinely exceeds the 60s
+    %% default; use a multi-minute budget so pip is not killed mid-install
+    %% (leaving the venv missing the package).
+    case run_cmd(Cmd, 600000) of
         {ok, _} -> ok;
         {error, _} = Error -> Error
     end.
@@ -281,11 +284,13 @@ collect_output(Port, Acc, Timeout) ->
 remove_dir(Dir) ->
     case filelib:is_dir(Dir) of
         true ->
-            case os:type() of
+            %% Use a port with a timeout, not os:cmd, so a stalled mount
+            %% cannot block the caller forever.
+            _ = case os:type() of
                 {win32, _} ->
-                    os:cmd("rmdir /s /q \"" ++ Dir ++ "\"");
+                    run_cmd("rmdir /s /q \"" ++ Dir ++ "\"", 60000);
                 _ ->
-                    os:cmd("rm -rf \"" ++ Dir ++ "\"")
+                    run_cmd("rm -rf \"" ++ Dir ++ "\"", 60000)
             end,
             ok;
         false ->

--- a/apps/barrel_rerank/src/barrel_rerank.erl
+++ b/apps/barrel_rerank/src/barrel_rerank.erl
@@ -195,7 +195,12 @@ init(Config) ->
                                     #{<<"ok">> := false, <<"error">> := Err} ->
                                         port_close(Port),
                                         {stop, {python_error, Err}}
-                                end
+                                end;
+                            {Port, {exit_status, Status}} ->
+                                %% Python died at startup (import error, OOM,
+                                %% failed model download): fail fast instead
+                                %% of blocking the full timeout.
+                                {stop, {port_exited, Status}}
                         after Timeout ->
                             port_close(Port),
                             {stop, timeout}


### PR DESCRIPTION
The reranker's startup handshake had no clause for the Python process exiting, so an import error, OOM, or failed model download at boot left the exit-status message unmatched and hung the caller for the full two-minute timeout. It now stops as soon as the port reports an exit status.

Installing the embedding venv used a 60s command timeout that a torch/sentence-transformers install routinely blows past, killing pip and leaving the venv missing packages; it now gets a multi-minute budget. Directory removal runs under a bounded port instead of an unbounded os:cmd so a stalled mount cannot block forever.