### PR TITLE
retry the barrel-lite browser smoke test on CI

### DIFF
--- a/clients/barrel-lite/playwright.config.ts
+++ b/clients/barrel-lite/playwright.config.ts
@@ -8,6 +8,8 @@ export default defineConfig({
   timeout: 60_000,
   fullyParallel: false,
   workers: 1,
+  // Browser E2E against a live server: retry a transient network flake on CI.
+  retries: process.env.CI ? 2 : 0,
   use: {
     baseURL: `http://127.0.0.1:${STATIC_PORT}`,
   },


### PR DESCRIPTION
The Playwright browser smoke suite drives a real chromium against a booted barrel_server, so it hits transient "Failed to fetch" network blips that fail a run at random (it failed on several unrelated merges and passed on others with no code change). Retry twice on CI, the standard mitigation for a live-server browser E2E. Unit tests and the sync engine's own error-retry loop are unchanged.