### PR TITLE
let a vector store be opened under a supervisor, not linked to the caller

### DIFF
--- a/apps/barrel/src/barrel.erl
+++ b/apps/barrel/src/barrel.erl
@@ -186,7 +186,8 @@ open_plain(DbBin, Opts) ->
         {ok, _DbPid} ->
             case vec_crypto_config(DbBin, EncSpec, VecConfig0) of
                 {ok, VecConfig} ->
-                    case barrel_vectordb:start_link(VecConfig#{name => DbBin}) of
+                    case start_vstore(VecConfig#{name => DbBin},
+                                      maps:get(store_supervised, Opts, false)) of
                         {ok, _StorePid} ->
                             {ok, with_encryption(#{name => DbBin,
                                                    docdb => DbBin,
@@ -234,7 +235,9 @@ do_open_record(DbBin, Opts, Policy) ->
                         {ok, VecConfig1} ->
                             do_open_record_stores(DbBin, Policy, Dim,
                                                   VecConfig0, VecConfig1,
-                                                  EncSpec);
+                                                  EncSpec,
+                                                  maps:get(store_supervised,
+                                                           Opts, false));
                         {error, _} = CErr ->
                             _ = barrel_docdb:close_db(DbBin),
                             CErr
@@ -247,7 +250,7 @@ do_open_record(DbBin, Opts, Policy) ->
     end.
 
 do_open_record_stores(DbBin, Policy, Dim, VecConfig0, VecConfig1,
-                      EncSpec) ->
+                      EncSpec, Supervised) ->
     case init_embed(Policy, Dim) of
         {ok, EmbedState} ->
             VecConfig = VecConfig1#{
@@ -260,7 +263,7 @@ do_open_record_stores(DbBin, Policy, Dim, VecConfig0, VecConfig1,
                 docstore => {barrel_record_docstore,
                              #{db => DbBin, policy => Policy}}
             },
-            case barrel_vectordb:start_link(VecConfig) of
+            case start_vstore(VecConfig, Supervised) of
                 {ok, _StorePid} ->
                     case start_indexer(DbBin, Policy,
                                        EmbedState, Dim) of
@@ -920,6 +923,13 @@ ensure_docdb(DbBin, DocOpts) ->
         {error, _} ->
             barrel_docdb:create_db(DbBin, DocOpts)
     end.
+
+%% Start the vector store either linked to the caller (default: the caller
+%% owns the store's life) or under barrel_vectordb_store_sup (when the
+%% caller must not be the store's parent, e.g. a barrel_dbs open worker).
+%% Both leave the docdb server supervised as usual.
+start_vstore(Config, true) -> barrel_vectordb:start_supervised(Config);
+start_vstore(Config, false) -> barrel_vectordb:start_link(Config).
 
 put_encryption(DocOpts, disabled) -> DocOpts;
 put_encryption(DocOpts, Spec) -> DocOpts#{encryption => Spec}.

--- a/apps/barrel/test/barrel_SUITE.erl
+++ b/apps/barrel/test/barrel_SUITE.erl
@@ -20,7 +20,8 @@
     t_vector_batch/1,
     t_changes/1,
     t_delete_db/1,
-    t_binary_names/1
+    t_binary_names/1,
+    t_supervised_store_survives_opener/1
 ]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -31,7 +32,7 @@
 all() ->
     [t_doc_crud, t_batch_docs, t_attachments, t_attachment_stream,
      t_vectors, t_vector_batch, t_changes, t_delete_db,
-     t_binary_names].
+     t_binary_names, t_supervised_store_survives_opener].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(barrel_docdb),
@@ -256,4 +257,27 @@ t_binary_names(Config) ->
     %% deterministic no-atom-leak proof for the whole facade path
     ?assertError(badarg, binary_to_existing_atom(Name, utf8)),
     ?assertError(badarg, binary_to_existing_atom(Branch, utf8)),
+    ok.
+
+%% A store opened `store_supervised' is parented to the store supervisor,
+%% so it outlives the process that opened it (a `start_link' store would
+%% die with its opener). This is what lets a manager open on a worker.
+t_supervised_store_survives_opener(Config) ->
+    Priv = ?config(priv_dir, Config),
+    VPath = filename:join(Priv, "sup_survives_vec"),
+    Name = <<"sup_survives_db">>,
+    VCfg = #{dimension => ?DIM, db_path => VPath, bm25_backend => memory},
+    Parent = self(),
+    Opener = spawn(fun() ->
+        {ok, _Db} = barrel:open(Name, #{vectordb => VCfg,
+                                        store_supervised => true}),
+        Parent ! opened
+    end),
+    receive opened -> ok after 20000 -> ct:fail(open_timeout) end,
+    timer:sleep(200),
+    ?assertNot(is_process_alive(Opener)),
+    ?assertNotEqual(undefined,
+                    barrel_vectordb_registry:whereis_name({vstore, Name})),
+    ?assert(is_pid(persistent_term:get({barrel_db, Name}, undefined))),
+    ok = barrel:close(#{name => Name, docdb => Name, vstore => Name}),
     ok.

--- a/apps/barrel_vectordb/src/barrel_vectordb.erl
+++ b/apps/barrel_vectordb/src/barrel_vectordb.erl
@@ -79,6 +79,7 @@
 %% API - Lifecycle
 -export([
     start_link/1,
+    start_supervised/1,
     stop/1
 ]).
 
@@ -266,6 +267,19 @@ start_link(Config) ->
         dimension => Dimension
     }, maps:without([name, dimensions, path], Config)),
     barrel_vectordb_server:start_link(Name, StoreConfig).
+
+%% @doc Start a store under {@link barrel_vectordb_store_sup} (the store's
+%% parent is the supervisor, not the caller), reusing a store already
+%% running for the same name. Use this to open a store on behalf of a
+%% long-lived owner that must not be the store's parent; `start_link/1'
+%% (caller-linked) stays the default for callers that own the store's life.
+-spec start_supervised(store_config()) -> {ok, pid()} | {error, term()}.
+start_supervised(Config) ->
+    case barrel_vectordb_store_sup:start_store(Config) of
+        {ok, Pid} -> {ok, Pid};
+        {error, {already_started, Pid}} -> {ok, Pid};
+        {error, _} = Err -> Err
+    end.
 
 %% @doc Destroy a store: close every handle (RocksDB, index, disk
 %% BM25) and remove the storage directory. The store stops.

--- a/apps/barrel_vectordb/src/barrel_vectordb_store_sup.erl
+++ b/apps/barrel_vectordb/src/barrel_vectordb_store_sup.erl
@@ -1,0 +1,49 @@
+%%%-------------------------------------------------------------------
+%%% @doc Dynamic supervisor for vector store processes.
+%%%
+%%% Mirrors {@link barrel_db_sup} for the docdb side: stores start under a
+%%% simple_one_for_one supervisor (temporary children) instead of being
+%%% linked to the caller, so a composed database opened on behalf of a
+%%% manager is not tied to the transient process that opened it. The store
+%%% is found by name through {@link barrel_vectordb_registry}; a crash of a
+%%% temporary child is not auto-restarted, the owner reopens on next use
+%%% (same contract as the docdb server).
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_vectordb_store_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/0]).
+-export([start_store/1]).
+
+-export([init/1]).
+
+-define(SERVER, ?MODULE).
+
+%% @doc Start the store supervisor.
+-spec start_link() -> {ok, pid()} | {error, term()}.
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+%% @doc Start a vector store under the supervisor (parent is the
+%% supervisor, not the caller). `Config' is the {@link barrel_vectordb}
+%% store config, including `name'.
+-spec start_store(map()) -> {ok, pid()} | {error, term()}.
+start_store(Config) ->
+    supervisor:start_child(?SERVER, [Config]).
+
+-spec init([]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
+init([]) ->
+    SupFlags = #{strategy => simple_one_for_one,
+                 intensity => 5,
+                 period => 60},
+    %% start_link/1 extracts `name' from the config and start_links the
+    %% server; called from here it links the store to this supervisor.
+    Store = #{id => barrel_vectordb_store,
+              start => {barrel_vectordb, start_link, []},
+              restart => temporary,
+              shutdown => 5000,
+              type => worker,
+              modules => [barrel_vectordb_server]},
+    {ok, {SupFlags, [Store]}}.

--- a/apps/barrel_vectordb/src/barrel_vectordb_sup.erl
+++ b/apps/barrel_vectordb/src/barrel_vectordb_sup.erl
@@ -45,4 +45,11 @@ init([]) ->
         shutdown => 5000,
         type => worker
     },
-    {ok, {SupFlags, [Registry]}}.
+    StoreSup = #{
+        id => barrel_vectordb_store_sup,
+        start => {barrel_vectordb_store_sup, start_link, []},
+        restart => permanent,
+        shutdown => infinity,
+        type => supervisor
+    },
+    {ok, {SupFlags, [Registry, StoreSup]}}.


### PR DESCRIPTION
A composed database's docdb server already runs under a dynamic supervisor (`barrel_db_sup`), found by name, so it outlives whoever opened it. The vector store did not: `barrel:open` `start_link`s it to the caller, so it dies when the caller exits (`gen_batch_server` treats its starter as parent). That inconsistency is what blocks opening a database on behalf of a long-lived owner from a short-lived worker — the enabling piece for making `barrel_dbs` open off its message loop.

Adds a store supervisor mirroring `barrel_db_sup` and a `barrel:open` `store_supervised` option that parents the store to it (reusing a store already running for the name). The default stays caller-linked, so direct `barrel:open` callers keep their current owner-tied lifecycle. A regression test proves a `store_supervised` store outlives its opener.

Foundation for the `barrel_dbs` async-open PR.