### PR TITLE
bump versions and changelogs for the review-hardening round

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to the Barrel umbrella are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and each app
 is versioned independently under [Semantic Versioning](https://semver.org/).
 
+## [2026-07-18] Code-review hardening + non-blocking database opens
+
+A multi-dimension review (C NIFs, supervision, concurrency, resource leaks,
+security) drove a round of fixes across the umbrella: the vector NIFs bounds-check
+their inputs, replication no longer spins on a non-advancing source, compaction
+and sweeps run off the database writer loop, and the sync surface closes a
+signed-attachment forgery, an mTLS config gap, and a filter ReDoS. The database
+lifecycle manager now opens databases in a worker off its message loop, with
+request coalescing, so a cold or wedged open no longer blocks node-wide lifecycle
+calls; this rides on a new `barrel:open` `store_supervised` option that parents
+the vector store to a supervisor instead of the caller.
+
+| App | Version | Change |
+|-----|---------|--------|
+| barrel | 1.1.0 | non-blocking `barrel_dbs` opens (worker + coalescing); `barrel:open` `store_supervised` option; reopen no longer leaks the vector store |
+| barrel_docdb | 1.1.1 | replication no-progress guard + task lifecycle; compaction/retention/TTL off the writer loop; `fold_docs` honors `id_prefix`; wire-filter ReDoS bound; cursor snapshot handoff |
+| barrel_server | 1.2.1 | signed-attachment body binding; mTLS `verify_peer` gate; wire-filter ReDoS + search `k` clamp; live-query bridge opens off its loop |
+| barrel_vectordb | 2.2.0 | supervised store (`start_supervised`); batch-ADC NIF bounds checks; RocksDB batch/ETS/monitor cleanup |
+| barrel_faiss | 1.0.1 | `search` caps `k` and allocates inside the try; resource re-open on upgrade; strict metric atoms |
+| barrel_rerank | 1.0.1 | startup fails fast on a Python exit instead of hanging |
+| barrel_embed | 2.3.1 | venv pip/rm commands bounded so a torch install is not killed at 60s |
+
 ## [2026-07-17] Sync-wire auth hardening + multi-protocol serving
 
 `barrel_server` gains opt-in Ed25519 signed-request auth and an mTLS transport

--- a/apps/barrel/CHANGELOG.md
+++ b/apps/barrel/CHANGELOG.md
@@ -3,6 +3,23 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.0] - 2026-07-18
+
+### Added
+- `barrel:open` `store_supervised` option: parent the vector store to a
+  supervisor instead of linking it to the caller, so a store opened on behalf of
+  a long-lived owner outlives the process that opened it.
+
+### Changed
+- `barrel_dbs` opens databases in a short-lived worker off its message loop, so a
+  cold or wedged open no longer blocks every other ensure/close/list call
+  node-wide; concurrent opens of the same database coalesce onto one open, and
+  close/destroy/branch/pin defer while their target is mid-open.
+
+### Fixed
+- The docdb-crash reopen path stops the surviving vector store instead of leaking
+  its RocksDB handles.
+
 ## [1.0.1] - 2026-07-11
 
 ### Fixed

--- a/apps/barrel/src/barrel.app.src
+++ b/apps/barrel/src/barrel.app.src
@@ -1,6 +1,6 @@
 {application, barrel, [
     {description, "Barrel: the embeddable edge-AI database composing the document and vector layers"},
-    {vsn, "1.0.1"},
+    {vsn, "1.1.0"},
     {registered, [barrel_sup]},
     {mod, {barrel_app, []}},
     {applications, [

--- a/apps/barrel_docdb/CHANGELOG.md
+++ b/apps/barrel_docdb/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-07-18
+
+### Fixed
+- Replication drain stops with `{error, no_progress}` when a source returns a
+  non-empty batch without advancing its sequence, instead of spinning at 100% CPU.
+- Replication tasks are linked to the trap-exit manager (no orphan doubling on a
+  manager restart), and per-batch checkpointing runs off the manager loop.
+- Compaction, retention and TTL sweeps run in a worker off the writer loop, so a
+  long sweep no longer makes concurrent writes time out.
+- `fold_docs` honors `id_prefix` (it was scanning the whole database) and reads
+  under a caller-side snapshot instead of blocking the writer.
+- Replication-changes wire-filter regex is bounded by a match limit and filter
+  nesting is capped (ReDoS); a resumed chunked query hands its snapshot to the
+  successor cursor.
+
 ## [1.1.0] - 2026-07-17
 
 ### Added

--- a/apps/barrel_docdb/src/barrel_docdb.app.src
+++ b/apps/barrel_docdb/src/barrel_docdb.app.src
@@ -1,6 +1,6 @@
 {application, barrel_docdb, [
     {description, "Erlang document database with MVCC, queries, and replication"},
-    {vsn, "1.1.0"},
+    {vsn, "1.1.1"},
     {registered, [barrel_docdb_sup]},
     {mod, {barrel_docdb_app, []}},
     {applications, [

--- a/apps/barrel_embed/CHANGELOG.md
+++ b/apps/barrel_embed/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.3.1] - 2026-07-18
+
+### Fixed
+- The managed-venv pip install uses a multi-minute timeout, so a
+  torch/sentence-transformers install is no longer killed at 60s (which left the
+  venv missing packages); directory removal runs under a bounded port instead of
+  an unbounded `os:cmd`.
+
 ## [2.3.0] - 2026-07-08
 
 Coordinated umbrella release.

--- a/apps/barrel_embed/src/barrel_embed.app.src
+++ b/apps/barrel_embed/src/barrel_embed.app.src
@@ -1,6 +1,6 @@
 {application, barrel_embed,
  [{description, "Lightweight embedding generation for Erlang"},
-  {vsn, "2.3.0"},
+  {vsn, "2.3.1"},
   {registered, []},
   {mod, {barrel_embed_app, []}},
   {applications,

--- a/apps/barrel_faiss/CHANGELOG.md
+++ b/apps/barrel_faiss/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2026-07-18
+
+### Fixed
+- `search` caps `k` and allocates its result buffers inside the try, so an
+  oversized `k` returns an error instead of aborting the VM across the C ABI.
+- `on_upgrade` re-opens the index resource type; an unknown metric atom is
+  rejected instead of defaulting to L2; `close` runs on a dirty scheduler.
+
 ## [1.0.0] - 2026-07-10
 
 Coordinated umbrella release. See the umbrella [CHANGELOG](../../CHANGELOG.md).

--- a/apps/barrel_faiss/src/barrel_faiss.app.src
+++ b/apps/barrel_faiss/src/barrel_faiss.app.src
@@ -1,6 +1,6 @@
 {application, barrel_faiss,
  [{description, "Erlang NIF bindings for FAISS vector similarity search"},
-  {vsn, "1.0.0"},
+  {vsn, "1.0.1"},
   {registered, []},
   {applications, [kernel, stdlib]},
   {env, []},

--- a/apps/barrel_rerank/CHANGELOG.md
+++ b/apps/barrel_rerank/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.1 (2026-07-18)
+
+- Fail fast on a Python startup exit instead of hanging the full timeout: the
+  init handshake now handles the port's `exit_status`.
+
 ## 1.0.0 (2026-07-10)
 
 Coordinated umbrella release. Added tests for the sidecar response decoder.

--- a/apps/barrel_rerank/src/barrel_rerank.app.src
+++ b/apps/barrel_rerank/src/barrel_rerank.app.src
@@ -1,6 +1,6 @@
 {application, barrel_rerank, [
     {description, "Cross-encoder reranking for Erlang"},
-    {vsn, "1.0.0"},
+    {vsn, "1.0.1"},
     {registered, []},
     {mod, {barrel_rerank_app, []}},
     {applications, [kernel, stdlib]},

--- a/apps/barrel_server/CHANGELOG.md
+++ b/apps/barrel_server/CHANGELOG.md
@@ -3,6 +3,20 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.1] - 2026-07-18
+
+### Fixed
+- A signed attachment upload binds the body to the signed
+  `x-barrel-content-sha256` header (not the unsigned `x-barrel-digest`), so an
+  on-path body swap on a signed upload is rejected.
+- mTLS is dropped from the accepted auth set unless the listener sets
+  `verify_peer`, so a certless client is never authenticated by a config gap.
+- The replication changes wire filter bounds regex work and nesting depth
+  (ReDoS), and vector search `k` is clamped.
+- The live-query bridge opens databases in the caller, so a cold open no longer
+  blocks other subscribe/snapshot/unsubscribe calls; a snapshot reuses a cached
+  id-sorted view instead of re-sorting in the loop.
+
 ## [1.2.0] - 2026-07-17
 
 ### Added

--- a/apps/barrel_server/src/barrel_server.app.src
+++ b/apps/barrel_server/src/barrel_server.app.src
@@ -1,6 +1,6 @@
 {application, barrel_server, [
     {description, "Multi-protocol server for the barrel edge database (REST/JSON over livery)"},
-    {vsn, "1.2.0"},
+    {vsn, "1.2.1"},
     {registered, [barrel_server_sup]},
     {mod, {barrel_server_app, []}},
     {applications, [

--- a/apps/barrel_vectordb/CHANGELOG.md
+++ b/apps/barrel_vectordb/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2026-07-18
+
+### Added
+- `barrel_vectordb:start_supervised/1` and `barrel_vectordb_store_sup`: start a
+  store parented to a supervisor (not the caller), reusing a store already
+  running for the name, so it outlives the process that opened it.
+
+### Fixed
+- The batch subspace-ADC NIF bounds-checks the tables and code binaries before
+  reading, so a truncated or mismatched input is rejected instead of read out of
+  bounds; radii are read through an aligned buffer; the list conversions run on a
+  dirty scheduler; non-finite distances map to a defined value.
+- The RocksDB write batch is released on every add/delete path; the name registry
+  drops a monitor on unregister; a failed BM25 index open deletes the ETS tables
+  it created.
+
 ## [2.1.2] - 2026-07-11
 
 ### Fixed

--- a/apps/barrel_vectordb/src/barrel_vectordb.app.src
+++ b/apps/barrel_vectordb/src/barrel_vectordb.app.src
@@ -1,6 +1,6 @@
 {application, barrel_vectordb, [
     {description, "Embedded Erlang vector database with pluggable backends (HNSW, FAISS) and RocksDB for semantic search"},
-    {vsn, "2.1.2"},
+    {vsn, "2.2.0"},
     {registered, [barrel_vectordb_sup]},
     {mod, {barrel_vectordb_app, []}},
     {applications, [


### PR DESCRIPTION
Versions and changelogs for the apps touched by the code-review fixes and the non-blocking database-open work.

| App | | |
|---|---|---|
| barrel | 1.0.1 → 1.1.0 | `store_supervised` open option + async `barrel_dbs` |
| barrel_docdb | 1.1.0 → 1.1.1 | replication / writer-loop / fold_docs / ReDoS fixes |
| barrel_server | 1.2.0 → 1.2.1 | attachment / mTLS / ReDoS / search-k + live-bridge |
| barrel_vectordb | 2.1.2 → 2.2.0 | `start_supervised` + NIF / resource fixes |
| barrel_faiss | 1.0.0 → 1.0.1 | search-k / upgrade / metric fixes |
| barrel_rerank | 1.0.0 → 1.0.1 | startup fails fast on a Python exit |
| barrel_embed | 2.3.0 → 2.3.1 | venv command timeouts |

Minor bumps where a public API was added (`barrel:open store_supervised`, `barrel_vectordb:start_supervised`), patch elsewhere. Includes a coordinated entry in the umbrella changelog.