### PR TITLE
replace deprecated prefix-catch with try/catch

### DIFF
--- a/apps/barrel_embed/src/barrel_embed_port_server.erl
+++ b/apps/barrel_embed/src/barrel_embed_port_server.erl
@@ -161,7 +161,7 @@ handle_info(_Info, State) ->
     {noreply, State}.
 
 terminate(_Reason, #state{port = Port}) ->
-    catch port_close(Port),
+    _ = try port_close(Port) catch _:_ -> ok end,
     ok.
 
 %%====================================================================

--- a/apps/barrel_rerank/src/barrel_rerank.erl
+++ b/apps/barrel_rerank/src/barrel_rerank.erl
@@ -248,7 +248,7 @@ handle_info(_Msg, State) ->
     {noreply, State}.
 
 terminate(_Reason, #state{port = Port}) ->
-    catch port_close(Port),
+    _ = try port_close(Port) catch _:_ -> ok end,
     ok.
 
 %%====================================================================

--- a/apps/barrel_rerank/src/barrel_rerank_venv.erl
+++ b/apps/barrel_rerank/src/barrel_rerank_venv.erl
@@ -219,6 +219,6 @@ collect_output(Port, Acc) ->
             Output = iolist_to_binary(lists:reverse(Acc)),
             {error, {exit_code, Code, Output}}
     after 600000 ->
-        catch port_close(Port),
+        _ = try port_close(Port) catch _:_ -> ok end,
         {error, timeout}
     end.

--- a/apps/barrel_vectordb/src/barrel_vectordb_server.erl
+++ b/apps/barrel_vectordb/src/barrel_vectordb_server.erl
@@ -927,7 +927,7 @@ terminate(_Reason, #state{db = Db, index = Index, index_module = Mod, cf_hnsw = 
     %% The disk BM25 backend holds file + nested RocksDB handles
     _ = case {BM25Backend, BM25} of
         {disk, Idx} when Idx =/= undefined ->
-            catch barrel_vectordb_bm25_disk:close(Idx);
+            try barrel_vectordb_bm25_disk:close(Idx) catch _:_ -> ok end;
         _ ->
             ok
     end,


### PR DESCRIPTION
The prefix `catch Expr` operator warns as deprecated on recent OTP. The port-close and BM25-index cleanups in the release apps (`barrel_embed`, `barrel_rerank`, `barrel_vectordb`) now use `try ... catch _:_ -> ok end` so the build is clean ahead of the Hex releases. No behavior change.