### PR TITLE
feat: S3-compatible attachment backend (barrel_att_s3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ name: CI
 #               catches hidden cross-app dependencies before publishing
 #   - faiss:    optional FAISS backend leg (needs the FAISS C++ library)
 #   - server:   network server leg (pulls livery + transports)
+#   - s3:       optional S3 attachment-backend leg (real MinIO + Garage)
 #   - barrel-lite: TypeScript client (typecheck, build, unit tests)
 # Dev target is OTP 29; CI pins OTP 28 (image guaranteed, code builds on both).
 
@@ -119,6 +120,39 @@ jobs:
       # the FAISS C++ library is installed above, so run the suite (not just compile)
       - run: rebar3 as faiss ct --suite apps/barrel_faiss/test/barrel_faiss_SUITE
 
+  s3:
+    name: S3 attachment backend
+    # Needs real docker (MinIO + Garage via docker compose), which the
+    # erlang:28 container the other legs use does not expose -- same reason
+    # e2e-replication below runs directly on the runner instead of in a
+    # container. rebar3 comes from setup-beam rather than the container
+    # image for the same reason.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: '28'
+          rebar3-version: '3.25.0'
+      - name: System dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake build-essential libssl-dev zlib1g-dev \
+            libsnappy-dev liblz4-dev libzstd-dev python3 python3-venv
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/rebar3
+          key: rebar3-s3-${{ hashFiles('rebar.lock') }}
+      # Prints GARAGE_S3_TEST_ACCESS_KEY/_SECRET_KEY/_BUCKET as `export`
+      # lines on success; the garage group in barrel_att_s3_SUITE skips
+      # cleanly without them, so this must run before the suite, not after.
+      - name: Provision minio + garage
+        run: test/e2e/attachments-s3-setup.sh | sed 's/^export //' >> "$GITHUB_ENV"
+      - run: rebar3 as s3 ct --suite apps/barrel_att_s3/test/barrel_att_s3_SUITE
+      - name: Tear down minio + garage
+        if: always()
+        run: docker compose -f test/e2e/docker-compose.attachments-s3.yml down -v --remove-orphans
+
   barrel-lite:
     name: barrel-lite (TS client)
     runs-on: ubuntu-latest
@@ -209,3 +243,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: Replication across two peers
         run: bash test/e2e/replication.sh
+
+  e2e-attachments-s3:
+    name: E2E S3 attachment backend (MinIO + Garage + two peers)
+    # Opt-in: needs a Docker-capable runner and builds the server image.
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: S3 attachment backend against real MinIO and Garage
+        run: bash test/e2e/attachments-s3.sh

--- a/apps/barrel/src/barrel.erl
+++ b/apps/barrel/src/barrel.erl
@@ -60,6 +60,7 @@
 %% Attachments / blobs (barrel_docdb; backend pluggable per database)
 -export([
     put_attachment/4,
+    put_attachment/5,
     get_attachment/3,
     delete_attachment/3,
     list_attachments/2,
@@ -644,6 +645,13 @@ compile_bql(Bql, Opts) ->
 -spec put_attachment(db(), binary(), binary(), binary()) -> {ok, map()} | {error, term()}.
 put_attachment(#{docdb := DbBin}, DocId, AttName, Data) ->
     barrel_docdb:put_attachment(DbBin, DocId, AttName, Data).
+
+%% @doc Store a document attachment with options (create_only,
+%% expected_etag, content_type, ...; see barrel_docdb:put_attachment/5).
+-spec put_attachment(db(), binary(), binary(), binary(), map()) ->
+    {ok, map()} | {ok, ignored} | {error, term()}.
+put_attachment(#{docdb := DbBin}, DocId, AttName, Data, Opts) ->
+    barrel_docdb:put_attachment(DbBin, DocId, AttName, Data, Opts).
 
 %% @doc Fetch a document attachment.
 -spec get_attachment(db(), binary(), binary()) -> {ok, binary()} | {error, term()}.

--- a/apps/barrel_att_s3/LICENSE
+++ b/apps/barrel_att_s3/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2024 Benoit Chesneau
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/apps/barrel_att_s3/README.md
+++ b/apps/barrel_att_s3/README.md
@@ -1,0 +1,41 @@
+# barrel_att_s3
+
+S3-compatible attachment storage backend for `barrel_docdb`. Stores
+attachment bytes in an S3 bucket (AWS S3, MinIO, Garage) instead of the
+embedded RocksDB instance `barrel_docdb` uses by default.
+
+[Documentation](https://barrel-db.eu/docs/lib/att-s3/) |
+[HexDocs](https://hexdocs.pm/barrel_att_s3) |
+[Repository](https://github.com/barrel-db/barrel)
+
+Kept out of the default (embeddable) `barrel_docdb` build -- it pulls
+`livery_s3` (and `livery`), so it opts in via its own `s3` rebar3 profile.
+
+## Use
+
+```erlang
+{ok, _} = barrel_docdb:create_db(<<"mydb">>, #{
+    att_opts => #{
+        backend => s3,
+        s3 => #{
+            bucket => <<"my-bucket">>,
+            endpoint => <<"https://s3.eu-west-1.amazonaws.com">>,
+            region => <<"eu-west-1">>,
+            access_key_id => <<"...">>,
+            secret_access_key => <<"...">>
+        }
+    }
+}),
+
+{ok, _Info} = barrel_docdb:put_attachment(<<"mydb">>, <<"doc1">>,
+    <<"greeting.txt">>, <<"Hello, World!">>).
+```
+
+Everything else -- `get_attachment/4`, `delete_attachment/4`, streaming --
+works exactly as it does with the default backend; the backend choice is
+entirely in `att_opts`.
+
+## Documentation
+
+- [Getting started](docs/getting-started.md) -- config shape, credentials, `part_size`.
+- [Limitations](docs/limitations.md) -- what M1 doesn't do yet, and the store-compatibility table.

--- a/apps/barrel_att_s3/docs/getting-started.md
+++ b/apps/barrel_att_s3/docs/getting-started.md
@@ -1,0 +1,166 @@
+# Getting started
+
+`barrel_att_s3` stores a database's attachment bytes in an S3-compatible
+bucket instead of `barrel_docdb`'s default embedded RocksDB instance. Use it
+when attachments should live in object storage -- AWS S3, MinIO, or Garage --
+rather than on the same disk as the database. This page takes you from an
+empty bucket to your first attachment.
+
+## Requirements
+
+Build the umbrella (or `barrel_docdb`) with the `s3` rebar3 profile, which
+adds `barrel_att_s3` and its dependency on `livery_s3`:
+
+```console
+$ rebar3 as s3 compile
+```
+
+A plain `rebar3 compile` never touches this app or `livery_s3` -- they stay
+out of the default (embeddable) build.
+
+## Point a database at S3
+
+Pass `att_opts` when creating the database. `backend => s3` selects this
+module; everything under `s3` except `bucket` and `part_size` passes
+straight to `livery_s3:new/1`, so any option that client accepts (custom
+`endpoint`, `region`, credentials, path-style addressing, and so on) works
+here too.
+
+```erlang
+{ok, _} = barrel_docdb:create_db(<<"mydb">>, #{
+    att_opts => #{
+        backend => s3,
+        s3 => #{
+            bucket => <<"my-bucket">>,
+            endpoint => <<"https://s3.eu-west-1.amazonaws.com">>,
+            region => <<"eu-west-1">>,
+            access_key_id => <<"AKIA...">>,
+            secret_access_key => <<"...">>
+        }
+    }
+}).
+```
+
+`bucket` is required; `open/2` returns `{error, missing_bucket}` without it.
+The bucket itself is not created for you -- create it before pointing a
+database at it.
+
+Or over HTTP: `PUT /db/:name` accepts the same shape as a JSON body.
+
+```console
+$ curl -X PUT http://localhost:8080/db/mydb \
+    -H 'content-type: application/json' \
+    -d '{
+      "att_opts": {
+        "backend": "s3",
+        "s3": {
+          "bucket": "my-bucket",
+          "endpoint": "https://s3.eu-west-1.amazonaws.com",
+          "region": "eu-west-1",
+          "access_key_id": "AKIA...",
+          "secret_access_key": "..."
+        }
+      }
+    }'
+```
+
+An empty body still works exactly as before, defaulting to the RocksDB
+backend. A bad `backend` value or an `s3` key that isn't a real
+`livery_s3`/`barrel_att_s3_store` option is a `400 bad_att_opts`, not a
+crash or a silent fallback to the default backend.
+
+## Use it
+
+Once the database exists, every attachment function on `barrel_docdb` works
+exactly as it does with the default backend -- the backend choice lives
+entirely in `att_opts`, set once at creation:
+
+```erlang
+{ok, Info} = barrel_docdb:put_attachment(<<"mydb">>, <<"doc1">>,
+    <<"greeting.txt">>, <<"Hello, World!">>),
+
+{ok, Data} = barrel_docdb:get_attachment(<<"mydb">>, <<"doc1">>,
+    <<"greeting.txt">>),
+
+ok = barrel_docdb:delete_attachment(<<"mydb">>, <<"doc1">>,
+    <<"greeting.txt">>).
+```
+
+Large attachments stream through `put_stream`/`write_chunk`/`finish_stream`
+under the hood (this is also the path every *replicated* attachment goes
+through) -- you don't call these directly through `barrel_docdb`'s API, but
+it's worth knowing: a stream buffers in memory and only starts a multipart
+upload once the buffer crosses `part_size` (default 8 MiB), so a small
+attachment costs one `PutObject` call, not three.
+
+## Tuning `part_size` for Garage
+
+If you're backing a database with Garage, set `part_size` to match your
+cluster's configured `block_size`. Garage's own documentation warns that
+multipart parts not aligned to `block_size` cause quadratic-complexity
+metadata overhead:
+
+```erlang
+s3 => #{
+    bucket => <<"my-bucket">>,
+    endpoint => <<"http://garage.internal:3900">>,
+    region => <<"garage">>,
+    access_key_id => <<"...">>,
+    secret_access_key => <<"...">>,
+    part_size => 8 * 1024 * 1024  %% match your garage.toml block_size
+}
+```
+
+AWS S3 and MinIO don't need this tuning; the default is fine.
+
+## Write-conflict detection (optional)
+
+Pass `create_only => true` or `expected_etag => Etag` to `put_attachment/5`
+to guard against a concurrent write to the same attachment:
+
+```erlang
+%% only succeeds if nothing exists at this key yet
+{ok, _} = barrel_docdb:put_attachment(<<"mydb">>, <<"doc1">>,
+    <<"note.txt">>, <<"first">>, #{create_only => true}),
+
+%% the same call again fails: something is already there
+{error, {conflict, CurrentInfo}} = barrel_docdb:put_attachment(<<"mydb">>,
+    <<"doc1">>, <<"note.txt">>, <<"second">>, #{create_only => true}).
+```
+
+`CurrentInfo` is what's actually stored now (digest, content type, length,
+etag), enough to decide whether to retry, surface the conflict, or force an
+overwrite by retrying without the option. Neither option is honored on every
+store -- see [Limitations](limitations.md) for which ones, and what happens
+on a store that can't.
+
+Or over HTTP: `If-None-Match: *` for `create_only`, `If-Match: <etag>` for
+`expected_etag`, on the attachment `PUT` route.
+
+```console
+$ curl -X PUT http://localhost:8080/db/mydb/doc/doc1/att/note.txt \
+    -H 'If-None-Match: *' -d 'first'
+# 201 -- nothing was there yet
+
+$ curl -X PUT http://localhost:8080/db/mydb/doc/doc1/att/note.txt \
+    -H 'If-None-Match: *' -d 'second'
+# 409 {"error":"conflict","current":{...}} -- something already is
+```
+
+A store that can't enforce this at all (Garage) fails the request
+immediately with `501 conditional_writes_unsupported`, the same way the
+Erlang API does -- not a hang, not a silent unprotected write.
+
+## Branching
+
+`barrel_docdb:branch_db/3` (and `POST /db/:db/_timeline/branch` over HTTP)
+works against an S3-backed database: the branch gets its own bucket prefix,
+independent of its parent from the moment it exists.
+
+```erlang
+{ok, _} = barrel_docdb:branch_db(<<"mydb">>, <<"mydb-branch">>, #{}).
+```
+
+Forking isn't O(1) the way it is for the default backend, though -- see
+[Limitations](limitations.md#branching-cost) for the cost and what a read
+looks like for an attachment the background copy hasn't reached yet.

--- a/apps/barrel_att_s3/docs/limitations.md
+++ b/apps/barrel_att_s3/docs/limitations.md
@@ -1,0 +1,127 @@
+# Limitations
+
+What this backend does not do yet, and the one behavior difference between
+S3-compatible stores you need to know before choosing one. Read this before
+putting it into production.
+
+## Branching cost
+
+`barrel_docdb:branch_db/3` works against an S3-backed database, but forking
+isn't O(1) the way it is for the default RocksDB backend (a hard-link
+checkpoint). S3 has no equivalent to a hard link, so a fork does a real
+server-side copy: one `CopyObject` call per attachment the parent has.
+
+That copy runs in the background, not inline in `branch_db/3` -- forking
+returns as soon as the (cheap, local) part is done, regardless of how many
+attachments the parent has. What's still catching up is the attachment
+*bytes*: reading one the copy hasn't reached yet returns
+`{error, {att_sync_pending, {DocId, AttName}}}` (HTTP 503) rather than
+blocking or returning stale data. A write on the branch is never blocked by
+this and is never overwritten by the catch-up copy once it lands.
+
+For a parent with many or large attachments, expect a freshly forked
+branch's attachments to become fully available over some real, non-zero
+window after `branch_db/3` returns -- not instantly, and not bounded by
+anything other than how fast the copy runs.
+
+## Deleting a database
+
+`barrel_docdb:delete_db/2` erases the bucket objects too, not just the local
+directory -- but only automatically if the database is open when you delete
+it. For a database that's already closed, pass the same `att_opts` you
+created it with (`delete_db(Name, #{att_opts => ...})`): nothing else can
+recover S3 credentials for a closed database, so without it the bucket
+objects are left behind while the local directory is still removed.
+
+Deleting an already-open database can still race a fork-copy sweep that's
+in flight for it (see "Branching cost" above): the delete's object listing
+is a one-time snapshot, and anything the sweep copies in after that
+snapshot is never revisited. Closing this fully needs a live-process
+registry to find and join an in-flight sweep for a given store, which is
+out of scope today -- avoid deleting a database while a fork of it is
+still catching up. This is narrower than it sounds: a freshly reopened
+closed database never hits it (`delete_db` skips spawning a sweep it
+would only abandon), so the gap is limited to a database still open from
+the branch operation itself.
+
+## HTTP surface
+
+Both backend selection and write-conflict detection work over HTTP now --
+see [getting started](getting-started.md). Two caveats worth knowing:
+
+- **Re-`PUT`-ing an already-open database with different `att_opts` is a
+  silent no-op.** `barrel_dbs`'s in-memory fast path returns the
+  already-open handle without even looking at the new Opts. It only takes
+  effect the next time the database is cold-opened (idle-swept or after a
+  restart), with nothing validating the new config against what the
+  database actually holds -- pointing an existing S3-backed database at a
+  different bucket this way is a real footgun, not something this app
+  protects you from. This is a property of `barrel_dbs:ensure/2` itself,
+  not specific to `att_opts` or to going through HTTP.
+- **`If-None-Match`/`If-Match` are accepted, but only enforced against an
+  S3-backed database.** The default RocksDB (blob) backend's `put/6` never
+  inspects `create_only`/`expected_etag` at all, so sending these headers
+  against a non-S3-backed database is silently ignored -- same as the
+  Erlang API already was; see "Concurrent writers to the same key" below.
+
+## Abandoned multipart uploads
+
+A crash between starting and completing a multipart upload leaves orphaned
+parts that S3 keeps billing until aborted or expired. `abort_stream/1`
+covers an in-process failure, but not a hard crash mid-upload. Set a bucket
+lifecycle rule to clean these up automatically:
+
+```json
+{
+  "Rules": [{
+    "ID": "abort-incomplete-multipart-uploads",
+    "Status": "Enabled",
+    "AbortIncompleteMultipartUpload": { "DaysAfterInitiation": 1 }
+  }]
+}
+```
+
+## Concurrent writers to the same key
+
+Two uncoordinated processes writing the same attachment key -- the S3
+equivalent of two RocksDB processes pointed at one data directory, which
+RocksDB's file lock prevents structurally and S3 has no equivalent for --
+can clobber each other. `create_only`/`expected_etag` (see [getting
+started](getting-started.md)) turn this from a silent-corruption risk into
+a loud `{error, {conflict, _}}` for a caller that opts in, but only on a
+store that can actually enforce them -- see the table below.
+
+Ordinary replication is not this risk in the usual case: `barrel_rep` always
+checks a target's actual stored digest via `get_info/4` before transferring
+anything, so two S3-backed databases replicating into the same bucket don't
+redundantly transfer or corrupt each other's data. Replication's LWW
+convergence is independent of `create_only`/`expected_etag` entirely --
+those are opt-in, S3-level conditional writes you pass explicitly;
+replication instead compares each write's HLC origin against the target's
+own local feed (`barrel_att_feed:check/6`) before writing, and that S3 write
+is always a plain, unconditional `PutObject`/`CopyObject` once the check
+passes, on every store including Garage. The one residual gap: if two
+replication streams push to the *same* target attachment at the same
+instant, both can pass the local LWW check before either has written, and
+whichever S3 write physically lands last wins -- not necessarily the one
+with the newer origin. Narrow, store-independent, and not solved further
+here (same class of check-then-act race accepted elsewhere in this design).
+
+## Store compatibility
+
+The one difference you need to know before choosing a store: whether it
+actually enforces the conditional writes `create_only`/`expected_etag`
+depend on. `open/2` runs a capability probe against the configured bucket
+and records the verified result -- a store that didn't verifiably enforce it
+gets `{error, conditional_writes_unsupported}` on every `create_only`/
+`expected_etag` call, rather than a silent, unprotected overwrite.
+
+| Store | Conditional writes (`create_only`/`expected_etag`) | Notes |
+|-------|------------------------------------------------------|-------|
+| AWS S3 | Supported (since 2024) | |
+| MinIO | Supported (since 2023) | |
+| Garage | **Not supported** | ["Structurally impossible to implement in Garage due to the lack of a consensus algorithm, which is one of Garage's core design choices which we cannot reconsider."](https://garagehq.deuxfleurs.fr/documentation/reference-manual/known-issues/) Not a bug, not planned. |
+
+If you need real protection against concurrent writers to the same
+attachment key, use AWS S3 or MinIO. On Garage, the one-writer-per-key
+discipline is a purely operational rule -- there is no backstop.

--- a/apps/barrel_att_s3/rebar.config
+++ b/apps/barrel_att_s3/rebar.config
@@ -1,0 +1,43 @@
+{erl_opts, [debug_info, warnings_as_errors]}.
+
+%% Sibling app (barrel_att_backend behaviour, barrel_keyspace) and the S3
+%% client. Kept in its own app, not a barrel_docdb dependency, so the default
+%% (embeddable) build never pulls in livery; opt in with `rebar3 as s3 compile`.
+%% mimerl is used directly (content-type inference, matching the RocksDB
+%% backend); livery is used directly for livery_client:read/2, the sanctioned
+%% way to drain a get_object stream => true reader; rocksdb is used directly
+%% for the local attachment-feed metadata store; hlc (barrel_hlc/barrel_att_feed)
+%% is used directly for the same feed's origin timestamps -- all four are
+%% also reachable transitively (via barrel_docdb, via livery_s3), but direct
+%% use gets a direct dependency.
+{deps, [
+    {barrel_docdb, "~> 1.1"},
+    {livery_s3, "~> 0.2.0"},
+    {livery, "~> 0.4.4"},
+    {mimerl, "1.5.0"},
+    {rocksdb, "3.1.2"},
+    {hlc, "3.0.4"}
+]}.
+
+{project_plugins, [rebar3_hex, rebar3_ex_doc]}.
+
+{eunit_opts, [verbose]}.
+{cover_enabled, true}.
+
+%% Library API: exports are consumed by barrel_att_store's dynamic dispatch,
+%% so do not enable exports_not_used (it would flag every public function).
+{xref_checks, [
+    undefined_function_calls,
+    undefined_functions,
+    locals_not_used
+]}.
+
+{dialyzer, [
+    {plt_extra_apps, [barrel_docdb, livery_s3, livery, mimerl, rocksdb, hlc]}
+]}.
+
+{profiles, [
+    {test, [{deps, [{meck, "1.2.0"}]}]}
+]}.
+
+{hex, [{doc, ex_doc}]}.

--- a/apps/barrel_att_s3/src/barrel_att_s3.app.src
+++ b/apps/barrel_att_s3/src/barrel_att_s3.app.src
@@ -1,0 +1,25 @@
+{application, barrel_att_s3, [
+    {description, "S3-compatible attachment storage backend for barrel_docdb"},
+    {vsn, "0.1.0"},
+    {registered, []},
+    {applications, [
+        kernel,
+        stdlib,
+        crypto,
+        rocksdb,
+        hlc,
+        %% barrel_hlc:new_hlc/0 (feed origin timestamps) calls the
+        %% barrel_hlc_clock process, which barrel_docdb's own supervisor
+        %% starts (hlc the library app has none of its own) -- in real use
+        %% barrel_att_s3 is only ever reached from inside an already-running
+        %% barrel_docdb (barrel_db_server opens it), so this is already
+        %% true in practice; declared for anything that loads this app in
+        %% isolation.
+        barrel_docdb,
+        livery_s3
+    ]},
+    {env, []},
+    {modules, []},
+    {licenses, ["Apache-2.0"]},
+    {links, [{"GitHub", "https://github.com/barrel-db/barrel"}]}
+]}.

--- a/apps/barrel_att_s3/src/barrel_att_s3_store.erl
+++ b/apps/barrel_att_s3/src/barrel_att_s3_store.erl
@@ -1,0 +1,1254 @@
+%%%-------------------------------------------------------------------
+%%% @doc S3-compatible attachment storage backend.
+%%%
+%%% Implements `barrel_att_backend' against an S3-compatible object store via
+%%% `livery_s3', including the attachment change feed (`att_changes/4',
+%%% `att_floor/2', `sweep_att_feed/3') on top of the local feed store this
+%%% module opens (see "Local feed store" below) -- thin delegation to
+%%% `barrel_att_feed', the same way `barrel_att_store_blob' does -- plus
+%%% `rebuild_feed/2', which recovers feed state directly from S3 object
+%%% metadata if the local feed is ever lost (see "Attachment change feed"
+%%% below), and `checkpoint/2', which makes `barrel_docdb:branch_db/3' work
+%%% against an S3-backed database (see "Branching" below). Every optional
+%%% callback `barrel_att_backend' defines is implemented.
+%%% `delete/5' is nominally optional too but called unconditionally by
+%%% `barrel_att_store:delete/5', so it must exist regardless.
+%%%
+%%% == Config ==
+%%% `att_opts => #{backend => s3, s3 => #{bucket, endpoint, region,
+%%% access_key_id, secret_access_key, ...}}' -- every key in the nested `s3'
+%%% map except `bucket' and `part_size' passes straight to `livery_s3:new/1'.
+%%% `att_opts.db_name' (set by `barrel_db_server' from the database's
+%%% resolved keyspace name, not user-facing config) seeds the S3 key prefix
+%%% the first time a given `Path' is ever opened -- see "Key scheme" below.
+%%%
+%%% == Local feed store ==
+%%% `open/2' also opens a small, local, metadata-only RocksDB instance at
+%%% `Path/feed.db' (`Path' is always `<DbPath>/attachments', a real local
+%%% directory even though the attachment bytes themselves live in S3 --
+%%% confirmed via `barrel_db_server:init/8'). `barrel_att_feed' is not
+%%% actually storage-agnostic: it hardcodes `rocksdb:*' calls against
+%%% whatever handle it's given, so this is where those calls land for this
+%%% backend, exactly the way `barrel_att_store_blob' points the same module
+%%% at its own blob-data handle. The feed handle is stored in `att_ref' as
+%%% `feed_ref'.
+%%%
+%%% == Key scheme ==
+%%% `Prefix/hex(DocId)/AttName'. `DocId' is arbitrary bytes with no length
+%%% cap, so it is hex-encoded; `AttName' is already validated to exclude
+%%% NUL/`/'/`\'. A defensive length check rejects keys that would exceed S3's
+%%% 1024-byte cap.
+%%%
+%%% `Prefix' is NOT the per-call `DbName' argument (every `barrel_att_backend'
+%%% callback still receives one, the contract requires it, but this backend
+%%% stops trusting it for key construction) -- it's read once at `open/2'
+%%% from a small local marker file, `Path/s3_prefix':
+%%%
+%%% <ul>
+%%%   <li>If the marker exists, its content is the prefix, unconditionally
+%%%       -- covers both a reopened store and a freshly checkpointed
+%%%       branch.</li>
+%%%   <li>If it doesn't (first-ever open of a fresh `Path'), the prefix is
+%%%       derived from `att_opts.db_name' (identical to the scheme's
+%%%       original, pre-persisted-marker behavior) and the marker is
+%%%       written so every future open agrees. This is also why an existing
+%%%       database's first post-upgrade open doesn't move its keys: it
+%%%       derives and persists the exact prefix it already had.</li>
+%%% </ul>
+%%%
+%%% Branching needs the prefix decoupled from `DbName' entirely, since
+%%% `barrel_keyspace:resolve/1' maps a branch's name back to its parent's
+%%% -- see "Branching" below.
+%%%
+%%% == Branching ==
+%%% `checkpoint/2' does only the cheap synchronous part: a RocksDB
+%%% checkpoint of the local feed, a fresh random prefix, and a
+%%% `Path/fork_pending' marker recording `{Bucket, OldPrefix}'. It returns
+%%% immediately -- `branch_db/3' does not block on attachment count.
+%%%
+%%% The actual S3 copy (`run_copy_sweep/7') is spawned by the branch's own
+%%% first `open/2', not by `checkpoint/2' -- `fork/6' always opens the
+%%% branch right after checkpointing it, so spawning from both would race
+%%% a redundant sweep. This also means a fork that fails before ever
+%%% reaching `open/2' leaves nothing spawned, and crash recovery is just
+%%% `open/2' finding the marker again on a later open.
+%%%
+%%% The sweep skips a destination key that already exists (a branch write
+%%% wins regardless of ordering, since it always lands eventually) and any
+%%% key the branch's own feed shows as deleted since the fork -- rechecked
+%%% right after the copy lands too, since a delete (unlike a put) does not
+%%% self-heal a lost race: nothing else would remove an object the sweep
+%%% just created. The marker only clears once every key succeeds; a
+%%% partial failure retries on the next open.
+%%%
+%%% Reads (`get/4', `get_stream/4', `get_info/4') check the local feed
+%%% first: a row whose object isn't copied yet returns
+%%% `{error, {att_sync_pending, {DocId, AttName}}}' instead of blocking or
+%%% returning stale data. `fold/5' is not feed-checked and only reflects
+%%% what has been copied so far.
+%%%
+%%% Forking a still-syncing source is refused with
+%%% `{error, {fork_sync_pending, retry}}' -- unreachable today since
+%%% `barrel_timeline' already rejects forking a branch, kept as a safety
+%%% net regardless.
+%%%
+%%% `destroy/2' can race an ALREADY-RUNNING sweep for the same store the
+%%% same way: `Options.resume_fork_sync => false' stops `open/2' from
+%%% spawning a NEW one, but there is no live-process registry here to find
+%%% and join/kill a sweep some EARLIER, unrelated open already started.
+%%% Deleting a still-syncing branch while it happens to be open can still
+%%% leak the objects that sweep writes after `destroy/2''s own listing
+%%% snapshot -- narrow, not closed here, same class of accepted
+%%% check-then-act race as the ones above. See `docs/limitations.md`'s
+%%% "Deleting a database" section.
+%%%
+%%% == Whole-blob vs. streaming ==
+%%% The caller already has the full binary in memory for `put/5,6', so it is
+%%% always a single `put_object' (S3 single-PUT covers up to 5GB) -- no
+%%% multipart there. Streaming (`put_stream'/`write_chunk'/`finish_stream',
+%%% the path every *replicated* attachment actually goes through) buffers in
+%%% memory and only starts a multipart upload once the buffer crosses
+%%% `part_size'; `finish_stream' does a single `put_object' if that never
+%%% happens (the common case for small/replicated attachments).
+%%%
+%%% == Write-conflict detection ==
+%%% Opt-in optimistic concurrency via S3 conditional writes: `create_only
+%%% => true' (`If-None-Match: "*"') and `expected_etag => Etag' (`If-Match:
+%%% Etag') on `put/5,6' and `finish_stream/1'. Default (neither given)
+%%% stays unconditional, matching the RocksDB backend. A failed precondition
+%%% surfaces as `{error, {conflict, CurrentInfo}}' (what's actually there
+%%% now), not just `precondition_failed'.
+%%%
+%%% Not every S3-compatible store can be trusted to enforce this: MinIO has
+%%% since 2023, AWS since 2024, but Garage cannot at all, by its own
+%%% documented design (no consensus algorithm) -- and a store that silently
+%%% accepts the headers without enforcing them is a worse failure mode than
+%%% one that rejects them outright, since a caller would believe it's
+%%% protected when it is not. `open/2' runs a capability probe (a
+%%% `create_only' put to a throwaway key, then a deliberate second one that
+%%% must be rejected) and records the verified result; `create_only'/
+%%% `expected_etag' fail fast with `{error, conditional_writes_unsupported}'
+%%% if the store didn't verifiably enforce it, rather than silently
+%%% proceeding unprotected.
+%%%
+%%% `create_only'/`expected_etag' apply uniformly whether a write ends up a
+%%% single `put_object' or a multipart upload: `livery_s3' >= 0.2.0 supports
+%%% conditional writes on `complete_multipart_upload' too (the object is
+%%% created there, not at `create_multipart_upload', so completion is the
+%%% only place the guard can apply). A losing conditional completion
+%%% (`precondition_failed' 412, `conditional_request_conflict' 409 -- the
+%%% upload id is dead either way for our purposes, a one-shot `finish_stream'
+%%% never retries it -- or `not_found' 404 when an `if_match' completion
+%%% lost to a concurrent delete) is reported the same
+%%% `{error, {conflict, CurrentInfo}}' shape as the single-put path.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_att_s3_store).
+-behaviour(barrel_att_backend).
+
+-export([open/2, close/1, checkpoint/2, destroy/2]).
+-export([put/5, put/6, get/4, delete/4, delete/5]).
+-export([delete_all/3]).
+-export([fold/5]).
+-export([get_info/4]).
+-export([put_stream/5, put_stream/6]).
+-export([write_chunk/2, finish_stream/1, abort_stream/1]).
+-export([get_stream/4, read_chunk/1, close_stream/1]).
+-export([att_changes/4, att_floor/2, sweep_att_feed/3, rebuild_feed/2]).
+
+-define(DEFAULT_PART_SIZE, 8 * 1024 * 1024). %% 8 MiB; used starting Step 3
+-define(MAX_KEY_SIZE, 1024).
+-define(META_DIGEST, <<"digest">>).
+-define(META_ORIGIN, <<"origin-hlc">>).
+-define(FORK_PENDING, "fork_pending").
+-define(DELETE_BATCH, 1000). %% S3 DeleteObjects cap per request
+
+-spec open(string(), map()) -> {ok, map()} | {error, term()}.
+open(Path, Options) ->
+    S3Opts = maps:get(s3, Options, #{}),
+    case maps:find(bucket, S3Opts) of
+        error ->
+            {error, missing_bucket};
+        {ok, Bucket} ->
+            _ = application:ensure_all_started(livery_s3),
+            ClientOpts = maps:without([bucket, part_size], S3Opts),
+            Client = livery_s3:new(ClientOpts),
+            PartSize = maps:get(part_size, S3Opts, ?DEFAULT_PART_SIZE),
+            ConditionalWrites = probe_conditional_writes(Client, Bucket),
+            case open_feed_and_prefix(Path, Options) of
+                {ok, FeedRef, Prefix} ->
+                    AttRef = #{client => Client, bucket => Bucket, part_size => PartSize,
+                              conditional_writes => ConditionalWrites,
+                              feed_ref => FeedRef, prefix => Prefix, path => Path},
+                    ok = maybe_resume_fork_sync(AttRef, Path, Options),
+                    {ok, AttRef};
+                {error, _} = Err ->
+                    Err
+            end
+    end.
+
+%% @private Resumes a pending fork sync (fresh fork or crash recovery --
+%% the sweep is idempotent, so both just re-run it). The only place the
+%% sweep is spawned from; checkpoint/2 only writes the marker.
+%%
+%% `Options.resume_fork_sync => false' skips spawning it even if a marker
+%% is present -- for a caller about to destroy/2 this store immediately
+%% anyway (see barrel_docdb:maybe_destroy_closed_att_store/3), where
+%% spawning a sweep just to abandon it is pure waste, and skipping it
+%% removes one whole path by which destroy/2 could race a sweep still
+%% writing into the prefix it is about to delete. Defaults to `true'.
+maybe_resume_fork_sync(AttRef, Path, Options) ->
+    case maps:get(resume_fork_sync, Options, true) of
+        false -> ok;
+        true -> do_maybe_resume_fork_sync(AttRef, Path, Options)
+    end.
+
+do_maybe_resume_fork_sync(#{client := Client, bucket := Bucket, prefix := Prefix,
+                            feed_ref := FeedRef}, Path, Options) ->
+    case read_fork_pending(Path) of
+        {ok, {_MarkerBucket, OldPrefix}} ->
+            case maps:get(db_name, Options, undefined) of
+                undefined ->
+                    logger:warning(
+                        "attachment fork sync at ~s cannot resume: no "
+                        "db_name given to open/2", [Path]),
+                    ok;
+                DbName ->
+                    _ = spawn(fun() ->
+                        run_copy_sweep(Path, FeedRef, DbName, Client, Bucket,
+                                       OldPrefix, Prefix)
+                    end),
+                    ok
+            end;
+        not_found ->
+            ok;
+        {error, Reason} ->
+            logger:warning("attachment fork_pending marker at ~s unreadable: ~p",
+                           [Path, Reason]),
+            ok
+    end.
+
+%% @private The local feed metadata store: opened at Path/feed.db regardless
+%% of whether feed callbacks are wired up yet (Step 1 only lays the
+%% groundwork), so its lifecycle (create-if-missing, checkpoint-ability) is
+%% established once and doesn't change shape when att_changes/4 etc. land.
+open_feed_and_prefix(Path, Options) ->
+    FeedPath = filename:join(Path, "feed.db"),
+    ok = filelib:ensure_dir(FeedPath ++ "/"),
+    case rocksdb:open(FeedPath, [{create_if_missing, true}]) of
+        {ok, FeedRef} ->
+            case read_or_derive_prefix(Path, Options) of
+                {ok, Prefix} ->
+                    {ok, FeedRef, Prefix};
+                {error, _} = Err ->
+                    _ = rocksdb:close(FeedRef),
+                    Err
+            end;
+        {error, _} = Err ->
+            Err
+    end.
+
+%% @private See the moduledoc's "Key scheme" section for why this exists.
+read_or_derive_prefix(Path, Options) ->
+    PrefixFile = filename:join(Path, "s3_prefix"),
+    case file:read_file(PrefixFile) of
+        {ok, Prefix} ->
+            {ok, Prefix};
+        {error, enoent} ->
+            case maps:find(db_name, Options) of
+                {ok, DbName} ->
+                    case file:write_file(PrefixFile, DbName) of
+                        ok -> {ok, DbName};
+                        {error, _} = Err -> Err
+                    end;
+                error ->
+                    {error, missing_db_name}
+            end;
+        {error, _} = Err ->
+            Err
+    end.
+
+%% @private A store either verifiably enforces If-None-Match (the second,
+%% deliberately-colliding put is rejected) or it's treated as unsupported --
+%% including on any probe hiccup unrelated to the property being tested,
+%% since this only gates an opt-in safety net, not ordinary operation:
+%% failing closed here just means create_only/expected_etag refuse clearly
+%% instead of silently proceeding unprotected.
+probe_conditional_writes(Client, Bucket) ->
+    ProbeKey = <<".barrel_att_s3_probe/",
+                (binary:encode_hex(crypto:strong_rand_bytes(8), lowercase))/binary>>,
+    Result = case livery_s3:put_object(Client, Bucket, ProbeKey, <<"probe">>,
+                                       #{if_none_match => <<"*">>}) of
+        {ok, _} ->
+            case livery_s3:put_object(Client, Bucket, ProbeKey, <<"probe2">>,
+                                      #{if_none_match => <<"*">>}) of
+                {error, precondition_failed} -> supported;
+                _ -> unsupported
+            end;
+        _ ->
+            unsupported
+    end,
+    _ = livery_s3:delete_object(Client, Bucket, ProbeKey),
+    Result.
+
+-spec close(map()) -> ok.
+close(#{feed_ref := FeedRef}) ->
+    rocksdb:close(FeedRef).
+
+%%====================================================================
+%% Branching: non-blocking eager copy
+%%====================================================================
+%%
+%% See the moduledoc's "Branching" section for the full design.
+
+%% @doc Refuses a source still mid-sync from its own fork (checked via
+%% `path', not `BranchPath') -- unreachable via barrel_timeline today,
+%% kept as a safety net.
+-spec checkpoint(map(), string()) -> ok | {error, term()}.
+checkpoint(#{feed_ref := FeedRef, bucket := Bucket, prefix := OldPrefix,
+            path := SourcePath}, BranchPath) ->
+    case read_fork_pending(SourcePath) of
+        {ok, _} ->
+            {error, {fork_sync_pending, retry}};
+        not_found ->
+            do_checkpoint(FeedRef, Bucket, OldPrefix, BranchPath);
+        {error, _} = Err ->
+            Err
+    end.
+
+%% ensure_path(BranchPath), not ensure_dir(FeedPath ++ "/"): checkpoint's
+%% target must not already exist, unlike rocksdb:open's create_if_missing.
+do_checkpoint(FeedRef, Bucket, OldPrefix, BranchPath) ->
+    ok = filelib:ensure_path(BranchPath),
+    FeedPath = filename:join(BranchPath, "feed.db"),
+    case rocksdb:checkpoint(FeedRef, FeedPath) of
+        ok ->
+            NewPrefix = binary:encode_hex(crypto:strong_rand_bytes(16), lowercase),
+            case file:write_file(filename:join(BranchPath, "s3_prefix"), NewPrefix) of
+                ok -> write_fork_pending(BranchPath, Bucket, OldPrefix);
+                {error, _} = Err -> Err
+            end;
+        {error, _} = Err ->
+            Err
+    end.
+
+%% @private {Bucket, OldPrefix} is all a crash/restart needs to resume.
+write_fork_pending(Path, Bucket, OldPrefix) ->
+    File = fork_pending_path(Path),
+    Tmp = File ++ ".tmp",
+    Data = io_lib:format("~p.~n", [#{bucket => Bucket, old_prefix => OldPrefix}]),
+    case file:write_file(Tmp, Data) of
+        ok -> file:rename(Tmp, File);
+        {error, _} = Err -> Err
+    end.
+
+read_fork_pending(Path) ->
+    case file:consult(fork_pending_path(Path)) of
+        {ok, [#{bucket := Bucket, old_prefix := OldPrefix}]} ->
+            {ok, {Bucket, OldPrefix}};
+        {error, enoent} ->
+            not_found;
+        _ ->
+            {error, corrupt_fork_pending}
+    end.
+
+clear_fork_pending(Path) ->
+    case file:delete(fork_pending_path(Path)) of
+        ok -> ok;
+        {error, enoent} -> ok;
+        {error, _} = Err -> Err
+    end.
+
+fork_pending_path(Path) ->
+    filename:join(Path, ?FORK_PENDING).
+
+%% @doc Copies every object under OldPrefix to NewPrefix, skipping keys
+%% already there (branch write or a prior partial run) or deleted since
+%% the fork. Clears fork_pending only once every key succeeds.
+run_copy_sweep(Path, FeedRef, DbName, Client, Bucket, OldPrefix, NewPrefix) ->
+    ListPrefix = <<OldPrefix/binary, "/">>,
+    case livery_s3:list_objects_all(Client, Bucket, #{prefix => ListPrefix}) of
+        {ok, #{objects := Objects}} ->
+            Results = [copy_one(FeedRef, DbName, Client, Bucket, OldPrefix, NewPrefix, Key)
+                      || #{key := Key} <- Objects],
+            case lists:all(fun(Ok) -> Ok end, Results) of
+                true ->
+                    ok = clear_fork_pending(Path);
+                false ->
+                    logger:warning(
+                        "attachment fork copy sweep for ~s incomplete; "
+                        "will retry on next open", [Path])
+            end;
+        {error, Reason} ->
+            logger:warning(
+                "attachment fork copy sweep for ~s failed to list ~s: ~p; "
+                "will retry on next open", [Path, OldPrefix, Reason])
+    end.
+
+copy_one(FeedRef, DbName, Client, Bucket, OldPrefix, NewPrefix, SrcKey) ->
+    case key_to_doc_att(OldPrefix, SrcKey) of
+        {ok, DocId, AttName} ->
+            case deleted_since_fork(FeedRef, DbName, DocId, AttName) of
+                true ->
+                    true;
+                false ->
+                    DstKey = swap_prefix(OldPrefix, NewPrefix, SrcKey),
+                    copy_if_absent(FeedRef, DbName, DocId, AttName, Client, Bucket,
+                                   SrcKey, DstKey)
+            end;
+        error ->
+            true
+    end.
+
+deleted_since_fork(FeedRef, DbName, DocId, AttName) ->
+    case barrel_att_feed:index_get(FeedRef, DbName, DocId, AttName) of
+        {ok, #{op := delete}} -> true;
+        _ -> false
+    end.
+
+%% @private Rechecks for a delete right after the copy lands and undoes
+%% it if one raced in -- unlike a put, a delete does not self-heal a lost
+%% race (delete_object on an absent key is a no-op).
+copy_if_absent(FeedRef, DbName, DocId, AttName, Client, Bucket, SrcKey, DstKey) ->
+    case livery_s3:head_object(Client, Bucket, DstKey) of
+        {ok, _} ->
+            true;
+        {error, not_found} ->
+            case livery_s3:copy_object(Client, Bucket, SrcKey, Bucket, DstKey) of
+                {ok, _} ->
+                    case deleted_since_fork(FeedRef, DbName, DocId, AttName) of
+                        true -> _ = livery_s3:delete_object(Client, Bucket, DstKey);
+                        false -> ok
+                    end,
+                    true;
+                {error, Reason} ->
+                    logger:warning("attachment fork copy ~s -> ~s failed: ~p",
+                                   [SrcKey, DstKey, Reason]),
+                    false
+            end;
+        {error, Reason} ->
+            logger:warning("attachment fork copy HEAD ~s failed: ~p", [DstKey, Reason]),
+            false
+    end.
+
+swap_prefix(OldPrefix, NewPrefix, Key) ->
+    OldLen = byte_size(OldPrefix),
+    <<OldPrefix:OldLen/binary, Rest/binary>> = Key,
+    <<NewPrefix/binary, Rest/binary>>.
+
+%% @private Distinguishes a genuinely absent attachment from one whose
+%% bytes just haven't been copied by an in-progress fork sync yet.
+not_found_or_sync_pending(#{feed_ref := FeedRef, path := Path}, DbName, DocId, AttName) ->
+    case barrel_att_feed:index_get(FeedRef, DbName, DocId, AttName) of
+        {ok, #{op := put}} ->
+            case read_fork_pending(Path) of
+                {ok, _} -> {error, {att_sync_pending, {DocId, AttName}}};
+                _ -> {error, not_found}
+            end;
+        _ ->
+            {error, not_found}
+    end.
+
+%% @doc Erase every S3 object under this store's own prefix, called from
+%% delete_db before the local directory is removed. Clears fork_pending
+%% first (best-effort -- an in-flight background sweep isn't cancelled,
+%% just no longer resumed on a future open that will never happen).
+-spec destroy(map(), binary()) -> ok | {error, term()}.
+destroy(#{client := Client, bucket := Bucket, prefix := Prefix, path := Path}, _DbName) ->
+    _ = clear_fork_pending(Path),
+    case livery_s3:list_objects_all(Client, Bucket, #{prefix => <<Prefix/binary, "/">>}) of
+        {ok, #{objects := Objects}} ->
+            delete_in_batches(Client, Bucket, [maps:get(key, O) || O <- Objects]);
+        {error, _} = Err ->
+            Err
+    end.
+
+%% S3's DeleteObjects caps a single request at 1000 keys.
+delete_in_batches(_Client, _Bucket, []) ->
+    ok;
+delete_in_batches(Client, Bucket, Keys) ->
+    {Batch, Rest} = case Keys of
+        [_ | _] = All when length(All) > ?DELETE_BATCH ->
+            lists:split(?DELETE_BATCH, All);
+        All ->
+            {All, []}
+    end,
+    case livery_s3:delete_objects(Client, Bucket, Batch) of
+        {ok, _} -> delete_in_batches(Client, Bucket, Rest);
+        {error, _} = Err -> Err
+    end.
+
+-spec put(map(), binary(), binary(), binary(), binary()) ->
+    {ok, map()} | {error, term()}.
+put(AttRef, DbName, DocId, AttName, Data) ->
+    put(AttRef, DbName, DocId, AttName, Data, #{}).
+
+-spec put(map(), binary(), binary(), binary(), binary(), map()) ->
+    {ok, map()} | {error, term()}.
+put(#{prefix := Prefix} = AttRef, DbName, DocId, AttName, Data, Opts) when is_binary(Data) ->
+    with_key(Prefix, DocId, AttName, fun(Key) ->
+        do_put(AttRef, DbName, DocId, Key, AttName, Data, Opts)
+    end).
+
+do_put(#{client := Client, bucket := Bucket, conditional_writes := CW,
+         feed_ref := FeedRef} = AttRef, DbName, DocId, Key, AttName, Data, Opts) ->
+    Digest = compute_digest(Data),
+    case check_expected_digest(Digest, Opts) of
+        {error, _} = Err ->
+            Err;
+        ok ->
+            OriginOpt = maps:get(origin_hlc, Opts, undefined),
+            case resolve_origin(FeedRef, DbName, DocId, AttName, OriginOpt, Digest) of
+                ignored ->
+                    {ok, ignored};
+                {apply, OriginHlc} ->
+                    case conditional_headers(Opts, CW) of
+                        {error, _} = Err ->
+                            Err;
+                        {ok, CondHeaders} ->
+                            ContentType = maps:get(content_type, Opts, mimerl:filename(AttName)),
+                            PutOpts = maps:merge(#{
+                                content_type => ContentType,
+                                metadata => #{?META_DIGEST => Digest,
+                                              ?META_ORIGIN => encode_origin(OriginHlc)}
+                            }, CondHeaders),
+                            case livery_s3:put_object(Client, Bucket, Key, Data, PutOpts) of
+                                {ok, _} ->
+                                    commit_feed_put(FeedRef, DbName, DocId, AttName,
+                                                    OriginHlc, Digest, byte_size(Data),
+                                                    ContentType),
+                                    {ok, #{name => AttName, content_type => ContentType,
+                                           length => byte_size(Data), digest => Digest,
+                                           chunked => false}};
+                                {error, precondition_failed} ->
+                                    conflict_error(AttRef, Key, AttName);
+                                {error, _} = Err ->
+                                    Err
+                            end
+                    end
+            end
+    end.
+
+%% @private expected_digest is a data-integrity check on the incoming bytes
+%% (mirrors barrel_att_store_blob's put/6), distinct from the
+%% write-conflict-detection Opts (create_only/expected_etag) below.
+check_expected_digest(Digest, Opts) ->
+    case maps:get(expected_digest, Opts, undefined) of
+        undefined -> ok;
+        Digest -> ok;
+        _Other -> {error, digest_mismatch}
+    end.
+
+%% @private Local writes (no origin_hlc) always mint a fresh origin and
+%% proceed unconditionally -- there is no "other version" to compare
+%% against for a direct, non-replicated write. Replicated writes (an
+%% origin_hlc supplied) run the last-write-wins guard against the local
+%% feed, exactly mirroring barrel_att_store_blob:resolve_origin/6, just
+%% against this backend's own local feed_ref instead of its blob handle.
+resolve_origin(_FeedRef, _DbName, _DocId, _AttName, undefined, _Digest) ->
+    {apply, barrel_hlc:new_hlc()};
+resolve_origin(FeedRef, DbName, DocId, AttName, OriginHlc, Digest) ->
+    case barrel_att_feed:check(FeedRef, DbName, DocId, AttName, OriginHlc, Digest) of
+        apply -> {apply, OriginHlc};
+        ignored -> ignored
+    end.
+
+%% @private Moves the (DocId, AttName) feed row to a fresh local HLC,
+%% committed as its own local RocksDB batch -- NOT atomic with the S3 write
+%% that already succeeded by the time this runs (S3 and RocksDB are two
+%% different systems; there is no cross-system transaction to have). A
+%% failure here is logged, not propagated: the attachment itself was
+%% already durably written, so returning an error here would be
+%% misleading. The residual window this opens (S3 succeeded, the feed
+%% commit didn't) is the same class of gap rebuild_feed/2 (Step 4) and
+%% barrel_rep_att's not-found tolerance already absorb elsewhere -- not a
+%% new risk this introduces.
+commit_feed_put(FeedRef, DbName, DocId, AttName, OriginHlc, Digest, Length, ContentType) ->
+    FeedOps = barrel_att_feed:ops(FeedRef, DbName, DocId, AttName, put, OriginHlc,
+                                  #{digest => Digest, length => Length,
+                                    content_type => ContentType}),
+    commit_feed(FeedRef, DbName, DocId, AttName, FeedOps).
+
+commit_feed(FeedRef, DbName, DocId, AttName, FeedOps) ->
+    {ok, Batch} = rocksdb:batch(),
+    try
+        lists:foreach(
+            fun({put, K, V}) -> ok = rocksdb:batch_put(Batch, K, V);
+               ({delete, K}) -> ok = rocksdb:batch_delete(Batch, K)
+            end,
+            FeedOps),
+        case rocksdb:write_batch(FeedRef, Batch, []) of
+            ok -> ok;
+            {error, Reason} ->
+                logger:warning("attachment feed commit for ~s/~s/~s failed: ~p",
+                               [DbName, DocId, AttName, Reason]),
+                ok
+        end
+    after
+        rocksdb:release_batch(Batch)
+    end.
+
+%% @private Translates create_only/expected_etag into the S3 headers
+%% livery_s3 expects, gated on the store having verifiably enforced them at
+%% open/2 -- {ok, #{}} (no headers) when the caller asked for neither, so
+%% ordinary unconditional writes never even consult ConditionalWrites.
+-spec conditional_headers(map(), supported | unsupported) ->
+    {ok, map()} | {error, conditional_writes_unsupported}.
+conditional_headers(Opts, ConditionalWrites) ->
+    CreateOnly = maps:get(create_only, Opts, false),
+    ExpectedEtag = maps:get(expected_etag, Opts, undefined),
+    case CreateOnly =:= false andalso ExpectedEtag =:= undefined of
+        true ->
+            {ok, #{}};
+        false ->
+            case ConditionalWrites of
+                unsupported ->
+                    {error, conditional_writes_unsupported};
+                supported ->
+                    Headers0 = case CreateOnly of
+                        true -> #{if_none_match => <<"*">>};
+                        false -> #{}
+                    end,
+                    Headers = case ExpectedEtag of
+                        undefined -> Headers0;
+                        Etag -> Headers0#{if_match => Etag}
+                    end,
+                    {ok, Headers}
+            end
+    end.
+
+%% @private A failed precondition reports what's actually at Key now, so
+%% the caller can decide: retry against the new baseline, surface it, or
+%% force an overwrite by retrying without the conditional options.
+conflict_error(#{client := Client, bucket := Bucket}, Key, AttName) ->
+    case livery_s3:head_object(Client, Bucket, Key) of
+        {ok, Meta} ->
+            Metadata = maps:get(metadata, Meta, #{}),
+            {error, {conflict, #{
+                name => AttName,
+                content_type => maps:get(content_type, Meta,
+                                         mimerl:filename(AttName)),
+                length => maps:get(content_length, Meta, 0),
+                digest => maps:get(?META_DIGEST, Metadata, undefined),
+                etag => maps:get(etag, Meta, undefined)
+            }}};
+        {error, not_found} ->
+            %% Raced with a delete between our rejected write and this
+            %% HEAD -- report the conflict without current info rather
+            %% than pretending the write actually landed.
+            {error, {conflict, undefined}};
+        {error, _} = Err ->
+            Err
+    end.
+
+-spec get(map(), binary(), binary(), binary()) ->
+    {ok, binary()} | {error, term()}.
+get(#{prefix := Prefix} = AttRef, DbName, DocId, AttName) ->
+    with_key(Prefix, DocId, AttName, fun(Key) ->
+        do_get(AttRef, DbName, DocId, AttName, Key)
+    end).
+
+do_get(#{client := Client, bucket := Bucket} = AttRef, DbName, DocId, AttName, Key) ->
+    case livery_s3:get_object(Client, Bucket, Key) of
+        {ok, #{body := Body}} -> {ok, Body};
+        {error, {s3, _Code, _Msg, #{status := 404}}} ->
+            not_found_or_sync_pending(AttRef, DbName, DocId, AttName);
+        {error, _} = Err -> Err
+    end.
+
+-spec delete(map(), binary(), binary(), binary()) -> ok | {error, term()}.
+delete(AttRef, DbName, DocId, AttName) ->
+    delete(AttRef, DbName, DocId, AttName, #{}).
+
+%% @doc `Opts.origin_hlc', for a replicated delete, runs the same
+%% last-write-wins guard put/6 does. Unlike barrel_att_store_blob, this
+%% always writes a delete tombstone to the feed rather than first checking
+%% whether the attachment (or an index row) already existed -- that check
+%% would cost an extra S3 round trip here, and skipping it only costs a
+%% slightly larger feed for deletes of things that were never there, not a
+%% correctness gap.
+-spec delete(map(), binary(), binary(), binary(), map()) ->
+    ok | {error, term()}.
+delete(#{prefix := Prefix} = AttRef, DbName, DocId, AttName, Opts) ->
+    with_key(Prefix, DocId, AttName, fun(Key) ->
+        do_delete(AttRef, DbName, DocId, Key, AttName, Opts)
+    end).
+
+do_delete(#{client := Client, bucket := Bucket, feed_ref := FeedRef},
+          DbName, DocId, Key, AttName, Opts) ->
+    OriginOpt = maps:get(origin_hlc, Opts, undefined),
+    case resolve_origin(FeedRef, DbName, DocId, AttName, OriginOpt, <<>>) of
+        ignored ->
+            ok;
+        {apply, OriginHlc} ->
+            case livery_s3:delete_object(Client, Bucket, Key) of
+                ok ->
+                    FeedOps = barrel_att_feed:ops(FeedRef, DbName, DocId, AttName,
+                                                  delete, OriginHlc, #{}),
+                    commit_feed(FeedRef, DbName, DocId, AttName, FeedOps);
+                {error, _} = Err ->
+                    Err
+            end
+    end.
+
+-spec delete_all(map(), binary(), binary()) -> ok | {error, term()}.
+delete_all(#{client := Client, bucket := Bucket, prefix := Prefix}, _DbName, DocId) ->
+    case doc_prefix(Prefix, DocId) of
+        {error, _} = Err ->
+            Err;
+        {ok, DocPrefix} ->
+            case livery_s3:list_objects_all(Client, Bucket, #{prefix => DocPrefix}) of
+                {ok, #{objects := []}} ->
+                    ok;
+                {ok, #{objects := Objects}} ->
+                    Keys = [maps:get(key, O) || O <- Objects],
+                    case livery_s3:delete_objects(Client, Bucket, Keys) of
+                        {ok, _} -> ok;
+                        {error, _} = Err -> Err
+                    end;
+                {error, _} = Err ->
+                    Err
+            end
+    end.
+
+%% @doc Enumerates attachment names under a document. Does not fetch object
+%% bodies: the sole caller in this codebase (`barrel_att:list_attachments/3'
+%% via `barrel_docdb:list_attachments/2') discards `Data' entirely, and
+%% fetching bytes (or even just metadata) per key here would cost N extra S3
+%% round trips for a value nothing reads -- `Data' is `undefined'. Revisit if
+%% a real consumer of fold's Data argument appears.
+-spec fold(map(), binary(), binary(), fun(), term()) -> term().
+fold(#{client := Client, bucket := Bucket, prefix := StorePrefix}, _DbName, DocId, Fun, Acc) ->
+    case doc_prefix(StorePrefix, DocId) of
+        {error, _} ->
+            Acc;
+        {ok, Prefix} ->
+            case livery_s3:list_objects_all(Client, Bucket, #{prefix => Prefix}) of
+                {ok, #{objects := Objects}} ->
+                    fold_objects(Objects, Prefix, Fun, Acc);
+                {error, _} ->
+                    Acc
+            end
+    end.
+
+fold_objects([], _Prefix, _Fun, Acc) ->
+    Acc;
+fold_objects([#{key := Key} | Rest], Prefix, Fun, Acc) ->
+    AttName = att_name_from_key(Prefix, Key),
+    case Fun(AttName, undefined, Acc) of
+        {ok, Acc1} -> fold_objects(Rest, Prefix, Fun, Acc1);
+        {stop, Acc1} -> Acc1;
+        stop -> Acc
+    end.
+
+-spec get_info(map(), binary(), binary(), binary()) ->
+    {ok, map()} | {error, term()}.
+get_info(#{prefix := Prefix} = AttRef, DbName, DocId, AttName) ->
+    with_key(Prefix, DocId, AttName, fun(Key) ->
+        do_get_info(AttRef, DbName, DocId, AttName, Key)
+    end).
+
+do_get_info(#{client := Client, bucket := Bucket} = AttRef, DbName, DocId, AttName, Key) ->
+    case livery_s3:head_object(Client, Bucket, Key) of
+        {ok, Meta} ->
+            Metadata = maps:get(metadata, Meta, #{}),
+            {ok, #{
+                name => AttName,
+                content_type => maps:get(content_type, Meta,
+                                         mimerl:filename(AttName)),
+                length => maps:get(content_length, Meta, 0),
+                digest => maps:get(?META_DIGEST, Metadata, undefined),
+                chunked => false
+            }};
+        {error, not_found} ->
+            not_found_or_sync_pending(AttRef, DbName, DocId, AttName);
+        {error, _} = Err ->
+            Err
+    end.
+
+%%====================================================================
+%% Attachment change feed
+%%====================================================================
+%%
+%% Thin delegation to barrel_att_feed against feed_ref, exactly mirroring
+%% barrel_att_store_blob's own one-liners (apps/barrel_docdb/src/
+%% barrel_att_store_blob.erl:589-604) -- the module's key encoding, codec,
+%% and read-side folding are storage-agnostic, and this backend's local
+%% feed store follows the same key layout blob's own RocksDB does, just in
+%% a dedicated instance rather than sharing one with blob data.
+
+-spec att_changes(map(), binary(), barrel_hlc:timestamp() | first, map()) ->
+    {ok, [barrel_att_feed:entry()], barrel_hlc:timestamp() | first}.
+att_changes(#{feed_ref := FeedRef}, DbName, Since, Opts) ->
+    barrel_att_feed:att_changes(FeedRef, DbName, Since, Opts).
+
+-spec att_floor(map(), binary()) -> barrel_hlc:timestamp() | undefined.
+att_floor(#{feed_ref := FeedRef}, DbName) ->
+    barrel_att_feed:att_floor(FeedRef, DbName).
+
+-spec sweep_att_feed(map(), binary(), barrel_hlc:timestamp()) ->
+    {ok, #{tombstones_swept := non_neg_integer()}}.
+sweep_att_feed(#{feed_ref := FeedRef}, DbName, Cutoff) ->
+    barrel_att_feed:sweep(FeedRef, DbName, Cutoff).
+
+%% @doc Maintenance escape hatch: resynthesize feed rows for every
+%% attachment currently present in the bucket, for when the local feed is
+%% lost or corrupted -- unlike barrel_att_store_blob:rebuild_feed/2, which
+%% has no separate record of a write's original origin once its feed is
+%% gone and so always falls back to the MINIMUM origin, this backend can
+%% usually do better: `?META_ORIGIN' rides in each object's own S3 custom
+%% metadata, independent of the local feed entirely, so the real origin
+%% survives a feed loss and is recovered here. Only an object written
+%% before `?META_ORIGIN' existed (pre-M2) has none to recover, and falls
+%% back to `barrel_hlc:min()' the same way blob's rebuild always does --
+%% so any real write, local or remote, still wins the LWW race against it.
+%% Only rebuilds `put' rows for attachments that currently exist: a delete
+%% tombstone for something already gone from the bucket is never
+%% reconstructed, matching blob's own rebuild scope (a fresh put's LWW
+%% check finds no index row either way, and applies unconditionally, the
+%% same outcome a tombstone would have produced). Safe to re-run.
+-spec rebuild_feed(map(), binary()) -> {ok, #{rows := non_neg_integer()}} | {error, term()}.
+rebuild_feed(#{client := Client, bucket := Bucket, prefix := Prefix,
+               feed_ref := FeedRef}, DbName) ->
+    ListPrefix = <<Prefix/binary, "/">>,
+    case livery_s3:list_objects_all(Client, Bucket, #{prefix => ListPrefix}) of
+        {ok, #{objects := Objects}} ->
+            N = lists:foldl(
+                fun(#{key := Key}, Count) ->
+                    case rebuild_one(Client, Bucket, Prefix, FeedRef, DbName, Key) of
+                        true -> Count + 1;
+                        false -> Count
+                    end
+                end,
+                0,
+                Objects),
+            {ok, #{rows => N}};
+        {error, _} = Err ->
+            Err
+    end.
+
+%% @private HEADs the object for its digest/origin/content-type (a listing
+%% alone carries none of those) and writes one feed row for it. A 404 here
+%% means it raced with a delete between the listing and this HEAD -- skip
+%% it rather than fabricating a row for something no longer there.
+rebuild_one(Client, Bucket, Prefix, FeedRef, DbName, Key) ->
+    case key_to_doc_att(Prefix, Key) of
+        {ok, DocId, AttName} ->
+            case livery_s3:head_object(Client, Bucket, Key) of
+                {ok, Meta} ->
+                    Metadata = maps:get(metadata, Meta, #{}),
+                    Digest = maps:get(?META_DIGEST, Metadata, <<>>),
+                    ContentType = maps:get(content_type, Meta,
+                                           mimerl:filename(AttName)),
+                    Length = maps:get(content_length, Meta, 0),
+                    OriginHlc = decode_origin(maps:get(?META_ORIGIN, Metadata, undefined)),
+                    Ops = barrel_att_feed:ops(FeedRef, DbName, DocId, AttName, put,
+                                              OriginHlc,
+                                              #{digest => Digest, length => Length,
+                                                content_type => ContentType}),
+                    ok = commit_feed(FeedRef, DbName, DocId, AttName, Ops),
+                    true;
+                {error, _} ->
+                    false
+            end;
+        error ->
+            false
+    end.
+
+%% @private Inverse of object_key/3: `Prefix/hex(DocId)/AttName' -> the
+%% original DocId bytes and AttName. AttName is validated elsewhere to
+%% exclude "/", so splitting Rest on the first "/" cleanly separates the
+%% hex DocId from it.
+key_to_doc_att(Prefix, Key) ->
+    Offset = byte_size(Prefix) + 1,
+    case Offset =< byte_size(Key) of
+        true ->
+            Rest = binary:part(Key, Offset, byte_size(Key) - Offset),
+            case binary:split(Rest, <<"/">>) of
+                [HexDocId, AttName] when AttName =/= <<>> ->
+                    try
+                        {ok, binary:decode_hex(HexDocId), AttName}
+                    catch
+                        _:_ -> error
+                    end;
+                _ ->
+                    error
+            end;
+        false ->
+            error
+    end.
+
+%%====================================================================
+%% Key scheme
+%%====================================================================
+
+%% @private Resolve the object key, defensively rejecting anything that
+%% would exceed S3's 1024-byte key cap, then run Fun against it. `Prefix' is
+%% the store's own persisted key prefix (see the moduledoc), not a DbName.
+with_key(Prefix, DocId, AttName, Fun) ->
+    case object_key(Prefix, DocId, AttName) of
+        {error, _} = Err -> Err;
+        {ok, Key} -> Fun(Key)
+    end.
+
+-spec object_key(binary(), binary(), binary()) ->
+    {ok, binary()} | {error, key_too_long}.
+object_key(Prefix, DocId, AttName) ->
+    case doc_prefix(Prefix, DocId) of
+        {error, _} = Err -> Err;
+        {ok, DocPrefix} -> bounded_key(<<DocPrefix/binary, AttName/binary>>)
+    end.
+
+-spec doc_prefix(binary(), binary()) -> {ok, binary()} | {error, key_too_long}.
+doc_prefix(Prefix, DocId) ->
+    bounded_key(<<Prefix/binary, "/",
+                  (binary:encode_hex(DocId, lowercase))/binary, "/">>).
+
+bounded_key(Key) ->
+    case byte_size(Key) =< ?MAX_KEY_SIZE of
+        true -> {ok, Key};
+        false -> {error, key_too_long}
+    end.
+
+att_name_from_key(Prefix, Key) ->
+    PrefixLen = byte_size(Prefix),
+    binary:part(Key, PrefixLen, byte_size(Key) - PrefixLen).
+
+compute_digest(Data) ->
+    Digest = crypto:hash(sha256, Data),
+    <<"sha256-", (binary:encode_hex(Digest, lowercase))/binary>>.
+
+%% @private barrel_hlc:encode/1's raw 12-byte binary isn't safe as an HTTP
+%% header value as-is; hex-encode it the same way the digest already is.
+encode_origin(OriginHlc) ->
+    binary:encode_hex(barrel_hlc:encode(OriginHlc), lowercase).
+
+%% @private Inverse of encode_origin/1, used by rebuild_feed/2. Missing or
+%% unparseable (a corrupt/foreign value should not crash a recovery pass)
+%% falls back to barrel_hlc:min() -- the same "any real write wins" floor
+%% blob's own rebuild_feed/2 always uses.
+decode_origin(undefined) ->
+    barrel_hlc:min();
+decode_origin(HexOrigin) ->
+    try
+        barrel_hlc:decode(binary:decode_hex(HexOrigin))
+    catch
+        _:_ -> barrel_hlc:min()
+    end.
+
+%%====================================================================
+%% Streaming API
+%%====================================================================
+%%
+%% This is the path every *replicated* attachment actually goes through
+%% (barrel_rep_att:transfer/6 always calls get_attachment_stream/
+%% put_attachment, never the whole-blob API). write_chunk buffers in memory
+%% and does NOT start a multipart upload eagerly: a real S3 call only
+%% happens once the buffer crosses part_size, and finish_stream does a
+%% single put_object if that threshold was never crossed (the common case
+%% for small/replicated attachments) instead of a needless 3-call
+%% create+upload_part+complete sequence.
+%%
+%% Stream maps thread through write_chunk/read_chunk exactly like the
+%% RocksDB backend's: each call returns the map to pass to the next call,
+%% and on {error, _} the caller's last-known-good map (from the previous
+%% successful call) is what abort_stream/1 must be given -- it alone
+%% accurately reflects what has actually been sent to S3 so far.
+
+-spec put_stream(map(), binary(), binary(), binary(), binary()) ->
+    {ok, map()} | {error, term()}.
+put_stream(AttRef, DbName, DocId, AttName, ContentType) ->
+    put_stream(AttRef, DbName, DocId, AttName, ContentType, #{}).
+
+-spec put_stream(map(), binary(), binary(), binary(), binary(), map()) ->
+    {ok, map()} | {error, term()}.
+put_stream(#{prefix := Prefix} = AttRef, DbName, DocId, AttName, ContentType, Opts) ->
+    with_key(Prefix, DocId, AttName, fun(Key) ->
+        {ok, #{
+            type => write,
+            att_ref => AttRef,
+            key => Key,
+            db_name => DbName,
+            doc_id => DocId,
+            att_name => AttName,
+            content_type => ContentType,
+            origin_hlc => maps:get(origin_hlc, Opts, undefined),
+            expected_digest => maps:get(expected_digest, Opts, undefined),
+            create_only => maps:get(create_only, Opts, false),
+            expected_etag => maps:get(expected_etag, Opts, undefined),
+            buffer => <<>>,
+            digest_ctx => crypto:hash_init(sha256),
+            length => 0,
+            multipart => undefined
+        }}
+    end).
+
+-spec write_chunk(map(), binary()) -> {ok, map()} | {error, term()}.
+write_chunk(#{type := write, buffer := Buffer, digest_ctx := Ctx,
+              length := Length} = Stream, Data) ->
+    NewBuffer = <<Buffer/binary, Data/binary>>,
+    Stream1 = Stream#{
+        buffer => NewBuffer,
+        digest_ctx => crypto:hash_update(Ctx, Data),
+        length => Length + byte_size(Data)
+    },
+    case byte_size(NewBuffer) >= part_size(Stream1) of
+        true -> flush_part(Stream1, maps:get(multipart, Stream1) =:= undefined);
+        false -> {ok, Stream1}
+    end.
+
+part_size(#{att_ref := #{part_size := PartSize}}) -> PartSize.
+
+%% @private Upload the buffer as one multipart part, creating the upload
+%% first if none exists yet. `WasUndefined' is whether `multipart' was
+%% `undefined' before THIS write_chunk call started: if the upload was just
+%% created in this same call and the part upload then fails, the caller's
+%% retained (pre-call) stream has no upload_id at all to abort_stream later
+%% -- self-abort here instead of orphaning it. If the upload already
+%% existed from a prior successful call, the caller's own stream already
+%% carries it, so abort_stream on that is sufficient; no self-abort here.
+%%
+%% create_only/expected_etag are NOT applied to create_multipart_upload:
+%% the object is created at completion, not here (see finish_stream/1),
+%% consistent with where livery_s3 itself applies conditional writes for
+%% multipart uploads.
+flush_part(#{multipart := undefined} = Stream, WasUndefined) ->
+    #{att_ref := #{client := Client, bucket := Bucket}, key := Key,
+      content_type := ContentType} = Stream,
+    case livery_s3:create_multipart_upload(Client, Bucket, Key,
+                                           #{content_type => ContentType}) of
+        {ok, UploadId} ->
+            Stream1 = Stream#{multipart => #{upload_id => UploadId,
+                                             parts => [], part_number => 1}},
+            flush_part(Stream1, WasUndefined);
+        {error, _} = Err ->
+            Err
+    end;
+flush_part(#{multipart := MP, buffer := Buffer} = Stream, WasUndefined) ->
+    #{att_ref := #{client := Client, bucket := Bucket}, key := Key} = Stream,
+    #{upload_id := UploadId, parts := Parts, part_number := PartNumber} = MP,
+    case livery_s3:upload_part(Client, Bucket, Key, UploadId, PartNumber, Buffer) of
+        {ok, #{etag := ETag}} ->
+            NewMP = MP#{parts => Parts ++ [{PartNumber, ETag}],
+                       part_number => PartNumber + 1},
+            {ok, Stream#{multipart => NewMP, buffer => <<>>}};
+        {error, Reason} ->
+            case WasUndefined of
+                true -> _ = livery_s3:abort_multipart_upload(Client, Bucket, Key, UploadId);
+                false -> ok
+            end,
+            {error, Reason}
+    end.
+
+%% @doc Finish a write stream: never crossed the multipart threshold ->
+%% single put_object with everything buffered (digest and origin checked
+%% BEFORE sending anything, since nothing has been written yet); otherwise
+%% upload the remainder as the final part (allowed under the size minimum
+%% since it's last) and complete -- a digest mismatch, a losing LWW check,
+%% or a completion failure aborts the whole multipart upload rather than
+%% leaving it dangling. The origin check runs against the local feed the
+%% same way put/6's does: local writes (no origin_hlc) always proceed,
+%% replicated ones are subject to the last-write-wins guard.
+-spec finish_stream(map()) -> {ok, map()} | {error, term()}.
+finish_stream(#{type := write, multipart := undefined} = Stream) ->
+    #{att_ref := #{client := Client, bucket := Bucket, feed_ref := FeedRef,
+                  conditional_writes := CW} = AttRef,
+      key := Key, db_name := DbName, doc_id := DocId, att_name := AttName,
+      content_type := ContentType,
+      buffer := Buffer, digest_ctx := Ctx,
+      origin_hlc := OriginOpt,
+      expected_digest := ExpectedDigest} = Stream,
+    Digest = finalize_digest(Ctx),
+    case digest_ok(Digest, ExpectedDigest) of
+        {error, _} = Err ->
+            Err;
+        ok ->
+            case resolve_origin(FeedRef, DbName, DocId, AttName, OriginOpt, Digest) of
+                ignored ->
+                    {ok, ignored};
+                {apply, OriginHlc} ->
+                    case conditional_headers(Stream, CW) of
+                        {error, _} = Err ->
+                            Err;
+                        {ok, CondHeaders} ->
+                            PutOpts = maps:merge(#{content_type => ContentType,
+                                                   metadata => #{?META_DIGEST => Digest,
+                                                                 ?META_ORIGIN => encode_origin(OriginHlc)}},
+                                                CondHeaders),
+                            case livery_s3:put_object(Client, Bucket, Key, Buffer, PutOpts) of
+                                {ok, _} ->
+                                    commit_feed_put(FeedRef, DbName, DocId, AttName,
+                                                    OriginHlc, Digest, byte_size(Buffer),
+                                                    ContentType),
+                                    {ok, #{name => AttName, content_type => ContentType,
+                                           length => byte_size(Buffer), digest => Digest,
+                                           chunked => false}};
+                                {error, precondition_failed} ->
+                                    conflict_error(AttRef, Key, AttName);
+                                {error, _} = Err ->
+                                    Err
+                            end
+                    end
+            end
+    end;
+finish_stream(#{type := write, multipart := MP} = Stream) ->
+    #{att_ref := #{client := Client, bucket := Bucket, feed_ref := FeedRef,
+                  conditional_writes := CW} = AttRef,
+      key := Key, db_name := DbName, doc_id := DocId, att_name := AttName,
+      content_type := ContentType,
+      buffer := Buffer, length := Length, digest_ctx := Ctx,
+      origin_hlc := OriginOpt,
+      expected_digest := ExpectedDigest} = Stream,
+    #{upload_id := UploadId, parts := Parts, part_number := PartNumber} = MP,
+    FinalParts = case Buffer of
+        <<>> ->
+            {ok, Parts};
+        _ ->
+            case livery_s3:upload_part(Client, Bucket, Key, UploadId,
+                                       PartNumber, Buffer) of
+                {ok, #{etag := ETag}} -> {ok, Parts ++ [{PartNumber, ETag}]};
+                {error, _} = UploadErr -> UploadErr
+            end
+    end,
+    case FinalParts of
+        {error, Reason} ->
+            _ = livery_s3:abort_multipart_upload(Client, Bucket, Key, UploadId),
+            {error, Reason};
+        {ok, AllParts} ->
+            Digest = finalize_digest(Ctx),
+            case digest_ok(Digest, ExpectedDigest) of
+                {error, _} = DigestErr ->
+                    _ = livery_s3:abort_multipart_upload(Client, Bucket, Key, UploadId),
+                    DigestErr;
+                ok ->
+                    case resolve_origin(FeedRef, DbName, DocId, AttName, OriginOpt, Digest) of
+                        ignored ->
+                            _ = livery_s3:abort_multipart_upload(Client, Bucket, Key, UploadId),
+                            {ok, ignored};
+                        {apply, OriginHlc} ->
+                            case conditional_headers(Stream, CW) of
+                                {error, _} = Err ->
+                                    _ = livery_s3:abort_multipart_upload(Client, Bucket, Key, UploadId),
+                                    Err;
+                                {ok, CondHeaders} ->
+                                    complete(AttRef, Key, UploadId, AllParts, CondHeaders,
+                                             DbName, DocId, AttName, ContentType, Length,
+                                             Digest, OriginHlc)
+                            end
+                    end
+            end
+    end.
+
+%% @private The object is created here, not at create_multipart_upload, so
+%% this is where a losing conditional write shows up. precondition_failed
+%% (412), conditional_request_conflict (409, a concurrent writer won an
+%% if_none_match race), and not_found (404, an if_match completion lost to
+%% a concurrent delete) all mean the same thing to our caller regardless of
+%% which one the upload_id's exact state maps to -- finish_stream is a
+%% one-shot terminal call either way, nothing here retries the same
+%% upload_id -- so all three report the same {conflict, CurrentInfo} shape
+%% as the single-put path. The abort attempt is harmless best-effort
+%% cleanup even when the upload id is already dead (409/404).
+%%
+%% ?META_DIGEST/?META_ORIGIN can't be set on create_multipart_upload (the
+%% digest isn't known until every part has been seen, and S3 only accepts
+%% custom object metadata at creation, never at completion), so a
+%% multipart-uploaded object is created here with none. A self-copy with a
+%% REPLACE metadata directive attaches it immediately after, a well-worn S3
+%% pattern for exactly this (set/refresh metadata without re-uploading the
+%% data). If that copy fails, it's logged and NOT propagated as an error --
+%% the attachment itself was already durably completed; a repair (or a
+%% future rebuild_feed/2 pass, which falls back to barrel_hlc:min() for
+%% whatever metadata still didn't make it) covers the gap either way.
+complete(#{client := Client, bucket := Bucket, feed_ref := FeedRef} = AttRef, Key,
+         UploadId, AllParts, CondHeaders, DbName, DocId, AttName, ContentType,
+         Length, Digest, OriginHlc) ->
+    case livery_s3:complete_multipart_upload(Client, Bucket, Key, UploadId,
+                                             AllParts, CondHeaders) of
+        {ok, _} ->
+            attach_multipart_metadata(Client, Bucket, Key, ContentType, Digest, OriginHlc),
+            commit_feed_put(FeedRef, DbName, DocId, AttName, OriginHlc, Digest,
+                            Length, ContentType),
+            {ok, #{name => AttName, content_type => ContentType,
+                   length => Length, digest => Digest, chunked => true}};
+        {error, Reason} when Reason =:= precondition_failed;
+                            Reason =:= conditional_request_conflict;
+                            Reason =:= not_found ->
+            _ = livery_s3:abort_multipart_upload(Client, Bucket, Key, UploadId),
+            conflict_error(AttRef, Key, AttName);
+        {error, _} = CompleteErr ->
+            _ = livery_s3:abort_multipart_upload(Client, Bucket, Key, UploadId),
+            CompleteErr
+    end.
+
+attach_multipart_metadata(Client, Bucket, Key, ContentType, Digest, OriginHlc) ->
+    Opts = #{content_type => ContentType,
+             metadata => #{?META_DIGEST => Digest,
+                           ?META_ORIGIN => encode_origin(OriginHlc)}},
+    case livery_s3:copy_object(Client, Bucket, Key, Bucket, Key, Opts) of
+        {ok, _} ->
+            ok;
+        {error, Reason} ->
+            logger:warning("attaching metadata to multipart object ~s failed: ~p",
+                           [Key, Reason]),
+            ok
+    end.
+
+finalize_digest(Ctx) ->
+    DigestBin = crypto:hash_final(Ctx),
+    <<"sha256-", (binary:encode_hex(DigestBin, lowercase))/binary>>.
+
+digest_ok(_Digest, undefined) -> ok;
+digest_ok(Digest, Digest) -> ok;
+digest_ok(_Digest, _Expected) -> {error, digest_mismatch}.
+
+%% @doc Cleans up only what was actually sent to S3: nothing, if the
+%% multipart threshold was never crossed (finish_stream is the only place
+%% that would have made anything visible); the in-progress multipart
+%% upload otherwise.
+-spec abort_stream(map()) -> ok.
+abort_stream(#{type := write, multipart := #{upload_id := UploadId}} = Stream) ->
+    #{att_ref := #{client := Client, bucket := Bucket}, key := Key} = Stream,
+    _ = livery_s3:abort_multipart_upload(Client, Bucket, Key, UploadId),
+    ok;
+abort_stream(_Stream) ->
+    ok.
+
+-spec get_stream(map(), binary(), binary(), binary()) ->
+    {ok, map()} | {error, term()}.
+get_stream(#{prefix := Prefix} = AttRef, DbName, DocId, AttName) ->
+    with_key(Prefix, DocId, AttName, fun(Key) ->
+        do_get_stream(AttRef, DbName, DocId, AttName, Key)
+    end).
+
+do_get_stream(#{client := Client, bucket := Bucket} = AttRef, DbName, DocId, AttName, Key) ->
+    case livery_s3:get_object(Client, Bucket, Key, #{stream => true}) of
+        {ok, #{body := {stream, Reader}}} ->
+            {ok, #{type => read, att_ref => AttRef, key => Key,
+                   att_name => AttName, reader => Reader}};
+        {error, {s3, _Code, _Msg, #{status := 404}}} ->
+            not_found_or_sync_pending(AttRef, DbName, DocId, AttName);
+        {error, _} = Err ->
+            Err
+    end.
+
+%% @doc Pulls from the `livery_client' reader `get_object' handed back
+%% (`stream => true'); `{done, _}' -> `eof' per the behaviour contract, not
+%% a 3-tuple, since there is no more data to hand the caller.
+-spec read_chunk(map()) -> {ok, binary(), map()} | eof | {error, term()}.
+read_chunk(#{type := read, reader := Reader} = Stream) ->
+    case livery_client:read(Reader, 30000) of
+        {ok, Data, NextReader} -> {ok, Data, Stream#{reader => NextReader}};
+        {done, _NextReader} -> eof;
+        {error, _} = Err -> Err
+    end.
+
+%% @doc No-op, matching the RocksDB backend: an abandoned (not fully
+%% drained) read stream's underlying connection is reclaimed by hackney's
+%% own pool/timeout machinery, not explicitly cancelled here -- livery_client
+%% exposes no cancel for a pull-style reader (only for its separate
+%% flow => manual push-stream mechanism, which get_object's `stream => true`
+%% option does not use).
+-spec close_stream(map()) -> ok.
+close_stream(_Stream) ->
+    ok.

--- a/apps/barrel_att_s3/test/README.md
+++ b/apps/barrel_att_s3/test/README.md
@@ -1,0 +1,75 @@
+# barrel_att_s3 test setup
+
+`barrel_att_s3_SUITE.erl` runs against real MinIO and Garage -- there is no
+mock. Each group skips cleanly if its store isn't reachable, so the suite is
+safe to run without either running.
+
+## Quick start
+
+```console
+$ eval "$(../../test/e2e/attachments-s3-setup.sh)"
+$ rebar3 as s3 ct --suite apps/barrel_att_s3/test/barrel_att_s3_SUITE
+```
+
+(paths above assume you're in `apps/barrel_att_s3/`; from the umbrella root
+use `test/e2e/attachments-s3-setup.sh` instead.)
+
+The setup script starts `test/e2e/docker-compose.attachments-s3.yml` (MinIO +
+Garage) and provisions both -- neither the suite nor
+`barrel_att_s3_store:open/2` create a bucket on their own, and Garage
+additionally needs a one-time layout assignment before it serves any S3
+request. It prints the Garage credentials it created as `export` lines; the
+`eval "$(...)"` above loads them into your shell so the `garage` group runs
+instead of skipping.
+
+Idempotent for MinIO. Not idempotent for Garage past the first run -- Garage
+never reveals a key's secret again after creation. Run `docker compose -f
+../../test/e2e/docker-compose.attachments-s3.yml down -v` first to start
+clean.
+
+## Manual setup
+
+If you'd rather not use the script, or already have your own MinIO/Garage:
+
+```console
+$ docker run -d -p 19000:9000 -p 19001:9001 \
+    -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \
+    minio/minio server /data --console-address :9001
+```
+
+MinIO needs a bucket created before the suite runs (it does not create one
+for you): `barrel-att-s3-test`, matching `MINIO_S3_TEST_BUCKET`'s default
+below.
+
+Garage needs a config file (see `test/e2e/garage.toml` for a working
+example), then, once the container is up:
+
+```console
+$ docker exec <container> /garage layout assign -z dc1 -c 1G <node-id>
+$ docker exec <container> /garage layout apply --version 1
+$ docker exec <container> /garage bucket create <bucket>
+$ docker exec <container> /garage key create <key-name>
+$ docker exec <container> /garage bucket allow <bucket> --key <key-name> --read --write
+```
+
+`<node-id>` comes from `docker exec <container> /garage node id -q`.
+
+## Env vars
+
+All optional for MinIO (defaults match the quick-start setup above);
+`GARAGE_S3_TEST_ACCESS_KEY`/`_SECRET_KEY` have no default -- the `garage`
+group skips without them.
+
+```
+MINIO_S3_TEST_ENDPOINT    (default http://127.0.0.1:19000)
+MINIO_S3_TEST_ACCESS_KEY  (default minioadmin)
+MINIO_S3_TEST_SECRET_KEY  (default minioadmin)
+MINIO_S3_TEST_REGION      (default us-east-1)
+MINIO_S3_TEST_BUCKET      (default barrel-att-s3-test)
+
+GARAGE_S3_TEST_ENDPOINT    (default http://127.0.0.1:13900)
+GARAGE_S3_TEST_ACCESS_KEY  (no default -- group skips without it)
+GARAGE_S3_TEST_SECRET_KEY  (no default -- group skips without it)
+GARAGE_S3_TEST_REGION      (default garage)
+GARAGE_S3_TEST_BUCKET      (default barrel-test)
+```

--- a/apps/barrel_att_s3/test/barrel_att_s3_SUITE.erl
+++ b/apps/barrel_att_s3/test/barrel_att_s3_SUITE.erl
@@ -1,0 +1,1345 @@
+%%%-------------------------------------------------------------------
+%%% @doc Test suite for barrel_att_s3_store: the whole-blob API (Step 2 --
+%%% open/close, put/get/delete/delete_all/fold, get_info, key scheme,
+%%% expected_digest) and the streaming/multipart API (Step 3 --
+%%% put_stream/write_chunk/finish_stream/abort_stream, get_stream/
+%%% read_chunk, the buffer-until-threshold single-put-vs-multipart
+%%% decision).
+%%%
+%%% Multipart tests use a 5 MiB part_size, not a tiny synthetic value:
+%%% real S3 (and MinIO) reject non-final parts under 5 MiB with
+%%% EntityTooSmall regardless of what part_size the *client* chooses to
+%%% buffer to, so a genuine multipart round trip needs real S3-sized data.
+%%% Garage is more lenient (a separate test below uses a 1 MiB part
+%%% against Garage only, to exercise that the part_size knob genuinely
+%%% changes behavior on a store that allows it).
+%%%
+%%% Runs against both MinIO and Garage (same test bodies, one per group),
+%%% since the two stores have deliberately different capability profiles
+%%% (see the plan) -- what's covered here is the part that must behave
+%%% identically everywhere. Connection details come from OS env vars; a
+%%% group skips cleanly if its store isn't configured/reachable, so this
+%%% suite is safe to run without either service present.
+%%%
+%%% Local setup this suite was developed against:
+%%%   MinIO:  docker run -p 19000:9000 -e MINIO_ROOT_USER=minioadmin \
+%%%           -e MINIO_ROOT_PASSWORD=minioadmin minio/minio server /data
+%%%   Garage: see apps/barrel_att_s3/test/README.md (bucket + key must be
+%%%           pre-provisioned; Garage keys can't create buckets themselves).
+%%%
+%%% Env vars (all optional for MinIO, defaults match the setup above;
+%%% GARAGE_S3_TEST_ACCESS_KEY/_SECRET_KEY have no default -- the garage
+%%% group skips without them):
+%%%   MINIO_S3_TEST_ENDPOINT/_ACCESS_KEY/_SECRET_KEY/_REGION/_BUCKET
+%%%   GARAGE_S3_TEST_ENDPOINT/_ACCESS_KEY/_SECRET_KEY/_REGION/_BUCKET
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_att_s3_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, groups/0, init_per_suite/1, end_per_suite/1,
+         init_per_group/2, end_per_group/2,
+         init_per_testcase/2, end_per_testcase/2]).
+
+-export([
+    open_missing_bucket/1,
+    put_get_roundtrip/1,
+    get_returns_not_found_for_missing/1,
+    get_info_returns_metadata/1,
+    get_info_not_found/1,
+    content_type_override_persists/1,
+    delete_removes_attachment/1,
+    delete_missing_is_ok/1,
+    fold_lists_attachment_names/1,
+    fold_stop_early/1,
+    delete_all_removes_every_attachment_for_doc/1,
+    delete_all_does_not_affect_other_docs/1,
+    expected_digest_match_succeeds/1,
+    expected_digest_mismatch_rejected/1,
+    key_too_long_rejected/1,
+    stream_small_single_put/1,
+    stream_large_multipart/1,
+    stream_abort_mid_multipart/1,
+    stream_digest_mismatch_small/1,
+    stream_digest_mismatch_multipart_aborts_upload/1,
+    stream_read_roundtrip/1,
+    stream_read_not_found/1,
+    stream_small_part_size_accepted_by_garage/1,
+    conditional_writes_capability_reflects_store/1,
+    default_put_stays_unconditional/1,
+    create_only_succeeds_on_fresh_key/1,
+    create_only_conflicts_on_existing_key/1,
+    expected_etag_match_succeeds/1,
+    expected_etag_stale_returns_conflict/1,
+    stream_create_only_conflicts_small_path/1,
+    stream_create_only_conflicts_multipart_path/1,
+    garage_create_only_fails_fast/1,
+    garage_expected_etag_fails_fast/1,
+    prefix_derived_from_db_name_on_first_open/1,
+    prefix_persists_across_reopen/1,
+    open_missing_db_name_on_fresh_path/1,
+    origin_hlc_newer_put_applies/1,
+    origin_hlc_stale_put_ignored/1,
+    origin_hlc_stale_delete_ignored/1,
+    origin_hlc_stream_stale_ignored_single_put/1,
+    origin_hlc_stream_stale_ignored_multipart/1,
+    att_changes_reflects_puts_and_deletes/1,
+    att_changes_pagination_and_since/1,
+    att_floor_and_sweep/1,
+    rebuild_feed_on_empty_store_returns_zero_rows/1,
+    rebuild_feed_recovers_lost_feed/1,
+    rebuild_feed_missing_origin_falls_back_to_min/1,
+    checkpoint_returns_fast_without_copying_bytes/1,
+    checkpoint_open_sweeps_and_converges/1,
+    checkpoint_branch_write_not_clobbered_by_sweep/1,
+    checkpoint_branch_delete_not_resurrected_by_sweep/1,
+    checkpoint_refuses_still_syncing_source/1,
+    destroy_removes_all_objects_under_prefix/1,
+    destroy_clears_fork_pending_marker/1,
+    resume_fork_sync_false_does_not_spawn_sweep/1
+]).
+
+-define(CASES, [
+    open_missing_bucket,
+    put_get_roundtrip,
+    get_returns_not_found_for_missing,
+    get_info_returns_metadata,
+    get_info_not_found,
+    content_type_override_persists,
+    delete_removes_attachment,
+    delete_missing_is_ok,
+    fold_lists_attachment_names,
+    fold_stop_early,
+    delete_all_removes_every_attachment_for_doc,
+    delete_all_does_not_affect_other_docs,
+    expected_digest_match_succeeds,
+    expected_digest_mismatch_rejected,
+    key_too_long_rejected,
+    stream_small_single_put,
+    stream_large_multipart,
+    stream_abort_mid_multipart,
+    stream_digest_mismatch_small,
+    stream_digest_mismatch_multipart_aborts_upload,
+    stream_read_roundtrip,
+    stream_read_not_found,
+    conditional_writes_capability_reflects_store,
+    default_put_stays_unconditional,
+    prefix_derived_from_db_name_on_first_open,
+    prefix_persists_across_reopen,
+    open_missing_db_name_on_fresh_path,
+    origin_hlc_newer_put_applies,
+    origin_hlc_stale_put_ignored,
+    origin_hlc_stale_delete_ignored,
+    origin_hlc_stream_stale_ignored_single_put,
+    origin_hlc_stream_stale_ignored_multipart,
+    att_changes_reflects_puts_and_deletes,
+    att_changes_pagination_and_since,
+    att_floor_and_sweep,
+    rebuild_feed_on_empty_store_returns_zero_rows,
+    rebuild_feed_recovers_lost_feed,
+    rebuild_feed_missing_origin_falls_back_to_min,
+    checkpoint_returns_fast_without_copying_bytes,
+    checkpoint_open_sweeps_and_converges,
+    checkpoint_branch_write_not_clobbered_by_sweep,
+    checkpoint_branch_delete_not_resurrected_by_sweep,
+    checkpoint_refuses_still_syncing_source,
+    destroy_removes_all_objects_under_prefix,
+    destroy_clears_fork_pending_marker,
+    resume_fork_sync_false_does_not_spawn_sweep
+]).
+
+%% MinIO has verifiably enforced If-Match/If-None-Match since 2023; Garage
+%% cannot at all, by its own documented design. Run the actual
+%% conflict-detection assertions only where they mean something.
+-define(MINIO_ONLY_CASES, [
+    create_only_succeeds_on_fresh_key,
+    create_only_conflicts_on_existing_key,
+    expected_etag_match_succeeds,
+    expected_etag_stale_returns_conflict,
+    stream_create_only_conflicts_small_path,
+    stream_create_only_conflicts_multipart_path
+]).
+
+-define(GARAGE_ONLY_CASES, [
+    stream_small_part_size_accepted_by_garage,
+    garage_create_only_fails_fast,
+    garage_expected_etag_fails_fast
+]).
+
+%% 5 MiB: the real S3/MinIO minimum for a non-final multipart part,
+%% independent of whatever part_size the client buffers to.
+-define(PART_SIZE, 5 * 1024 * 1024).
+
+%%====================================================================
+%% CT Callbacks
+%%====================================================================
+
+all() ->
+    [{group, minio}, {group, garage}].
+
+groups() ->
+    [
+        {minio, [sequence], ?CASES ++ ?MINIO_ONLY_CASES},
+        {garage, [sequence], ?CASES ++ ?GARAGE_ONLY_CASES}
+    ].
+
+init_per_suite(Config) ->
+    %% barrel_att_s3 now depends on barrel_docdb at the application level
+    %% (barrel_hlc:new_hlc/0, used for feed origin timestamps, needs
+    %% barrel_docdb's own supervisor-started clock process), so
+    %% ensure_all_started(barrel_att_s3) already covers this -- kept
+    %% explicit since this suite exercises the S3 backend on its own,
+    %% never through a running barrel_db_server.
+    {ok, _} = application:ensure_all_started(barrel_att_s3),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(minio, Config) ->
+    S3Opts = barrel_att_s3_test_support:minio_opts(),
+    case barrel_att_s3_test_support:reachable(S3Opts) of
+        true ->
+            Client = livery_s3:new(maps:without([bucket], S3Opts)),
+            Bucket = maps:get(bucket, S3Opts),
+            case livery_s3:create_bucket(Client, Bucket) of
+                ok -> ok;
+                {error, {s3, <<"BucketAlreadyOwnedByYou">>, _, _}} -> ok;
+                {error, {s3, <<"BucketAlreadyExists">>, _, _}} -> ok;
+                {error, Reason} -> ct:fail({minio_bucket_setup_failed, Reason})
+            end,
+            [{store, minio}, {s3_opts, S3Opts} | Config];
+        false ->
+            {skip, {minio_not_reachable, maps:get(endpoint, S3Opts)}}
+    end;
+init_per_group(garage, Config) ->
+    case barrel_att_s3_test_support:garage_opts() of
+        undefined ->
+            {skip, garage_credentials_not_configured};
+        S3Opts ->
+            case barrel_att_s3_test_support:reachable(S3Opts) of
+                true -> [{store, garage}, {s3_opts, S3Opts} | Config];
+                false -> {skip, {garage_not_reachable, maps:get(endpoint, S3Opts)}}
+            end
+    end.
+
+end_per_group(_Group, _Config) ->
+    ok.
+
+init_per_testcase(TestCase, Config) ->
+    S3Opts = ?config(s3_opts, Config),
+    %% priv_dir is shared across the whole suite run, not per-group, and
+    %% both groups run the same-named test cases -- without the store
+    %% prefix, minio.foo and garage.foo would open the same local feed.db
+    %% path and silently see each other's feed state (a real bug this
+    %% caught: att_floor_and_sweep saw a floor already set, left over from
+    %% the other group's earlier run of the same-named test).
+    Store = atom_to_binary(?config(store, Config), utf8),
+    DbName = <<Store/binary, "-", (atom_to_binary(TestCase, utf8))/binary>>,
+    Path = filename:join(?config(priv_dir, Config), binary_to_list(DbName)),
+    {ok, AttRef} = barrel_att_s3_store:open(Path,
+                                            #{s3 => S3Opts#{part_size => ?PART_SIZE},
+                                              db_name => DbName}),
+    [{att_ref, AttRef}, {db_name, DbName}, {path, Path} | Config].
+
+end_per_testcase(_TestCase, Config) ->
+    ok = barrel_att_s3_store:close(?config(att_ref, Config)),
+    ok.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+%% Polls Fun (a 0-arity predicate) every 50ms until it returns true or
+%% TimeoutMs elapses, at which point the test fails with a clear reason
+%% rather than a plain assertion mismatch on whatever the last poll saw.
+wait_until(Fun, TimeoutMs) ->
+    wait_until(Fun, TimeoutMs, 50).
+
+wait_until(Fun, TimeoutMs, _IntervalMs) when TimeoutMs =< 0 ->
+    case Fun() of
+        true -> ok;
+        false -> ct:fail(wait_until_timeout)
+    end;
+wait_until(Fun, TimeoutMs, IntervalMs) ->
+    case Fun() of
+        true -> ok;
+        false ->
+            timer:sleep(IntervalMs),
+            wait_until(Fun, TimeoutMs - IntervalMs, IntervalMs)
+    end.
+
+%% @private Builds a branch's att_ref by hand from checkpoint/2's own
+%% on-disk output (the persisted s3_prefix marker, a raw rocksdb:open of
+%% the checkpointed feed.db) instead of a real open/2 -- deliberately, so
+%% no sweep is ever spawned for BranchPath and a test can exercise its
+%% pre-sweep, pre-open state deterministically. Returns the feed handle
+%% too, so the caller can rocksdb:close/1 it -- always inside try/after,
+%% since an assertion failure between opening it and closing it would
+%% otherwise leak the handle for the rest of the CT run.
+open_branch_att_ref_raw(SourceAttRef, BranchPath) ->
+    {ok, PrefixBin} = file:read_file(filename:join(BranchPath, "s3_prefix")),
+    {ok, FeedRef} = rocksdb:open(filename:join(BranchPath, "feed.db"), []),
+    BranchAttRef = SourceAttRef#{feed_ref => FeedRef, prefix => PrefixBin,
+                                 path => BranchPath},
+    {BranchAttRef, FeedRef}.
+
+%%====================================================================
+%% Test Cases
+%%====================================================================
+
+open_missing_bucket(_Config) ->
+    ?assertEqual({error, missing_bucket},
+                 barrel_att_s3_store:open("/tmp/unused", #{s3 => #{}})).
+
+%% The per-testcase att_ref from init_per_testcase already IS a first-ever
+%% open of a fresh path, with db_name set to the testcase's own name -- this
+%% just asserts the prefix open/2 derived matches it exactly, since every
+%% other test in this suite implicitly depends on that being true.
+prefix_derived_from_db_name_on_first_open(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    ?assertEqual(DbName, maps:get(prefix, AttRef)).
+
+%% Opens its own dedicated path/att_ref rather than reusing the per-testcase
+%% one from init_per_testcase (this test needs to close and reopen it, and
+%% the per-testcase one is end_per_testcase's to close). Reopens the same
+%% path with a DIFFERENT db_name than the original open used, and confirms
+%% the prefix -- and so the actual S3 keys an attachment put through it
+%% lands under -- is still the ORIGINAL one, read from the persisted marker
+%% rather than re-derived. This is the property M2's branching design
+%% depends on (a checkpointed branch's marker is what makes its prefix
+%% stick across opens), and also what keeps an existing M1-created store's
+%% keys from moving on its first M2-code open.
+prefix_persists_across_reopen(Config) ->
+    DbName = ?config(db_name, Config),
+    Path = ?config(path, Config) ++ "-persist",
+    S3Opts = ?config(s3_opts, Config),
+    {ok, AttRef} = barrel_att_s3_store:open(Path,
+        #{s3 => S3Opts#{part_size => ?PART_SIZE}, db_name => DbName}),
+    DocId = <<"doc1">>,
+    Data = <<"persists across reopen">>,
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"note.txt">>, Data),
+    ok = barrel_att_s3_store:close(AttRef),
+
+    DifferentDbName = <<"not-", DbName/binary>>,
+    {ok, Reopened} = barrel_att_s3_store:open(Path,
+        #{s3 => S3Opts#{part_size => ?PART_SIZE}, db_name => DifferentDbName}),
+    ?assertEqual(DbName, maps:get(prefix, Reopened)),
+    ?assertEqual({ok, Data},
+                 barrel_att_s3_store:get(Reopened, DifferentDbName, DocId, <<"note.txt">>)),
+    ok = barrel_att_s3_store:delete(Reopened, DifferentDbName, DocId, <<"note.txt">>),
+    ok = barrel_att_s3_store:close(Reopened).
+
+open_missing_db_name_on_fresh_path(Config) ->
+    S3Opts = ?config(s3_opts, Config),
+    FreshPath = ?config(path, Config) ++ "-no-db-name",
+    ?assertEqual({error, missing_db_name},
+                 barrel_att_s3_store:open(FreshPath, #{s3 => S3Opts#{part_size => ?PART_SIZE}})).
+
+%% barrel_hlc:min/0 as the "old" origin and barrel_hlc:new_hlc/0 as "new" --
+%% trivially ordered, no need to construct anything more elaborate to
+%% exercise the guard. index_get/4 reaches into the local feed directly
+%% (feed_ref is exposed on att_ref): Step 3 hasn't landed att_changes/4 yet,
+%% so this is the only way to confirm what actually got committed.
+origin_hlc_newer_put_applies(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    OldOrigin = barrel_hlc:min(),
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"origin.txt">>,
+                                      <<"first">>, #{origin_hlc => OldOrigin}),
+    NewOrigin = barrel_hlc:new_hlc(),
+    {ok, Info} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"origin.txt">>,
+                                        <<"second">>, #{origin_hlc => NewOrigin}),
+    ?assertMatch(#{length := 6}, Info),
+    ?assertEqual({ok, <<"second">>},
+                 barrel_att_s3_store:get(AttRef, DbName, DocId, <<"origin.txt">>)),
+    FeedRef = maps:get(feed_ref, AttRef),
+    {ok, IdxEntry} = barrel_att_feed:index_get(FeedRef, DbName, DocId, <<"origin.txt">>),
+    ?assertEqual(NewOrigin, maps:get(origin, IdxEntry)),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"origin.txt">>).
+
+origin_hlc_stale_put_ignored(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    NewOrigin = barrel_hlc:new_hlc(),
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"stale.txt">>,
+                                      <<"second">>, #{origin_hlc => NewOrigin}),
+    OldOrigin = barrel_hlc:min(),
+    Result = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"stale.txt">>,
+                                     <<"first">>, #{origin_hlc => OldOrigin}),
+    ?assertEqual({ok, ignored}, Result),
+    ?assertEqual({ok, <<"second">>},
+                 barrel_att_s3_store:get(AttRef, DbName, DocId, <<"stale.txt">>)),
+    FeedRef = maps:get(feed_ref, AttRef),
+    {ok, IdxEntry} = barrel_att_feed:index_get(FeedRef, DbName, DocId, <<"stale.txt">>),
+    ?assertEqual(NewOrigin, maps:get(origin, IdxEntry)),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"stale.txt">>).
+
+origin_hlc_stale_delete_ignored(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    NewOrigin = barrel_hlc:new_hlc(),
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"del.txt">>,
+                                      <<"data">>, #{origin_hlc => NewOrigin}),
+    OldOrigin = barrel_hlc:min(),
+    Result = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"del.txt">>,
+                                        #{origin_hlc => OldOrigin}),
+    ?assertEqual(ok, Result),
+    ?assertEqual({ok, <<"data">>},
+                 barrel_att_s3_store:get(AttRef, DbName, DocId, <<"del.txt">>)),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"del.txt">>).
+
+origin_hlc_stream_stale_ignored_single_put(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    NewOrigin = barrel_hlc:new_hlc(),
+    {ok, S1} = barrel_att_s3_store:put_stream(AttRef, DbName, DocId,
+        <<"stream-stale.txt">>, <<"text/plain">>, #{origin_hlc => NewOrigin}),
+    {ok, S2} = barrel_att_s3_store:write_chunk(S1, <<"second">>),
+    {ok, _} = barrel_att_s3_store:finish_stream(S2),
+
+    OldOrigin = barrel_hlc:min(),
+    {ok, T1} = barrel_att_s3_store:put_stream(AttRef, DbName, DocId,
+        <<"stream-stale.txt">>, <<"text/plain">>, #{origin_hlc => OldOrigin}),
+    {ok, T2} = barrel_att_s3_store:write_chunk(T1, <<"first">>),
+    Result = barrel_att_s3_store:finish_stream(T2),
+    ?assertEqual({ok, ignored}, Result),
+    ?assertEqual({ok, <<"second">>},
+                 barrel_att_s3_store:get(AttRef, DbName, DocId, <<"stream-stale.txt">>)),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"stream-stale.txt">>).
+
+%% Also confirms the multipart metadata self-copy (Step 2's
+%% attach_multipart_metadata/6) actually lands: get_info's digest wouldn't
+%% be populated otherwise, since custom metadata can't be set at
+%% create_multipart_upload time (the digest isn't known yet) and S3 has no
+%% way to attach it at completion either.
+origin_hlc_stream_stale_ignored_multipart(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    NewOrigin = barrel_hlc:new_hlc(),
+    Part1 = binary:copy(<<"a">>, ?PART_SIZE),
+    {ok, S1} = barrel_att_s3_store:put_stream(AttRef, DbName, DocId,
+        <<"stream-stale-mp.bin">>, <<"application/octet-stream">>,
+        #{origin_hlc => NewOrigin}),
+    {ok, S2} = barrel_att_s3_store:write_chunk(S1, Part1),
+    ?assertNotEqual(undefined, maps:get(multipart, S2)),
+    {ok, S3} = barrel_att_s3_store:write_chunk(S2, <<"tail">>),
+    {ok, Info} = barrel_att_s3_store:finish_stream(S3),
+    ?assertMatch(#{chunked := true}, Info),
+    {ok, GotInfo} = barrel_att_s3_store:get_info(AttRef, DbName, DocId,
+                                                 <<"stream-stale-mp.bin">>),
+    ?assertNotEqual(undefined, maps:get(digest, GotInfo)),
+
+    OldOrigin = barrel_hlc:min(),
+    {ok, T1} = barrel_att_s3_store:put_stream(AttRef, DbName, DocId,
+        <<"stream-stale-mp.bin">>, <<"application/octet-stream">>,
+        #{origin_hlc => OldOrigin}),
+    {ok, T2} = barrel_att_s3_store:write_chunk(T1, binary:copy(<<"b">>, ?PART_SIZE)),
+    Result = barrel_att_s3_store:finish_stream(T2),
+    ?assertEqual({ok, ignored}, Result),
+    Expected = <<Part1/binary, "tail">>,
+    ?assertEqual({ok, Expected},
+                 barrel_att_s3_store:get(AttRef, DbName, DocId, <<"stream-stale-mp.bin">>)),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"stream-stale-mp.bin">>).
+
+%% barrel_att_feed itself (key encoding, LWW tie-breaking, pagination
+%% internals, sweep mechanics) has its own dedicated suite
+%% (barrel_att_feed_SUITE, in barrel_docdb). These just confirm the S3
+%% backend's delegation wiring -- feed_ref/DbName threaded through
+%% correctly -- against real puts/deletes, not barrel_att_feed's own logic.
+att_changes_reflects_puts_and_deletes(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"a.txt">>, <<"aa">>),
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"b.txt">>, <<"bb">>),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"a.txt">>),
+
+    {ok, Entries, _LastSeq} = barrel_att_s3_store:att_changes(AttRef, DbName, first, #{}),
+    ByName = [{maps:get(name, E), maps:get(op, E)} || E <- Entries],
+    ?assert(lists:member({<<"a.txt">>, delete}, ByName)),
+    ?assert(lists:member({<<"b.txt">>, put}, ByName)),
+
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"b.txt">>).
+
+att_changes_pagination_and_since(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"a.txt">>, <<"aa">>),
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"b.txt">>, <<"bb">>),
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"c.txt">>, <<"cc">>),
+
+    {ok, Batch1, LastSeq1} = barrel_att_s3_store:att_changes(AttRef, DbName, first,
+                                                             #{limit => 2}),
+    ?assertEqual(2, length(Batch1)),
+    {ok, Batch2, _LastSeq2} = barrel_att_s3_store:att_changes(AttRef, DbName, LastSeq1, #{}),
+    ?assertEqual(1, length(Batch2)),
+
+    Names1 = [maps:get(name, E) || E <- Batch1],
+    Names2 = [maps:get(name, E) || E <- Batch2],
+    ?assertEqual([], Names1 -- (Names1 -- Names2)),  %% no overlap between batches
+    ?assertEqual([<<"a.txt">>, <<"b.txt">>, <<"c.txt">>], lists:sort(Names1 ++ Names2)),
+
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"a.txt">>),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"b.txt">>),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"c.txt">>).
+
+att_floor_and_sweep(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    ?assertEqual(undefined, barrel_att_s3_store:att_floor(AttRef, DbName)),
+
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"a.txt">>, <<"aa">>),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"a.txt">>),
+
+    Cutoff = barrel_hlc:new_hlc(),
+    {ok, #{tombstones_swept := Swept}} =
+        barrel_att_s3_store:sweep_att_feed(AttRef, DbName, Cutoff),
+    ?assertEqual(1, Swept),
+    ?assertEqual(Cutoff, barrel_att_s3_store:att_floor(AttRef, DbName)),
+
+    %% put rows are never swept, only delete tombstones -- the a.txt put
+    %% was already replaced by its own delete's tombstone (one feed row
+    %% per (doc, attname), moved on every write), so sweeping that
+    %% tombstone leaves nothing in the feed at all.
+    {ok, Entries, _} = barrel_att_s3_store:att_changes(AttRef, DbName, first, #{}),
+    ?assertEqual([], Entries).
+
+rebuild_feed_on_empty_store_returns_zero_rows(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    ?assertEqual({ok, #{rows => 0}}, barrel_att_s3_store:rebuild_feed(AttRef, DbName)).
+
+%% Opens its own dedicated path (same DbName as the per-testcase config,
+%% but a fresh directory -- avoids double-closing the shared att_ref from
+%% init_per_testcase, same reasoning as prefix_persists_across_reopen).
+%% Puts two attachments, deletes one, then wipes ONLY feed.db (not the
+%% s3_prefix marker) to simulate a lost/corrupted local feed while leaving
+%% the store's actual identity and S3 objects untouched. rebuild_feed/2
+%% must recover the surviving attachment -- with its REAL origin, read
+%% back from the object's own ?META_ORIGIN, not the barrel_hlc:min()
+%% fallback -- and must not resurrect the deleted one (its object is gone,
+%% so there is nothing left to rebuild a row from).
+rebuild_feed_recovers_lost_feed(Config) ->
+    DbName = ?config(db_name, Config),
+    Path = ?config(path, Config) ++ "-rebuild",
+    S3Opts = ?config(s3_opts, Config),
+    OpenOpts = #{s3 => S3Opts#{part_size => ?PART_SIZE}, db_name => DbName},
+    {ok, AttRef} = barrel_att_s3_store:open(Path, OpenOpts),
+    DocId = <<"doc1">>,
+    KeepOrigin = barrel_hlc:new_hlc(),
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"keep.txt">>,
+                                      <<"keep-me">>, #{origin_hlc => KeepOrigin}),
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"gone.txt">>,
+                                      <<"gone">>, #{origin_hlc => barrel_hlc:new_hlc()}),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"gone.txt">>),
+    ok = barrel_att_s3_store:close(AttRef),
+
+    ok = file:del_dir_r(filename:join(Path, "feed.db")),
+    {ok, Reopened} = barrel_att_s3_store:open(Path, OpenOpts),
+    ?assertEqual(undefined, barrel_att_s3_store:att_floor(Reopened, DbName)),
+    ?assertEqual({ok, [], first},
+                 barrel_att_s3_store:att_changes(Reopened, DbName, first, #{})),
+
+    ?assertEqual({ok, #{rows => 1}},
+                 barrel_att_s3_store:rebuild_feed(Reopened, DbName)),
+
+    {ok, Entries, _} = barrel_att_s3_store:att_changes(Reopened, DbName, first, #{}),
+    ?assertMatch([#{name := <<"keep.txt">>, op := put, length := 7}], Entries),
+    FeedRef = maps:get(feed_ref, Reopened),
+    {ok, IdxEntry} = barrel_att_feed:index_get(FeedRef, DbName, DocId, <<"keep.txt">>),
+    ?assertEqual(KeepOrigin, maps:get(origin, IdxEntry)),
+    ?assertEqual(not_found,
+                 barrel_att_feed:index_get(FeedRef, DbName, DocId, <<"gone.txt">>)),
+
+    %% Safe to re-run: rebuilding again over the same bucket state doesn't
+    %% duplicate or otherwise disturb the recovered row.
+    ?assertEqual({ok, #{rows => 1}},
+                 barrel_att_s3_store:rebuild_feed(Reopened, DbName)),
+    {ok, Entries2, _} = barrel_att_s3_store:att_changes(Reopened, DbName, first, #{}),
+    ?assertEqual(1, length(Entries2)),
+
+    ok = barrel_att_s3_store:delete(Reopened, DbName, DocId, <<"keep.txt">>),
+    ok = barrel_att_s3_store:close(Reopened).
+
+%% Writes an object directly via livery_s3 (bypassing the store API
+%% entirely), with a digest but no ?META_ORIGIN -- standing in for a
+%% pre-M2 object that predates that metadata key. rebuild_feed/2 must
+%% still recover a row for it, falling back to barrel_hlc:min() as its
+%% origin (so any real write, local or remote, wins the LWW race against
+%% it), the same escape hatch blob's own rebuild_feed/2 always uses.
+rebuild_feed_missing_origin_falls_back_to_min(Config) ->
+    DbName = ?config(db_name, Config),
+    Path = ?config(path, Config) ++ "-rebuild-legacy",
+    S3Opts = ?config(s3_opts, Config),
+    OpenOpts = #{s3 => S3Opts#{part_size => ?PART_SIZE}, db_name => DbName},
+    {ok, AttRef} = barrel_att_s3_store:open(Path, OpenOpts),
+    #{client := Client, bucket := Bucket, prefix := Prefix} = AttRef,
+    DocId = <<"doc1">>,
+    AttName = <<"legacy.bin">>,
+    Key = <<Prefix/binary, "/", (binary:encode_hex(DocId, lowercase))/binary, "/",
+            AttName/binary>>,
+    Data = <<"pre-M2 object, no origin metadata">>,
+    Digest = <<"sha256-", (binary:encode_hex(crypto:hash(sha256, Data), lowercase))/binary>>,
+    {ok, _} = livery_s3:put_object(Client, Bucket, Key, Data,
+                                   #{content_type => <<"application/octet-stream">>,
+                                     metadata => #{<<"digest">> => Digest}}),
+
+    ?assertEqual({ok, #{rows => 1}}, barrel_att_s3_store:rebuild_feed(AttRef, DbName)),
+    FeedRef = maps:get(feed_ref, AttRef),
+    {ok, IdxEntry} = barrel_att_feed:index_get(FeedRef, DbName, DocId, AttName),
+    ?assertEqual(barrel_hlc:min(), maps:get(origin, IdxEntry)),
+    ?assertEqual(Digest, maps:get(digest, IdxEntry)),
+
+    ok = livery_s3:delete_object(Client, Bucket, Key),
+    ok = barrel_att_s3_store:close(AttRef).
+
+%%====================================================================
+%% checkpoint/2: non-blocking eager-copy branching
+%%====================================================================
+%%
+%% checkpoint/2 is called directly here (not through barrel_docdb:
+%% branch_db/3 / barrel_timeline:fork/6), mirroring how barrel_db_server's
+%% checkpoint_to/3 actually calls it: on the SOURCE's already-open att_ref,
+%% targeting the branch's brand-new (not yet existing) directory.
+
+%% Deterministic (no timing dependency): checkpoint/2 itself only does the
+%% cheap local part -- it never spawns the copy sweep (see the moduledoc's
+%% "Branching" section), so as long as this test never calls open/2 on
+%% BranchPath, NOTHING copies any bytes, no matter how long the test takes
+%% to get around to checking. The branch att_ref here is therefore built by
+%% hand from the checkpoint's own on-disk output (the persisted s3_prefix
+%% marker, a raw rocksdb:open of the checkpointed feed.db) rather than via
+%% open/2, specifically to avoid triggering the real sweep.
+checkpoint_returns_fast_without_copying_bytes(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    Path = ?config(path, Config),
+    DocId = <<"doc1">>,
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"a.txt">>, <<"alpha">>),
+
+    BranchPath = Path ++ "-branch-fast",
+    ?assertEqual(ok, barrel_att_s3_store:checkpoint(AttRef, BranchPath)),
+
+    %% the new prefix is already persisted and differs from the parent's
+    {ok, OldPrefixBin} = file:read_file(filename:join(Path, "s3_prefix")),
+    {ok, NewPrefixBin} = file:read_file(filename:join(BranchPath, "s3_prefix")),
+    ?assertNotEqual(OldPrefixBin, NewPrefixBin),
+
+    %% the copied feed rows are keyed under the SOURCE's DbName (a straight
+    %% byte-for-byte checkpoint) -- exactly matching a real branch, whose
+    %% keyspace always resolves to its parent's name (barrel_keyspace), so
+    %% every call against it, including on the branch side, uses DbName too
+    %% (not some new name of the branch's own).
+    {BranchAttRef, BranchFeedRef} = open_branch_att_ref_raw(AttRef, BranchPath),
+    try
+        %% the branch's local feed already knows about a.txt (a straight
+        %% RocksDB checkpoint), but the bytes have not been copied -- get/4,
+        %% get_info/4, and get_stream/4 all report the distinguishable pending
+        %% error rather than not_found or blocking
+        ?assertEqual({error, {att_sync_pending, {DocId, <<"a.txt">>}}},
+                     barrel_att_s3_store:get(BranchAttRef, DbName, DocId, <<"a.txt">>)),
+        ?assertEqual({error, {att_sync_pending, {DocId, <<"a.txt">>}}},
+                     barrel_att_s3_store:get_info(BranchAttRef, DbName, DocId, <<"a.txt">>)),
+        ?assertEqual({error, {att_sync_pending, {DocId, <<"a.txt">>}}},
+                     barrel_att_s3_store:get_stream(BranchAttRef, DbName, DocId, <<"a.txt">>)),
+
+        %% an attachment that genuinely never existed is still plain not_found,
+        %% not pending -- the feed has no row for it at all
+        ?assertEqual({error, not_found},
+                     barrel_att_s3_store:get(BranchAttRef, DbName, DocId, <<"never.txt">>))
+    after
+        ok = rocksdb:close(BranchFeedRef)
+    end,
+    ok = file:del_dir_r(BranchPath),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"a.txt">>).
+
+%% The real end-to-end path: checkpoint/2, then a real open/2 on the
+%% branch (as barrel_timeline:fork/6 always does immediately afterward),
+%% which spawns the copy sweep. Not a hard timing assertion -- polls with
+%% a generous bound until every attachment converges, proving the sweep
+%% actually finishes and the branch ends up byte-identical to the parent
+%% for everything neither side touched after the fork.
+checkpoint_open_sweeps_and_converges(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    Path = ?config(path, Config),
+    S3Opts = ?config(s3_opts, Config),
+    DocId = <<"doc1">>,
+    Names = [integer_to_binary(N) || N <- lists:seq(1, 8)],
+    lists:foreach(
+        fun(Name) ->
+            {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, Name,
+                                              <<"data-", Name/binary>>)
+        end,
+        Names),
+
+    BranchPath = Path ++ "-branch-converge",
+    ?assertEqual(ok, barrel_att_s3_store:checkpoint(AttRef, BranchPath)),
+
+    %% db_name here only ever seeds a fresh prefix on a marker-less open --
+    %% BranchPath already carries checkpoint/2's marker, so this value is
+    %% unused for that purpose; every per-call DbName below is the SOURCE's
+    %% own name, matching a real branch's keyspace (see barrel_keyspace).
+    {ok, Branch} = barrel_att_s3_store:open(BranchPath,
+        #{s3 => S3Opts#{part_size => ?PART_SIZE}, db_name => DbName}),
+
+    ok = wait_until(
+        fun() ->
+            lists:all(
+                fun(Name) ->
+                    barrel_att_s3_store:get(Branch, DbName, DocId, Name) =:=
+                        {ok, <<"data-", Name/binary>>}
+                end,
+                Names)
+        end,
+        10000),
+
+    ok = barrel_att_s3_store:close(Branch),
+    ok = file:del_dir_r(BranchPath),
+    lists:foreach(
+        fun(Name) -> ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, Name) end,
+        Names).
+
+%% A write on the branch to a key the sweep has not reached yet must
+%% survive: the sweep's head_object-before-copy check is exactly what
+%% prevents it from later overwriting this newer, independent write with
+%% the stale parent copy.
+checkpoint_branch_write_not_clobbered_by_sweep(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    Path = ?config(path, Config),
+    S3Opts = ?config(s3_opts, Config),
+    DocId = <<"doc1">>,
+    Names = [integer_to_binary(N) || N <- lists:seq(1, 8)],
+    lists:foreach(
+        fun(Name) ->
+            {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, Name,
+                                              <<"parent-", Name/binary>>)
+        end,
+        Names),
+
+    BranchPath = Path ++ "-branch-write",
+    ?assertEqual(ok, barrel_att_s3_store:checkpoint(AttRef, BranchPath)),
+
+    {ok, Branch} = barrel_att_s3_store:open(BranchPath,
+        #{s3 => S3Opts#{part_size => ?PART_SIZE}, db_name => DbName}),
+
+    %% overwrite one attachment on the branch immediately -- races the
+    %% sweep on purpose
+    Target = lists:nth(1, Names),
+    {ok, _} = barrel_att_s3_store:put(Branch, DbName, DocId, Target,
+                                      <<"branch-owns-this">>),
+
+    ok = wait_until(
+        fun() ->
+            lists:all(
+                fun(Name) when Name =:= Target ->
+                        barrel_att_s3_store:get(Branch, DbName, DocId, Name) =:=
+                            {ok, <<"branch-owns-this">>};
+                   (Name) ->
+                        barrel_att_s3_store:get(Branch, DbName, DocId, Name) =:=
+                            {ok, <<"parent-", Name/binary>>}
+                end,
+                Names)
+        end,
+        10000),
+
+    %% and it is still the branch's value, not clobbered after convergence
+    ?assertEqual({ok, <<"branch-owns-this">>},
+                 barrel_att_s3_store:get(Branch, DbName, DocId, Target)),
+
+    ok = barrel_att_s3_store:close(Branch),
+    ok = file:del_dir_r(BranchPath),
+    lists:foreach(
+        fun(Name) -> ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, Name) end,
+        Names).
+
+%% A delete on the branch for a key the sweep has not reached yet must
+%% also survive: the sweep consults the branch's own feed (not just a
+%% bare existence check) before copying, so it does not resurrect
+%% something the branch has already tombstoned.
+checkpoint_branch_delete_not_resurrected_by_sweep(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    Path = ?config(path, Config),
+    S3Opts = ?config(s3_opts, Config),
+    DocId = <<"doc1">>,
+    Names = [integer_to_binary(N) || N <- lists:seq(1, 8)],
+    lists:foreach(
+        fun(Name) ->
+            {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, Name,
+                                              <<"parent-", Name/binary>>)
+        end,
+        Names),
+
+    BranchPath = Path ++ "-branch-delete",
+    ?assertEqual(ok, barrel_att_s3_store:checkpoint(AttRef, BranchPath)),
+
+    {ok, Branch} = barrel_att_s3_store:open(BranchPath,
+        #{s3 => S3Opts#{part_size => ?PART_SIZE}, db_name => DbName}),
+
+    Target = lists:nth(1, Names),
+    ok = barrel_att_s3_store:delete(Branch, DbName, DocId, Target),
+
+    ok = wait_until(
+        fun() ->
+            lists:all(
+                fun(Name) when Name =:= Target ->
+                        barrel_att_s3_store:get(Branch, DbName, DocId, Name) =:=
+                            {error, not_found};
+                   (Name) ->
+                        barrel_att_s3_store:get(Branch, DbName, DocId, Name) =:=
+                            {ok, <<"parent-", Name/binary>>}
+                end,
+                Names)
+        end,
+        10000),
+
+    ?assertEqual({error, not_found},
+                 barrel_att_s3_store:get(Branch, DbName, DocId, Target)),
+
+    ok = barrel_att_s3_store:close(Branch),
+    ok = file:del_dir_r(BranchPath),
+    lists:foreach(
+        fun(Name) when Name =:= Target -> ok;
+           (Name) -> ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, Name)
+        end,
+        Names).
+
+%% Forking a source that is itself still mid-sync (its own fork_pending
+%% marker still present) is refused, not silently allowed to produce an
+%% incomplete copy -- v1 lineage never actually reaches this via
+%% barrel_docdb:branch_db/3 (branching a branch is rejected earlier), but
+%% checkpoint/2 enforces it directly regardless, as a safety net.
+checkpoint_refuses_still_syncing_source(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    Path = ?config(path, Config),
+    DocId = <<"doc1">>,
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"a.txt">>, <<"alpha">>),
+
+    BranchPath = Path ++ "-branch-source",
+    ?assertEqual(ok, barrel_att_s3_store:checkpoint(AttRef, BranchPath)),
+
+    %% BranchPath now carries its own fork_pending marker (from the
+    %% checkpoint above) -- built by hand so no sweep is spawned and the
+    %% marker is still guaranteed present
+    {BranchAttRef, BranchFeedRef} = open_branch_att_ref_raw(AttRef, BranchPath),
+    try
+        GrandBranchPath = Path ++ "-branch-source-grandchild",
+        ?assertEqual({error, {fork_sync_pending, retry}},
+                     barrel_att_s3_store:checkpoint(BranchAttRef, GrandBranchPath))
+    after
+        ok = rocksdb:close(BranchFeedRef)
+    end,
+    ok = file:del_dir_r(BranchPath),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"a.txt">>).
+
+%%====================================================================
+%% destroy/2: S3 object cleanup on delete_db
+%%====================================================================
+
+destroy_removes_all_objects_under_prefix(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    #{client := Client, bucket := Bucket, prefix := Prefix} = AttRef,
+    DocId = <<"doc1">>,
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"a.txt">>, <<"alpha">>),
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"b.txt">>, <<"beta">>),
+
+    ?assertEqual(ok, barrel_att_s3_store:destroy(AttRef, DbName)),
+
+    {ok, #{objects := Objects}} =
+        livery_s3:list_objects_all(Client, Bucket, #{prefix => <<Prefix/binary, "/">>}),
+    ?assertEqual([], Objects).
+
+%% Built by hand (same reasoning as the checkpoint tests): a real open/2
+%% on BranchPath would spawn the copy sweep, which is not what this test
+%% is about. Writes directly to the branch's own prefix first so destroy
+%% has a real object to remove, not just an empty marker to clear.
+destroy_clears_fork_pending_marker(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    Path = ?config(path, Config),
+    DocId = <<"doc1">>,
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"a.txt">>, <<"alpha">>),
+
+    BranchPath = Path ++ "-branch-destroy",
+    ?assertEqual(ok, barrel_att_s3_store:checkpoint(AttRef, BranchPath)),
+    ?assert(filelib:is_regular(filename:join(BranchPath, "fork_pending"))),
+
+    {BranchAttRef, BranchFeedRef} = open_branch_att_ref_raw(AttRef, BranchPath),
+    try
+        {ok, _} = barrel_att_s3_store:put(BranchAttRef, DbName, DocId, <<"branch-own.txt">>,
+                                          <<"own-data">>),
+
+        ?assertEqual(ok, barrel_att_s3_store:destroy(BranchAttRef, DbName)),
+        ?assertNot(filelib:is_regular(filename:join(BranchPath, "fork_pending"))),
+
+        #{client := Client, bucket := Bucket, prefix := BranchPrefixBin} = BranchAttRef,
+        {ok, #{objects := Objects}} =
+            livery_s3:list_objects_all(Client, Bucket, #{prefix => <<BranchPrefixBin/binary, "/">>}),
+        ?assertEqual([], Objects)
+    after
+        ok = rocksdb:close(BranchFeedRef)
+    end,
+    ok = file:del_dir_r(BranchPath),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"a.txt">>).
+
+%% Options.resume_fork_sync => false (used by
+%% barrel_docdb:maybe_destroy_closed_att_store/3 right before an
+%% immediate destroy/2, so a sweep is never spawned just to be abandoned)
+%% must not spawn the copy sweep even though a fork_pending marker is
+%% present -- proven by: the marker is still there after open (a real
+%% sweep would eventually clear it), and the inherited attachment is
+%% still sync_pending (a real sweep would eventually copy it).
+resume_fork_sync_false_does_not_spawn_sweep(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    Path = ?config(path, Config),
+    S3Opts = ?config(s3_opts, Config),
+    DocId = <<"doc1">>,
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"a.txt">>, <<"alpha">>),
+
+    BranchPath = Path ++ "-branch-no-resume",
+    ?assertEqual(ok, barrel_att_s3_store:checkpoint(AttRef, BranchPath)),
+    ?assert(filelib:is_regular(filename:join(BranchPath, "fork_pending"))),
+
+    {ok, Branch} = barrel_att_s3_store:open(BranchPath,
+        #{s3 => S3Opts#{part_size => ?PART_SIZE}, db_name => DbName,
+          resume_fork_sync => false}),
+
+    %% a real sweep is idempotent but not instant -- give one a bounded
+    %% moment to have done SOMETHING if it had wrongly been spawned, then
+    %% confirm nothing changed
+    timer:sleep(500),
+    ?assert(filelib:is_regular(filename:join(BranchPath, "fork_pending"))),
+    ?assertEqual({error, {att_sync_pending, {DocId, <<"a.txt">>}}},
+                 barrel_att_s3_store:get(Branch, DbName, DocId, <<"a.txt">>)),
+
+    ok = barrel_att_s3_store:close(Branch),
+    ok = file:del_dir_r(BranchPath),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"a.txt">>).
+
+put_get_roundtrip(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    Data = <<"hello world">>,
+    {ok, Info} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"note.txt">>, Data),
+    ?assertMatch(#{name := <<"note.txt">>, length := 11, chunked := false}, Info),
+    ?assertEqual({ok, Data},
+                 barrel_att_s3_store:get(AttRef, DbName, DocId, <<"note.txt">>)),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"note.txt">>).
+
+get_returns_not_found_for_missing(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    ?assertEqual({error, not_found},
+                 barrel_att_s3_store:get(AttRef, DbName, <<"doc1">>, <<"nope.txt">>)).
+
+get_info_returns_metadata(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    Data = <<"some bytes">>,
+    {ok, #{digest := Digest}} =
+        barrel_att_s3_store:put(AttRef, DbName, DocId, <<"a.bin">>, Data),
+    {ok, InfoResult} = barrel_att_s3_store:get_info(AttRef, DbName, DocId, <<"a.bin">>),
+    ?assertMatch(#{name := <<"a.bin">>, length := 10, digest := Digest},
+                 InfoResult),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"a.bin">>).
+
+get_info_not_found(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    ?assertEqual({error, not_found},
+                 barrel_att_s3_store:get_info(AttRef, DbName, <<"doc1">>, <<"nope">>)).
+
+%% barrel_att_store_blob's get_info recomputes content-type from the
+%% filename for small attachments, ignoring any override the caller gave
+%% put/6 -- this backend persists it as a real S3 header, so an override
+%% survives the round trip. Documented divergence, not a bug.
+content_type_override_persists(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"data.bin">>,
+                                      <<"x">>, #{content_type => <<"application/custom">>}),
+    {ok, #{content_type := <<"application/custom">>}} =
+        barrel_att_s3_store:get_info(AttRef, DbName, DocId, <<"data.bin">>),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"data.bin">>).
+
+delete_removes_attachment(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"f">>, <<"v">>),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"f">>),
+    ?assertEqual({error, not_found},
+                 barrel_att_s3_store:get(AttRef, DbName, DocId, <<"f">>)).
+
+delete_missing_is_ok(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    ?assertEqual(ok, barrel_att_s3_store:delete(AttRef, DbName, <<"doc1">>, <<"nope">>)).
+
+fold_lists_attachment_names(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"a">>, <<"1">>),
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"b">>, <<"2">>),
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"c">>, <<"3">>),
+    Names = barrel_att_s3_store:fold(AttRef, DbName, DocId,
+                                     fun(Name, _Data, Acc) -> {ok, [Name | Acc]} end, []),
+    ?assertEqual([<<"a">>, <<"b">>, <<"c">>], lists:sort(Names)),
+    ok = barrel_att_s3_store:delete_all(AttRef, DbName, DocId).
+
+fold_stop_early(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"a">>, <<"1">>),
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"b">>, <<"2">>),
+    Result = barrel_att_s3_store:fold(AttRef, DbName, DocId,
+                                      fun(Name, _Data, Acc) -> {stop, [Name | Acc]} end, []),
+    ?assertEqual(1, length(Result)),
+    ok = barrel_att_s3_store:delete_all(AttRef, DbName, DocId).
+
+delete_all_removes_every_attachment_for_doc(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"a">>, <<"1">>),
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"b">>, <<"2">>),
+    ok = barrel_att_s3_store:delete_all(AttRef, DbName, DocId),
+    ?assertEqual({error, not_found},
+                 barrel_att_s3_store:get(AttRef, DbName, DocId, <<"a">>)),
+    ?assertEqual({error, not_found},
+                 barrel_att_s3_store:get(AttRef, DbName, DocId, <<"b">>)).
+
+%% Two different DocIds sharing an AttName must not collide -- proves the
+%% hex-encoded-DocId key scheme actually isolates documents.
+delete_all_does_not_affect_other_docs(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, <<"docA">>, <<"f">>, <<"a">>),
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, <<"docB">>, <<"f">>, <<"b">>),
+    ok = barrel_att_s3_store:delete_all(AttRef, DbName, <<"docA">>),
+    ?assertEqual({error, not_found},
+                 barrel_att_s3_store:get(AttRef, DbName, <<"docA">>, <<"f">>)),
+    ?assertEqual({ok, <<"b">>},
+                 barrel_att_s3_store:get(AttRef, DbName, <<"docB">>, <<"f">>)),
+    ok = barrel_att_s3_store:delete_all(AttRef, DbName, <<"docB">>).
+
+expected_digest_match_succeeds(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    Data = <<"payload">>,
+    Digest = <<"sha256-", (binary:encode_hex(crypto:hash(sha256, Data), lowercase))/binary>>,
+    ?assertMatch({ok, _},
+                 barrel_att_s3_store:put(AttRef, DbName, DocId, <<"f">>, Data,
+                                        #{expected_digest => Digest})),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"f">>).
+
+expected_digest_mismatch_rejected(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    ?assertEqual({error, digest_mismatch},
+                 barrel_att_s3_store:put(AttRef, DbName, DocId, <<"f">>, <<"payload">>,
+                                        #{expected_digest => <<"sha256-wrong">>})),
+    ?assertEqual({error, not_found},
+                 barrel_att_s3_store:get(AttRef, DbName, DocId, <<"f">>)).
+
+key_too_long_rejected(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    HugeDocId = binary:copy(<<"a">>, 2048),
+    ?assertEqual({error, key_too_long},
+                 barrel_att_s3_store:put(AttRef, DbName, HugeDocId, <<"f">>, <<"v">>)),
+    ?assertEqual({error, key_too_long},
+                 barrel_att_s3_store:get(AttRef, DbName, HugeDocId, <<"f">>)).
+
+%%====================================================================
+%% Streaming / multipart test cases
+%%====================================================================
+
+stream_small_single_put(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    {ok, S1} = barrel_att_s3_store:put_stream(AttRef, DbName, DocId,
+                                              <<"small.txt">>, <<"text/plain">>),
+    {ok, S2} = barrel_att_s3_store:write_chunk(S1, <<"hello">>),
+    {ok, Info} = barrel_att_s3_store:finish_stream(S2),
+    ?assertMatch(#{chunked := false, length := 5}, Info),
+    ?assertEqual({ok, <<"hello">>},
+                 barrel_att_s3_store:get(AttRef, DbName, DocId, <<"small.txt">>)),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"small.txt">>).
+
+stream_large_multipart(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    Part1 = binary:copy(<<"a">>, ?PART_SIZE),
+    Part2 = binary:copy(<<"b">>, 100),
+    Expected = <<Part1/binary, Part2/binary>>,
+    {ok, S1} = barrel_att_s3_store:put_stream(AttRef, DbName, DocId,
+                                              <<"large.bin">>, <<"application/octet-stream">>),
+    {ok, S2} = barrel_att_s3_store:write_chunk(S1, Part1),
+    ?assertNotEqual(undefined, maps:get(multipart, S2)),
+    {ok, S3} = barrel_att_s3_store:write_chunk(S2, Part2),
+    {ok, Info} = barrel_att_s3_store:finish_stream(S3),
+    ?assertMatch(#{chunked := true, length := 5242980}, Info),
+    ?assertEqual({ok, Expected},
+                 barrel_att_s3_store:get(AttRef, DbName, DocId, <<"large.bin">>)),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"large.bin">>).
+
+stream_abort_mid_multipart(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    {ok, S1} = barrel_att_s3_store:put_stream(AttRef, DbName, DocId,
+                                              <<"aborted.bin">>, <<"application/octet-stream">>),
+    {ok, S2} = barrel_att_s3_store:write_chunk(S1, binary:copy(<<"x">>, ?PART_SIZE)),
+    ?assertNotEqual(undefined, maps:get(multipart, S2)),
+    ?assertEqual(ok, barrel_att_s3_store:abort_stream(S2)),
+    ?assertEqual({error, not_found},
+                 barrel_att_s3_store:get(AttRef, DbName, DocId, <<"aborted.bin">>)).
+
+stream_digest_mismatch_small(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    {ok, S1} = barrel_att_s3_store:put_stream(AttRef, DbName, DocId, <<"bad.txt">>,
+                                              <<"text/plain">>,
+                                              #{expected_digest => <<"sha256-wrong">>}),
+    {ok, S2} = barrel_att_s3_store:write_chunk(S1, <<"hello">>),
+    ?assertEqual({error, digest_mismatch}, barrel_att_s3_store:finish_stream(S2)),
+    ?assertEqual({error, not_found},
+                 barrel_att_s3_store:get(AttRef, DbName, DocId, <<"bad.txt">>)).
+
+%% A mismatch discovered only at finish time (the digest can't be known
+%% until every part is in) must abort the whole multipart upload, not just
+%% report an error -- confirmed here by asserting no in-progress upload is
+%% left behind for anyone to accidentally complete later.
+stream_digest_mismatch_multipart_aborts_upload(Config) ->
+    AttRef = #{client := Client, bucket := Bucket} = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    {ok, S1} = barrel_att_s3_store:put_stream(AttRef, DbName, DocId, <<"bad2.bin">>,
+                                              <<"application/octet-stream">>,
+                                              #{expected_digest => <<"sha256-wrong">>}),
+    {ok, S2} = barrel_att_s3_store:write_chunk(S1, binary:copy(<<"z">>, ?PART_SIZE)),
+    {ok, S3} = barrel_att_s3_store:write_chunk(S2, binary:copy(<<"z">>, 100)),
+    ?assertEqual({error, digest_mismatch}, barrel_att_s3_store:finish_stream(S3)),
+    ?assertEqual({error, not_found},
+                 barrel_att_s3_store:get(AttRef, DbName, DocId, <<"bad2.bin">>)),
+    {ok, #{uploads := Uploads}} = livery_s3:list_multipart_uploads(Client, Bucket),
+    ?assertNot(lists:any(fun(#{key := K}) -> K =:= maps:get(key, S3) end, Uploads)).
+
+stream_read_roundtrip(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    Part1 = binary:copy(<<"q">>, ?PART_SIZE),
+    Expected = <<Part1/binary, "tail">>,
+    {ok, S1} = barrel_att_s3_store:put_stream(AttRef, DbName, DocId, <<"stream.bin">>,
+                                              <<"application/octet-stream">>),
+    {ok, S2} = barrel_att_s3_store:write_chunk(S1, Part1),
+    {ok, S3} = barrel_att_s3_store:write_chunk(S2, <<"tail">>),
+    {ok, _} = barrel_att_s3_store:finish_stream(S3),
+    {ok, R1} = barrel_att_s3_store:get_stream(AttRef, DbName, DocId, <<"stream.bin">>),
+    Got = drain(R1, []),
+    ?assertEqual(Expected, Got),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"stream.bin">>).
+
+stream_read_not_found(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    ?assertEqual({error, not_found},
+                 barrel_att_s3_store:get_stream(AttRef, DbName, <<"doc1">>, <<"nope">>)).
+
+%% Garage-only: unlike AWS/MinIO's strict 5 MiB minimum for a non-final
+%% part, Garage accepts a much smaller one (confirmed empirically at 1 MiB
+%% this session) -- exercises that the part_size config knob genuinely
+%% changes upload behavior on a store lenient enough to allow it, rather
+%% than a knob that's accepted but ignored.
+stream_small_part_size_accepted_by_garage(Config) ->
+    S3Opts = ?config(s3_opts, Config),
+    SmallPartSize = 1024 * 1024,
+    DbName = ?config(db_name, Config),
+    Path = ?config(path, Config) ++ "-small-part",
+    {ok, AttRef} = barrel_att_s3_store:open(Path,
+                                            #{s3 => S3Opts#{part_size => SmallPartSize},
+                                              db_name => DbName}),
+    DocId = <<"doc1">>,
+    Part1 = binary:copy(<<"a">>, SmallPartSize),
+    Part2 = binary:copy(<<"b">>, 50),
+    Expected = <<Part1/binary, Part2/binary>>,
+    {ok, S1} = barrel_att_s3_store:put_stream(AttRef, DbName, DocId, <<"garage-small.bin">>,
+                                              <<"application/octet-stream">>),
+    {ok, S2} = barrel_att_s3_store:write_chunk(S1, Part1),
+    ?assertNotEqual(undefined, maps:get(multipart, S2)),
+    {ok, S3} = barrel_att_s3_store:write_chunk(S2, Part2),
+    {ok, Info} = barrel_att_s3_store:finish_stream(S3),
+    ?assertMatch(#{chunked := true}, Info),
+    ?assertEqual({ok, Expected},
+                 barrel_att_s3_store:get(AttRef, DbName, DocId, <<"garage-small.bin">>)),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"garage-small.bin">>),
+    ok = barrel_att_s3_store:close(AttRef).
+
+%%====================================================================
+%% Streaming helpers
+%%====================================================================
+
+drain(Stream, Acc) ->
+    case barrel_att_s3_store:read_chunk(Stream) of
+        {ok, Data, Next} -> drain(Next, [Data | Acc]);
+        eof -> iolist_to_binary(lists:reverse(Acc))
+    end.
+
+%%====================================================================
+%% Write-conflict detection test cases
+%%====================================================================
+
+conditional_writes_capability_reflects_store(Config) ->
+    AttRef = ?config(att_ref, Config),
+    Expected = case ?config(store, Config) of
+        minio -> supported;
+        garage -> unsupported
+    end,
+    ?assertEqual(Expected, maps:get(conditional_writes, AttRef)).
+
+default_put_stays_unconditional(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"f">>, <<"v1">>),
+    ?assertMatch({ok, _}, barrel_att_s3_store:put(AttRef, DbName, DocId, <<"f">>, <<"v2">>)),
+    ?assertEqual({ok, <<"v2">>}, barrel_att_s3_store:get(AttRef, DbName, DocId, <<"f">>)),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"f">>).
+
+create_only_succeeds_on_fresh_key(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    ?assertMatch({ok, _},
+                 barrel_att_s3_store:put(AttRef, DbName, DocId, <<"f">>, <<"v1">>,
+                                        #{create_only => true})),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"f">>).
+
+create_only_conflicts_on_existing_key(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"f">>, <<"v1">>,
+                                      #{create_only => true}),
+    Result = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"f">>, <<"v2">>,
+                                     #{create_only => true}),
+    ?assertMatch({error, {conflict, #{name := <<"f">>, length := 2}}}, Result),
+    %% the rejected write never landed
+    ?assertEqual({ok, <<"v1">>}, barrel_att_s3_store:get(AttRef, DbName, DocId, <<"f">>)),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"f">>).
+
+expected_etag_match_succeeds(Config) ->
+    #{client := Client, bucket := Bucket} = AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"f">>, <<"v1">>),
+    Key = s3_key(DbName, DocId, <<"f">>),
+    {ok, #{etag := Etag}} = livery_s3:head_object(Client, Bucket, Key),
+    ?assertMatch({ok, _},
+                 barrel_att_s3_store:put(AttRef, DbName, DocId, <<"f">>, <<"v2">>,
+                                        #{expected_etag => Etag})),
+    ?assertEqual({ok, <<"v2">>}, barrel_att_s3_store:get(AttRef, DbName, DocId, <<"f">>)),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"f">>).
+
+expected_etag_stale_returns_conflict(Config) ->
+    #{client := Client, bucket := Bucket} = AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"f">>, <<"v1">>),
+    Key = s3_key(DbName, DocId, <<"f">>),
+    {ok, #{etag := StaleEtag}} = livery_s3:head_object(Client, Bucket, Key),
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"f">>, <<"v2">>),
+    Result = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"f">>, <<"v3">>,
+                                     #{expected_etag => StaleEtag}),
+    ?assertMatch({error, {conflict, #{name := <<"f">>}}}, Result),
+    ?assertEqual({ok, <<"v2">>}, barrel_att_s3_store:get(AttRef, DbName, DocId, <<"f">>)),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"f">>).
+
+stream_create_only_conflicts_small_path(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"f">>, <<"v1">>),
+    {ok, S1} = barrel_att_s3_store:put_stream(AttRef, DbName, DocId, <<"f">>,
+                                              <<"text/plain">>, #{create_only => true}),
+    {ok, S2} = barrel_att_s3_store:write_chunk(S1, <<"v2">>),
+    Result = barrel_att_s3_store:finish_stream(S2),
+    ?assertMatch({error, {conflict, #{name := <<"f">>}}}, Result),
+    ?assertEqual({ok, <<"v1">>}, barrel_att_s3_store:get(AttRef, DbName, DocId, <<"f">>)),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"f">>).
+
+%% create_only applies at completion, not create_multipart_upload (see the
+%% barrel_att_s3_store module doc): a doc already carrying "big.bin" makes
+%% the *second* stream's completion lose an If-None-Match race, not its
+%% first write_chunk -- unlike the single-put path, the multipart upload
+%% itself succeeds right up to completion before the conflict surfaces.
+stream_create_only_conflicts_multipart_path(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    Part1 = binary:copy(<<"a">>, ?PART_SIZE),
+    {ok, First1} = barrel_att_s3_store:put_stream(AttRef, DbName, DocId, <<"big.bin">>,
+                                                  <<"application/octet-stream">>,
+                                                  #{create_only => true}),
+    {ok, First2} = barrel_att_s3_store:write_chunk(First1, Part1),
+    {ok, _} = barrel_att_s3_store:finish_stream(First2),
+
+    {ok, Second1} = barrel_att_s3_store:put_stream(AttRef, DbName, DocId, <<"big.bin">>,
+                                                   <<"application/octet-stream">>,
+                                                   #{create_only => true}),
+    {ok, Second2} = barrel_att_s3_store:write_chunk(Second1, Part1),
+    Result = barrel_att_s3_store:finish_stream(Second2),
+    ?assertMatch({error, {conflict, #{name := <<"big.bin">>}}}, Result),
+    ?assertEqual({ok, Part1}, barrel_att_s3_store:get(AttRef, DbName, DocId, <<"big.bin">>)),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"big.bin">>).
+
+garage_create_only_fails_fast(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    ?assertEqual({error, conditional_writes_unsupported},
+                 barrel_att_s3_store:put(AttRef, DbName, DocId, <<"f">>, <<"v1">>,
+                                        #{create_only => true})),
+    ?assertEqual({error, not_found}, barrel_att_s3_store:get(AttRef, DbName, DocId, <<"f">>)).
+
+garage_expected_etag_fails_fast(Config) ->
+    AttRef = ?config(att_ref, Config),
+    DbName = ?config(db_name, Config),
+    DocId = <<"doc1">>,
+    {ok, _} = barrel_att_s3_store:put(AttRef, DbName, DocId, <<"f">>, <<"v1">>),
+    ?assertEqual({error, conditional_writes_unsupported},
+                 barrel_att_s3_store:put(AttRef, DbName, DocId, <<"f">>, <<"v2">>,
+                                        #{expected_etag => <<"whatever">>})),
+    ?assertEqual({ok, <<"v1">>}, barrel_att_s3_store:get(AttRef, DbName, DocId, <<"f">>)),
+    ok = barrel_att_s3_store:delete(AttRef, DbName, DocId, <<"f">>).
+
+s3_key(DbName, DocId, AttName) ->
+    <<DbName/binary, "/", (binary:encode_hex(DocId, lowercase))/binary, "/", AttName/binary>>.

--- a/apps/barrel_att_s3/test/barrel_att_s3_test_support.erl
+++ b/apps/barrel_att_s3/test/barrel_att_s3_test_support.erl
@@ -1,0 +1,73 @@
+%%%-------------------------------------------------------------------
+%%% @doc Shared MinIO/Garage test-fixture helpers for CT suites exercising
+%%% the barrel_att_s3 backend against real S3-compatible stores. Used by
+%%% both apps/barrel_att_s3/test/barrel_att_s3_SUITE.erl and
+%%% apps/barrel_docdb/test/barrel_rep_att_SUITE.erl -- kept in one place
+%%% since the env var names and default endpoints/buckets need to agree
+%%% with test/e2e/attachments-s3-setup.sh either way, and previously
+%%% drifted into two independent, near-identical copies.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_att_s3_test_support).
+
+-export([env_bin/2, minio_opts/0, garage_opts/0, reachable/1]).
+
+%% @doc `Var''s value as a binary, or `Default' if unset.
+-spec env_bin(string(), binary()) -> binary().
+env_bin(Var, Default) ->
+    case os:getenv(Var) of
+        false -> Default;
+        Value -> list_to_binary(Value)
+    end.
+
+%% @doc MinIO connection options (endpoint/region/credentials/bucket),
+%% from env vars with defaults matching test/e2e/attachments-s3-setup.sh.
+-spec minio_opts() -> map().
+minio_opts() ->
+    #{
+        bucket => env_bin("MINIO_S3_TEST_BUCKET", <<"barrel-att-s3-test">>),
+        endpoint => env_bin("MINIO_S3_TEST_ENDPOINT", <<"http://127.0.0.1:19000">>),
+        region => env_bin("MINIO_S3_TEST_REGION", <<"us-east-1">>),
+        access_key_id => env_bin("MINIO_S3_TEST_ACCESS_KEY", <<"minioadmin">>),
+        secret_access_key => env_bin("MINIO_S3_TEST_SECRET_KEY", <<"minioadmin">>)
+    }.
+
+%% @doc Same, for Garage -- `undefined' if `GARAGE_S3_TEST_ACCESS_KEY'/
+%% `_SECRET_KEY' aren't set (no usable default credentials for a store
+%% that must be provisioned externally; see attachments-s3-setup.sh).
+-spec garage_opts() -> map() | undefined.
+garage_opts() ->
+    case {os:getenv("GARAGE_S3_TEST_ACCESS_KEY"), os:getenv("GARAGE_S3_TEST_SECRET_KEY")} of
+        {false, _} -> undefined;
+        {_, false} -> undefined;
+        {AccessKey, SecretKey} ->
+            #{
+                bucket => env_bin("GARAGE_S3_TEST_BUCKET", <<"barrel-test">>),
+                endpoint => env_bin("GARAGE_S3_TEST_ENDPOINT", <<"http://127.0.0.1:13900">>),
+                region => env_bin("GARAGE_S3_TEST_REGION", <<"garage">>),
+                access_key_id => list_to_binary(AccessKey),
+                secret_access_key => list_to_binary(SecretKey)
+            }
+    end.
+
+%% @doc Cheap reachability probe, so a test skips cleanly instead of
+%% failing noisily when the store just isn't up. No bucket creation --
+%% callers that need the bucket to exist handle that themselves, since
+%% how strictly to treat a creation failure differs by caller (some fail
+%% loudly on an unexpected error, some treat it as best-effort). A
+%% working `list_buckets' proves the endpoint answers; some restricted
+%% keys (e.g. a scoped Garage key) can't list all buckets, so a `HEAD' on
+%% a bucket that may not exist yet is a fallback probe -- `not_found' is
+%% still a valid, connected response.
+-spec reachable(map()) -> boolean().
+reachable(S3Opts) ->
+    Client = livery_s3:new(maps:without([bucket], S3Opts)),
+    case livery_s3:list_buckets(Client) of
+        {ok, _} -> true;
+        {error, _} ->
+            case livery_s3:head_bucket(Client, <<"__reachability_probe__">>) of
+                {error, not_found} -> true;
+                {error, _} -> false;
+                ok -> true
+            end
+    end.

--- a/apps/barrel_docdb/docs/replication.md
+++ b/apps/barrel_docdb/docs/replication.md
@@ -86,6 +86,36 @@ Tasks = barrel_rep_tasks:list_tasks().
 
 Tasks move through `pending`, `running`, `paused`, `completed` (one-shot), and `failed`. Task config is persisted in a system database, so a task resumes from its checkpoint after a restart.
 
+### Attachments
+
+Tasks replicate attachments by default, same as `barrel_rep:replicate/2,3`. Attachments live on their own feed (independent of the document changes feed), so they have their own checkpoint (`att_seq`, persisted alongside `last_seq`) and their own idle-wake handling: a continuous task periodically re-checks attachments even when no document change occurs, so an attachment added to an already-replicated document still converges without any further doc write.
+
+```erlang
+{ok, TaskId} = barrel_rep_tasks:start_task(#{
+    source => <<"mydb">>,
+    target => <<"http://remote:8080/db/mydb">>,
+    mode => continuous,
+    direction => push,
+    attachments => true,      %% default; set false to skip attachments
+    att_batch_size => 100      %% attachment feed batch size (default 100)
+}).
+```
+
+Set `attachments => false` to replicate documents only. This is persisted with the rest of the task config, so it survives `pause_task`/`resume_task` and node restarts.
+
+### Attachment Storage Backends
+
+Where attachment bytes actually live is pluggable, via the `barrel_att_backend` behaviour: `barrel_att_store` picks a backend per database from `att_opts.backend` (default is `barrel_att_store_blob`, an embedded RocksDB instance with BlobDB enabled). `barrel_att_s3` (a separate sibling app, opt in with the `s3` rebar3 profile) is an S3-compatible backend for AWS S3, MinIO, or Garage -- see its [getting started](../../barrel_att_s3/docs/getting-started.md) guide.
+
+This matters for replication because the behaviour splits its callbacks in two:
+
+- **Required**: `put`/`get`/`delete`/streaming, storing and reading bytes. Any backend needs these.
+- **Optional**: `att_changes/4`, `att_floor/2`, `sweep_att_feed/3`, `rebuild_feed/2` (the attachment change feed replication reads from), `checkpoint/2` (timeline branching), `destroy/2` (backend-owned state beyond the local directory, erased on `delete_db`).
+
+`barrel_att_store_blob` implements both sets: it keeps its feed in the *same* RocksDB instance as the blobs, committed in the same write batch as the blob write, so the feed can never fall out of sync with what was actually stored. `barrel_att_s3` implements both sets too, as of a later revision than its first release: it keeps its feed in a small local RocksDB instance alongside the (remote) attachment bytes, since S3 has no equivalent to a local atomic write batch spanning both -- committed just after each S3 write succeeds, not atomically with it. Either way, replication treats both backends the same: full LWW-checked sync as both source and target.
+
+A backend that implements only the required set (put/get/delete/streaming, no feed at all) still degrades gracefully rather than erroring, detected per call via `barrel_att_store:supports_sync/1` (`erlang:function_exported/3`): attachment sync reports `att_sync => skipped` as a replication *source*, for one-shot replication, timeline merges, and tasks alike. Attachments still work locally (put/get/delete) in that case; they just don't replicate. This check only covers the source -- such a backend as a replication *target* is not detected, since `put`/`delete` are required callbacks and land regardless, with no feed on the target to check `origin_hlc` against, so the last-write-wins guard a feed-backed target enforces silently does not apply for it.
+
 ## Filtered Replication
 
 Replicate only documents matching specific criteria using the `filter` option. A filtered stream keeps its own checkpoint, separate from the full replication.

--- a/apps/barrel_docdb/src/barrel_att_backend.erl
+++ b/apps/barrel_docdb/src/barrel_att_backend.erl
@@ -101,5 +101,12 @@
 -callback checkpoint(AttRef :: map(), Path :: string()) ->
     ok | {error, term()}.
 
+%% Erase everything owned by this store beyond its local directory (e.g.
+%% remote objects) before delete_db removes that directory. Backends
+%% without it need no extra step: local deletion already covers them.
+-callback destroy(AttRef :: map(), DbName :: binary()) ->
+    ok | {error, term()}.
+
 -optional_callbacks([delete/5, att_changes/4, att_floor/2,
-                     sweep_att_feed/3, rebuild_feed/2, checkpoint/2]).
+                     sweep_att_feed/3, rebuild_feed/2, checkpoint/2,
+                     destroy/2]).

--- a/apps/barrel_docdb/src/barrel_att_store.erl
+++ b/apps/barrel_docdb/src/barrel_att_store.erl
@@ -3,10 +3,17 @@
 %%%
 %%% Selects an attachment backend (a {@link barrel_att_backend}) per database
 %%% and routes all attachment calls to it. The backend is chosen from
-%%% `att_opts.backend' at {@link open/2} (default `barrel_att_store_blob', the
-%%% RocksDB BlobDB backend) and tagged into the returned `att_ref'. Streaming
-%%% handles embed their `att_ref', so streaming calls dispatch to the same
-%%% backend.
+%%% `att_opts.backend' at {@link open/2} (default `blob', the RocksDB BlobDB
+%%% backend) via {@link backend_module/1}, resolved to a module and tagged
+%%% into the returned `att_ref'. Streaming handles embed their `att_ref', so
+%%% streaming calls dispatch to the same backend.
+%%%
+%%% Backends can be optional sibling apps (e.g. `barrel_att_s3`, kept out of
+%%% the default embeddable build so it doesn't pull in `livery_s3'/`livery');
+%%% {@link is_available/1} probes for one at runtime via `code:ensure_loaded/1',
+%%% the same pattern `barrel_vectordb_index' uses for the optional FAISS
+%%% backend, so `open/2' fails cleanly with `{error, {backend_unavailable, _}}'
+%%% rather than crashing on an unloaded module.
 %%%
 %%% Callers (barrel_att, barrel_docdb, barrel_db_server) keep using this module;
 %%% the backend split is transparent to them. This dispatcher is also the
@@ -18,6 +25,7 @@
 
 %% API
 -export([open/2, close/1]).
+-export([backend_module/1, is_available/1]).
 -export([put/5, put/6, get/4, delete/4]).
 -export([delete_all/3]).
 -export([fold/5]).
@@ -32,10 +40,11 @@
 -export([delete/5, att_changes/4, att_floor/2, sweep_att_feed/3,
          rebuild_feed/2, supports_sync/1]).
 -export([checkpoint/2]).
+-export([destroy/2]).
 
 -export_type([att_ref/0, att_stream/0]).
 
--define(DEFAULT_BACKEND, barrel_att_store_blob).
+-define(DEFAULT_BACKEND, blob).
 
 -type att_ref() :: #{backend => module(), _ => _}.
 -type att_stream() :: #{att_ref := att_ref(), _ => _}.
@@ -44,12 +53,67 @@
 %% API
 %%====================================================================
 
+%% @doc Resolve a symbolic backend name to its implementation module.
+%% A bare module atom (not `blob'/`s3') passes through unchanged, for
+%% back-compat with any caller that already names a module directly.
+-spec backend_module(atom()) -> module().
+backend_module(blob) -> barrel_att_store_blob;
+backend_module(s3) -> barrel_att_s3_store;
+backend_module(Module) when is_atom(Module) -> Module.
+
+%% @doc Whether a backend's implementation is present in the build.
+%% `blob' ships with barrel_docdb itself; other backends are optional
+%% sibling apps (opted into the build via their own rebar profile) probed
+%% for at runtime, same pattern as `barrel_vectordb_index:is_available/1'
+%% for the optional FAISS backend.
+-spec is_available(atom()) -> boolean().
+is_available(blob) ->
+    true;
+is_available(s3) ->
+    backend_loaded(barrel_att_s3_store);
+is_available(Module) when is_atom(Module) ->
+    true.
+
+%% @private A backend module's load state and exports never change once
+%% the node is up, so both are cached in a persistent_term after the
+%% first check -- code:ensure_loaded/1 and erlang:function_exported/3
+%% each cost a round trip through the code server; paying that on every
+%% open/checkpoint/destroy/supports_sync call is pure waste.
+backend_loaded(Module) ->
+    persistent_term_cached({?MODULE, loaded, Module}, fun() ->
+        case code:ensure_loaded(Module) of
+            {module, _} -> true;
+            {error, _} -> false
+        end
+    end).
+
+exported(Module, Function, Arity) ->
+    persistent_term_cached({?MODULE, exported, Module, Function, Arity}, fun() ->
+        backend_loaded(Module) andalso erlang:function_exported(Module, Function, Arity)
+    end).
+
+persistent_term_cached(Key, ComputeFun) ->
+    case persistent_term:get(Key, undefined) of
+        undefined ->
+            Result = ComputeFun(),
+            persistent_term:put(Key, Result),
+            Result;
+        Result ->
+            Result
+    end.
+
 -spec open(string(), map()) -> {ok, att_ref()} | {error, term()}.
 open(Path, Options) ->
-    Backend = maps:get(backend, Options, ?DEFAULT_BACKEND),
-    case Backend:open(Path, Options) of
-        {ok, AttRef} -> {ok, AttRef#{backend => Backend}};
-        {error, _} = Err -> Err
+    Backend0 = maps:get(backend, Options, ?DEFAULT_BACKEND),
+    case is_available(Backend0) of
+        false ->
+            {error, {backend_unavailable, Backend0}};
+        true ->
+            Backend = backend_module(Backend0),
+            case Backend:open(Path, Options) of
+                {ok, AttRef} -> {ok, AttRef#{backend => Backend}};
+                {error, _} = Err -> Err
+            end
     end.
 
 -spec close(att_ref()) -> ok.
@@ -186,23 +250,31 @@ rebuild_feed(AttRef, DbName) ->
 %% @doc Whether this database's backend supports attachment sync.
 -spec supports_sync(att_ref()) -> boolean().
 supports_sync(AttRef) ->
-    B = backend(AttRef),
-    _ = code:ensure_loaded(B),
-    erlang:function_exported(B, att_changes, 4).
+    exported(backend(AttRef), att_changes, 4).
 
 %% @doc Hard-link snapshot of the attachment store into Path
 %% (timeline forks). {error, unsupported} for backends without it.
 -spec checkpoint(att_ref(), string()) -> ok | {error, term()}.
 checkpoint(AttRef, Path) ->
     B = backend(AttRef),
-    _ = code:ensure_loaded(B),
-    case erlang:function_exported(B, checkpoint, 2) of
+    case exported(B, checkpoint, 2) of
         true -> B:checkpoint(AttRef, Path);
         false -> {error, unsupported}
     end.
 
+%% @doc Erase anything the backend owns beyond its local directory (e.g.
+%% S3 objects). {error, unsupported} for backends without it -- callers
+%% (delete_db) treat that as nothing extra to do.
+-spec destroy(att_ref(), binary()) -> ok | {error, term()}.
+destroy(AttRef, DbName) ->
+    B = backend(AttRef),
+    case exported(B, destroy, 2) of
+        true -> B:destroy(AttRef, barrel_keyspace:resolve(DbName));
+        false -> {error, unsupported}
+    end.
+
 backend(#{backend := B}) -> B;
-backend(_) -> ?DEFAULT_BACKEND.
+backend(_) -> backend_module(?DEFAULT_BACKEND).
 
 stream_backend(#{att_ref := AttRef}) -> backend(AttRef);
-stream_backend(_) -> ?DEFAULT_BACKEND.
+stream_backend(_) -> backend_module(?DEFAULT_BACKEND).

--- a/apps/barrel_docdb/src/barrel_changes_stream.erl
+++ b/apps/barrel_docdb/src/barrel_changes_stream.erl
@@ -83,12 +83,16 @@ next(Pid) ->
     end.
 
 %% @doc Wait for changes (push mode)
--spec await(pid()) -> {reference(), [barrel_changes:change()]} | [].
+-spec await(pid()) -> {reference(), [barrel_changes:change()]} | down.
 await(Pid) ->
     await(Pid, infinity).
 
-%% @doc Wait for changes with timeout (push mode)
--spec await(pid(), timeout()) -> {reference(), [barrel_changes:change()]} | [].
+%% @doc Wait for changes with timeout (push mode). Distinguishes a
+%% genuine timeout (`timeout') from the stream process dying (`down'),
+%% so a caller polling on a bounded timeout can tell "nothing new yet"
+%% from "this stream is gone."
+-spec await(pid(), timeout()) ->
+    {reference(), [barrel_changes:change()]} | timeout | down.
 await(Pid, Timeout) ->
     MRef = monitor(process, Pid),
     receive
@@ -96,10 +100,10 @@ await(Pid, Timeout) ->
             demonitor(MRef, [flush]),
             {ReqId, Changes};
         {'DOWN', MRef, process, _, _Reason} ->
-            []
+            down
     after Timeout ->
         demonitor(MRef, [flush]),
-        []
+        timeout
     end.
 
 %% @doc Acknowledge receipt of changes (push mode)

--- a/apps/barrel_docdb/src/barrel_db_server.erl
+++ b/apps/barrel_docdb/src/barrel_db_server.erl
@@ -352,9 +352,15 @@ init(Name, Config, CompiledChannels, DbPath, Keyspace, Parent, ForkHlc, Env) ->
                             Env),
     case barrel_store_rocksdb:open(DocStorePath, StoreOpts) of
         {ok, StoreRef} ->
-            %% Open attachment store (separate RocksDB with BlobDB)
+            %% Open attachment store (separate RocksDB with BlobDB). db_name
+            %% (the resolved keyspace, same value the compaction filter
+            %% above uses) lets a backend that needs a stable identity at
+            %% open time -- e.g. barrel_att_s3, seeding its S3 key prefix on
+            %% first open -- derive one without every backend needing its
+            %% own convention for it.
             AttStorePath = filename:join(DbPath, "attachments"),
-            AttOpts = add_env_opt(maps:get(att_opts, Config, #{}), Env),
+            AttOpts = add_env_opt((maps:get(att_opts, Config, #{}))#{db_name => Keyspace},
+                                  Env),
             case barrel_att_store:open(AttStorePath, AttOpts) of
                 {ok, AttRef} ->
                     %% Register in persistent_term for lookup

--- a/apps/barrel_docdb/src/barrel_docdb.erl
+++ b/apps/barrel_docdb/src/barrel_docdb.erl
@@ -406,6 +406,11 @@ delete_db(Name) when is_binary(Name) ->
 %%
 %% Databases created before per-db `data_dir' was remembered have no
 %% record; pass their `data_dir' explicitly via this function.
+%%
+%% An attachment backend with state beyond its local directory (S3) is
+%% given a chance to erase it first: automatic if the database is open,
+%% otherwise only if `att_opts' is given here too (nothing else can
+%% recover S3 credentials for an already-closed database).
 -spec delete_db(binary(), map()) -> ok | {error, term()}.
 delete_db(Name, Opts) when is_binary(Name), is_map(Opts) ->
     case validate_db_name(Name) of
@@ -420,6 +425,8 @@ do_delete_db(Name, Opts) ->
         {ok, Pid} ->
             {ok, Info} = barrel_db_server:info(Pid),
             DbPath = maps:get(db_path, Info),
+            {ok, AttRef} = barrel_db_server:get_att_ref(Pid),
+            destroy_att_store(AttRef, Name, DbPath),
             barrel_db_server:stop(Pid),
             %% Remove data directory via stdlib (no shell, no injection).
             del_db_dir(DbPath);
@@ -427,10 +434,61 @@ do_delete_db(Name, Opts) ->
             %% Not open: resolve the on-disk location from the option,
             %% the remembered per-db data_dir, or the app env default.
             DataDir = closed_db_data_dir(Name, Opts),
-            del_db_dir(filename:join(DataDir, binary_to_list(Name)))
+            DbPath = filename:join(DataDir, binary_to_list(Name)),
+            maybe_destroy_closed_att_store(Name, DbPath, Opts),
+            del_db_dir(DbPath)
     end,
     forget_db_dir(Name),
     Result.
+
+%% Best-effort: an attachment backend without extra state to erase (the
+%% default RocksDB one) returns {error, unsupported}, and del_db_dir right
+%% after this already removes everything it owns anyway. Wrapped in a
+%% catch-all: the documented {error, _} returns are already handled above,
+%% this is only for a genuine, unexpected crash deeper in the call chain --
+%% closing the caller's own handle (and removing the local directory)
+%% matters more than a clean exit from this one best-effort step, so a
+%% crash here is logged and swallowed rather than aborting the delete.
+destroy_att_store(AttRef, Name, DbPath) ->
+    AttPath = filename:join(DbPath, "attachments"),
+    try barrel_att_store:destroy(AttRef, Name) of
+        ok -> ok;
+        {error, unsupported} -> ok;
+        {error, Reason} ->
+            logger:warning("barrel_docdb: attachment destroy for ~ts (~s) failed: ~p",
+                           [Name, AttPath, Reason])
+    catch
+        Class:Reason:Stack ->
+            logger:warning("barrel_docdb: attachment destroy for ~ts (~s) crashed: ~p",
+                           [Name, AttPath, {Class, Reason, Stack}])
+    end.
+
+%% Only reachable with an explicit att_opts (e.g. S3 credentials) in
+%% Opts: a closed database has no running process to ask for its att_ref,
+%% and config is runtime-only (never persisted), so without att_opts here
+%% there is nothing to open a backend with -- del_db_dir still removes
+%% the local directory either way.
+%%
+%% resume_fork_sync => false: this store is about to be destroyed
+%% immediately below, so resuming a background fork-copy sweep on open
+%% would be pure waste -- and, more importantly, skipping it closes one
+%% whole path by which destroy/2's own listing snapshot could miss
+%% objects a freshly (re)spawned sweep writes afterward, orphaning them in
+%% the bucket with no local record left to ever revisit that prefix again.
+maybe_destroy_closed_att_store(Name, DbPath, Opts) ->
+    case maps:find(att_opts, Opts) of
+        error ->
+            ok;
+        {ok, AttOpts} ->
+            AttPath = filename:join(DbPath, "attachments"),
+            case barrel_att_store:open(AttPath, AttOpts#{resume_fork_sync => false}) of
+                {ok, AttRef} ->
+                    destroy_att_store(AttRef, Name, DbPath),
+                    barrel_att_store:close(AttRef);
+                {error, _} ->
+                    ok
+            end
+    end.
 
 del_db_dir(DbPath) ->
     case file:del_dir_r(DbPath) of

--- a/apps/barrel_docdb/src/barrel_rep_tasks.erl
+++ b/apps/barrel_docdb/src/barrel_rep_tasks.erl
@@ -69,6 +69,15 @@
 -define(BACKOFF_MIN, 1000).
 -define(BACKOFF_MAX, 60000).
 
+%% Bound on how long a stream-subscribed continuous task can go without
+%% re-checking attachments: attachments have their own feed, so a doc-only
+%% wake signal never fires for an attachment-only write. Separate from the
+%% doc-side pacing constants above since it addresses a different concern.
+-define(ATT_IDLE_INTERVAL, 5000).
+
+%% Default attachment sync batch size
+-define(DEFAULT_ATT_BATCH_SIZE, 100).
+
 %%====================================================================
 %% Types
 %%====================================================================
@@ -87,7 +96,9 @@
     target_transport => module(),         % Transport for target
     batch_size => pos_integer(),
     filter => barrel_rep:filter_opts(),
-    wait_for => [binary() | map()]        % Chain: wait for downstream targets
+    wait_for => [binary() | map()],       % Chain: wait for downstream targets
+    attachments => boolean(),             % Replicate attachments (default: true)
+    att_batch_size => pos_integer()       % Attachment feed batch size (default: 100)
 }.
 
 -type task() :: #{
@@ -95,6 +106,7 @@
     config := task_config(),
     status := task_status(),
     last_seq => seq() | first,
+    att_seq => seq() | first,
     error => binary(),
     created_at := integer(),
     updated_at := integer()
@@ -450,7 +462,10 @@ run_task(Parent, TaskId, Config, SourceTransport, TargetTransport, StartSeq) ->
         batch_size => maps:get(batch_size, Config, ?DEFAULT_BATCH_SIZE),
         filter => maps:get(filter, Config, #{}),
         wait_for => [resolve_endpoint(W)
-                     || W <- maps:get(wait_for, Config, [])]
+                     || W <- maps:get(wait_for, Config, [])],
+        attachments => maps:get(attachments, Config, true),
+        att_batch_size => maps:get(att_batch_size, Config,
+                                   ?DEFAULT_ATT_BATCH_SIZE)
     },
 
     ExtraAttrs = #{
@@ -525,11 +540,31 @@ run_task_loop(Ctx, Since) ->
 
     case FromTransport:get_changes(From, Since, ChangesOpts) of
         {ok, [], _LastSeq} when Mode =:= one_shot ->
-            %% No more changes, one-shot complete
-            gen_server:cast(Parent, {task_complete, TaskId});
+            %% No more doc changes: run the attachment phase to completion
+            %% once (mirrors barrel_rep:replicate_one_shot/2's "doc phase to
+            %% completion, then one attachment pass" shape) before reporting
+            %% the task done.
+            case sync_attachments(Ctx) of
+                ok ->
+                    gen_server:cast(Parent, {task_complete, TaskId});
+                {error, Reason} ->
+                    gen_server:cast(Parent, {task_error, TaskId,
+                                             {att_sync_failed, Reason}})
+            end;
 
         {ok, [], _LastSeq} ->
-            %% Idle: block on the wake signal (stream or poll timer)
+            %% Idle on the doc side. Attachments have their own feed, so a
+            %% doc-only wake signal never fires for an attachment-only
+            %% write: catch those up here too, best-effort, before waiting
+            %% again. Poll mode already revisits this branch on every sleep
+            %% cycle; stream mode's bounded wake (see wait_for_wake/1) is
+            %% what makes it revisit this branch when idle on a live stream.
+            case sync_attachments(Ctx) of
+                ok -> ok;
+                {error, Reason} ->
+                    gen_server:cast(Parent, {task_last_error, TaskId,
+                                             {att_sync_failed, Reason}})
+            end,
             run_task_loop(wait_for_wake(Ctx), Since);
 
         {ok, Changes, LastSeq} ->
@@ -546,7 +581,26 @@ run_task_loop(Ctx, Since) ->
                             %% Persist the checkpoint here in the task
                             %% process, off the manager's message loop.
                             _ = update_task_seq(TaskId, LastSeq),
-                            run_task_loop(reset_pacing(Ctx), LastSeq);
+                            case Mode of
+                                continuous ->
+                                    %% Attachments have no retry/backoff
+                                    %% risk for one-shot the way docs do;
+                                    %% the doc watermark is already durably
+                                    %% advanced above, so a broken
+                                    %% attachment target never stalls
+                                    %% healthy doc replication behind it.
+                                    case sync_attachments(Ctx) of
+                                        ok ->
+                                            run_task_loop(reset_pacing(Ctx),
+                                                         LastSeq);
+                                        {error, AttReason} ->
+                                            handle_loop_error(
+                                                Ctx, LastSeq,
+                                                {att_sync_failed, AttReason})
+                                    end;
+                                one_shot ->
+                                    run_task_loop(reset_pacing(Ctx), LastSeq)
+                            end;
                         {error, Reason} ->
                             handle_loop_error(Ctx, Since, Reason)
                     end
@@ -563,6 +617,27 @@ replicate_batch(From, To, FromTransport, ToTransport, Changes, WaitFor) ->
             wait_for_downstream(Changes, WaitFor);
         {error, _} = Error ->
             Error
+    end.
+
+%% @doc Attachment phase for a task: independent lifecycle + checkpoint
+%% (own watermark persisted on the task's own doc), same shape as
+%% barrel_rep:replicate_one_shot/2's post-doc-phase attachment sync and
+%% barrel_timeline's merge_attachments/4 (caller-owned checkpoint via
+%% sync_from/7). Skips entirely when the task config disabled it.
+sync_attachments(#{attachments := false}) ->
+    ok;
+sync_attachments(#{task_id := TaskId, from := From, to := To,
+                   from_transport := FromTransport,
+                   to_transport := ToTransport,
+                   att_batch_size := AttBatchSize}) ->
+    AttSince = get_task_att_seq(TaskId),
+    CheckpointFun = fun(Seq) -> update_task_att_seq(TaskId, Seq) end,
+    case barrel_rep_att:sync_from(From, To, FromTransport, ToTransport,
+                                  AttSince, CheckpointFun,
+                                  #{att_batch_size => AttBatchSize}) of
+        {ok, _Stats} -> ok;
+        skipped -> ok;
+        {error, _} = Error -> Error
     end.
 
 %% Continuous tasks ride out transient errors: record last_error on
@@ -585,14 +660,20 @@ reset_pacing(Ctx) ->
 
 %% Idle continuous task. Stream-woken: the stream payload is
 %% unfiltered, so it is a wake-up signal only; ack immediately and
-%% drain through the transport with the task's filter. Polling:
-%% adaptive interval, doubled while idle.
+%% drain through the transport with the task's filter. The await is
+%% bounded (not infinity): attachments have no doc-feed wake signal of
+%% their own, so a periodic timeout is what lets run_task_loop's idle
+%% branch re-check attachments even when no doc change ever arrives.
+%% Polling: adaptive interval, doubled while idle.
 wait_for_wake(#{wake := {stream, Stream}} = Ctx) ->
-    case barrel_changes_stream:await(Stream, infinity) of
+    case barrel_changes_stream:await(Stream, ?ATT_IDLE_INTERVAL) of
         {ReqId, _Changes} ->
             ok = barrel_changes_stream:ack(Stream, ReqId),
             Ctx;
-        [] ->
+        timeout ->
+            %% no doc changes yet; still alive, just re-check next time
+            Ctx;
+        down ->
             %% stream went away: degrade to polling
             Ctx#{wake := poll}
     end;
@@ -756,6 +837,17 @@ update_task_seq(TaskId, Seq) ->
         Doc#{<<"last_seq">> => format_seq(Seq)}
     end).
 
+update_task_att_seq(TaskId, Seq) ->
+    update_task_doc(TaskId, fun(Doc) ->
+        Doc#{<<"att_seq">> => format_seq(Seq)}
+    end).
+
+get_task_att_seq(TaskId) ->
+    case barrel_docdb:get_local_doc(?TASKS_DB, task_doc_id(TaskId)) of
+        {ok, Doc} -> parse_seq(maps:get(<<"att_seq">>, Doc, <<"first">>));
+        {error, not_found} -> first
+    end.
+
 update_task_last_error(TaskId, Reason) ->
     update_task_doc(TaskId, fun(Doc) ->
         Doc#{<<"last_error">> => format_reason(Reason)}
@@ -787,6 +879,7 @@ task_to_doc(#{id := Id, config := Config, status := Status,
         <<"config">> => config_to_map(Config),
         <<"status">> => atom_to_binary(Status),
         <<"last_seq">> => format_seq(maps:get(last_seq, Task, first)),
+        <<"att_seq">> => format_seq(maps:get(att_seq, Task, first)),
         <<"created_at">> => CreatedAt,
         <<"updated_at">> => UpdatedAt
     }.
@@ -797,6 +890,11 @@ doc_to_task(Doc) ->
         config => map_to_config(maps:get(<<"config">>, Doc)),
         status => binary_to_existing_atom(maps:get(<<"status">>, Doc), utf8),
         last_seq => parse_seq(maps:get(<<"last_seq">>, Doc, <<"first">>)),
+        %% Unconditional, defaulted like last_seq (not the maps:fold below,
+        %% which is only for genuinely-absent-until-first-error fields): a
+        %% task doc written before this field existed must still parse,
+        %% defaulting to a full attachment backfill.
+        att_seq => parse_seq(maps:get(<<"att_seq">>, Doc, <<"first">>)),
         created_at => maps:get(<<"created_at">>, Doc),
         updated_at => maps:get(<<"updated_at">>, Doc)
     },
@@ -828,6 +926,8 @@ config_to_map(Config) ->
                Acc#{<<"filter">> => barrel_rep_filter:to_wire(V)};
            (wait_for, V, Acc) ->
                Acc#{<<"wait_for">> => [endpoint_to_doc(W) || W <- V]};
+           (attachments, V, Acc) -> Acc#{<<"attachments">> => V};
+           (att_batch_size, V, Acc) -> Acc#{<<"att_batch_size">> => V};
            (_, _, Acc) -> Acc
         end,
         #{},
@@ -855,6 +955,8 @@ map_to_config(Map) ->
                    {error, _} -> Acc
                end;
            (<<"wait_for">>, V, Acc) -> Acc#{wait_for => V};
+           (<<"attachments">>, V, Acc) -> Acc#{attachments => V};
+           (<<"att_batch_size">>, V, Acc) -> Acc#{att_batch_size => V};
            (_, _, Acc) -> Acc
         end,
         #{},

--- a/apps/barrel_docdb/src/barrel_timeline.erl
+++ b/apps/barrel_docdb/src/barrel_timeline.erl
@@ -105,8 +105,10 @@ fork(Parent, ParentPid, PInfo, BranchName, BranchPath, Opts) ->
     DocsPath = filename:join(BranchPath, "docs"),
     AttPath = filename:join(BranchPath, "attachments"),
     try
-        {ok, ForkHlc} =
-            barrel_db_server:checkpoint_to(ParentPid, DocsPath, AttPath),
+        ForkHlc = case barrel_db_server:checkpoint_to(ParentPid, DocsPath, AttPath) of
+            {ok, Hlc} -> Hlc;
+            {error, _} = CkptErr -> throw(CkptErr)
+        end,
         ok = barrel_keyspace:write_meta(BranchPath, #{
             keyspace => Parent,
             parent => Parent,

--- a/apps/barrel_docdb/test/barrel_att_store_backend_tests.erl
+++ b/apps/barrel_docdb/test/barrel_att_store_backend_tests.erl
@@ -1,0 +1,63 @@
+%%%-------------------------------------------------------------------
+%%% @doc Backend resolution/selection tests for barrel_att_store.
+%%% Covers backend_module/1, is_available/1, and open/2's clean failure
+%%% on an unavailable backend -- deliberately not testing the s3 backend
+%%% itself here (that needs the s3 profile and a live store; see
+%%% barrel_att_s3's own test suite).
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_att_store_backend_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+backend_module_blob_test() ->
+    ?assertEqual(barrel_att_store_blob, barrel_att_store:backend_module(blob)).
+
+backend_module_s3_test() ->
+    ?assertEqual(barrel_att_s3_store, barrel_att_store:backend_module(s3)).
+
+backend_module_back_compat_bare_module_test() ->
+    %% An already-resolved module atom passes through unchanged, for any
+    %% caller that names a backend module directly rather than a symbolic
+    %% atom (no such caller exists today, kept for back-compat).
+    ?assertEqual(barrel_att_store_blob,
+                 barrel_att_store:backend_module(barrel_att_store_blob)),
+    ?assertEqual(some_custom_backend_module,
+                 barrel_att_store:backend_module(some_custom_backend_module)).
+
+is_available_blob_test() ->
+    ?assert(barrel_att_store:is_available(blob)).
+
+is_available_s3_matches_module_loadability_test() ->
+    %% This suite runs under both the default profile (barrel_att_s3 not in
+    %% the build) and the s3 profile (it is), so assert the invariant rather
+    %% than a profile-specific answer: is_available/1 must truthfully reflect
+    %% whether the backend module can actually be loaded.
+    Expected = case code:ensure_loaded(barrel_att_s3_store) of
+        {module, _} -> true;
+        {error, _} -> false
+    end,
+    ?assertEqual(Expected, barrel_att_store:is_available(s3)).
+
+is_available_bare_module_default_true_test() ->
+    ?assert(barrel_att_store:is_available(barrel_att_store_blob)).
+
+open_s3_backend_consistent_with_availability_test() ->
+    %% Same profile-agnostic reasoning: under the default profile this
+    %% asserts the clean {backend_unavailable, s3} failure; under the s3
+    %% profile the module loads and dispatches through to its own open/2,
+    %% which fails just as cleanly on the missing `s3.bucket` config this
+    %% call doesn't supply.
+    Result = barrel_att_store:open("/tmp/does-not-matter", #{backend => s3}),
+    case barrel_att_store:is_available(s3) of
+        false -> ?assertEqual({error, {backend_unavailable, s3}}, Result);
+        true -> ?assertEqual({error, missing_bucket}, Result)
+    end.
+
+open_default_backend_still_works_test() ->
+    Dir = "/tmp/barrel_att_store_backend_tests_"
+        ++ integer_to_list(erlang:unique_integer([positive])),
+    {ok, AttRef} = barrel_att_store:open(Dir, #{}),
+    ?assertEqual(barrel_att_store_blob, maps:get(backend, AttRef)),
+    ok = barrel_att_store:close(AttRef),
+    os:cmd("rm -rf " ++ Dir).

--- a/apps/barrel_docdb/test/barrel_docdb_test_att_backend_minimal.erl
+++ b/apps/barrel_docdb/test/barrel_docdb_test_att_backend_minimal.erl
@@ -1,0 +1,71 @@
+%% @doc Test-only attachment backend implementing only the REQUIRED
+%% barrel_att_backend callbacks (plus delete/5, which isn't safely
+%% optional -- barrel_att_store:delete/5 calls it unconditionally). No
+%% att_changes/4, att_floor/2, sweep_att_feed/3, rebuild_feed/2, or
+%% checkpoint/2 -- the same shape a real minimal backend (e.g.
+%% barrel_att_s3_store, a separate app) actually has. Used to exercise:
+%%
+%% - barrel_timeline's handling of a backend lacking checkpoint/2
+%%   (barrel_att_store:checkpoint/2 detects this via
+%%   erlang:function_exported/3, so simply not defining the function is
+%%   enough)
+%% - barrel_rep_att's behavior against a feedless backend: source-lacks-
+%%   feed -> att_sync => skipped; target-lacks-feed -> puts/deletes still
+%%   land, with no origin-HLC LWW guard applied
+%%
+%% without needing a real non-RocksDB backend just for these tests.
+%%
+%% Delegates storage to barrel_att_store_blob, but strips `origin_hlc`
+%% before every delegated call: blob's put/delete always consult its own
+%% internal feed for the LWW guard whenever `origin_hlc` is present
+%% (regardless of whether att_changes/4 is exported), so passing it
+%% through here would silently reintroduce the very guarantee this stub
+%% exists to prove is absent. A real feedless backend has no feed to
+%% check recency against at all and always overwrites; stripping
+%% `origin_hlc` before delegating reproduces exactly that.
+-module(barrel_docdb_test_att_backend_minimal).
+-behaviour(barrel_att_backend).
+
+-export([open/2, close/1]).
+-export([put/5, put/6, get/4, delete/4, delete/5]).
+-export([delete_all/3]).
+-export([fold/5]).
+-export([get_info/4]).
+-export([put_stream/5, put_stream/6]).
+-export([write_chunk/2, finish_stream/1, abort_stream/1]).
+-export([get_stream/4, read_chunk/1, close_stream/1]).
+
+open(Path, Options) -> barrel_att_store_blob:open(Path, Options).
+close(AttRef) -> barrel_att_store_blob:close(AttRef).
+put(AttRef, DbName, DocId, AttName, Data) ->
+    barrel_att_store_blob:put(AttRef, DbName, DocId, AttName, Data).
+put(AttRef, DbName, DocId, AttName, Data, Opts) ->
+    barrel_att_store_blob:put(AttRef, DbName, DocId, AttName, Data,
+                              strip_origin(Opts)).
+get(AttRef, DbName, DocId, AttName) ->
+    barrel_att_store_blob:get(AttRef, DbName, DocId, AttName).
+delete(AttRef, DbName, DocId, AttName) ->
+    barrel_att_store_blob:delete(AttRef, DbName, DocId, AttName).
+delete(AttRef, DbName, DocId, AttName, Opts) ->
+    barrel_att_store_blob:delete(AttRef, DbName, DocId, AttName,
+                                 strip_origin(Opts)).
+delete_all(AttRef, DbName, DocId) ->
+    barrel_att_store_blob:delete_all(AttRef, DbName, DocId).
+fold(AttRef, DbName, DocId, Fun, Acc) ->
+    barrel_att_store_blob:fold(AttRef, DbName, DocId, Fun, Acc).
+get_info(AttRef, DbName, DocId, AttName) ->
+    barrel_att_store_blob:get_info(AttRef, DbName, DocId, AttName).
+put_stream(AttRef, DbName, DocId, AttName, ContentType) ->
+    barrel_att_store_blob:put_stream(AttRef, DbName, DocId, AttName, ContentType).
+put_stream(AttRef, DbName, DocId, AttName, ContentType, Opts) ->
+    barrel_att_store_blob:put_stream(AttRef, DbName, DocId, AttName, ContentType,
+                                     strip_origin(Opts)).
+write_chunk(Stream, Data) -> barrel_att_store_blob:write_chunk(Stream, Data).
+finish_stream(Stream) -> barrel_att_store_blob:finish_stream(Stream).
+abort_stream(Stream) -> barrel_att_store_blob:abort_stream(Stream).
+get_stream(AttRef, DbName, DocId, AttName) ->
+    barrel_att_store_blob:get_stream(AttRef, DbName, DocId, AttName).
+read_chunk(Stream) -> barrel_att_store_blob:read_chunk(Stream).
+close_stream(Stream) -> barrel_att_store_blob:close_stream(Stream).
+
+strip_origin(Opts) -> maps:remove(origin_hlc, Opts).

--- a/apps/barrel_docdb/test/barrel_rep_SUITE.erl
+++ b/apps/barrel_docdb/test/barrel_rep_SUITE.erl
@@ -71,7 +71,10 @@ groups() ->
             task_config_round_trip,
             task_restore_after_manager_restart,
             task_event_driven_latency,
-            task_continuous_survives_error
+            task_continuous_survives_error,
+            task_one_shot_replicates_attachment,
+            task_continuous_replicates_attachment_only_change,
+            task_attachments_disabled_survives_restart
         ]}
     ].
 
@@ -1080,6 +1083,93 @@ task_continuous_survives_error(_Config) ->
         end
     end, 100, 100),
     {ok, #{status := running}} = barrel_rep_tasks:get_task(TaskId),
+    ok = barrel_rep_tasks:stop_task(TaskId),
+    ok = barrel_rep_tasks:delete_task(TaskId),
+    ok.
+
+%%====================================================================
+%% Task attachment replication (regression: tasks used to drop
+%% attachments entirely; barrel_rep and barrel_timeline always ran
+%% the attachment phase, barrel_rep_tasks never did)
+%%====================================================================
+
+task_one_shot_replicates_attachment(_Config) ->
+    {ok, _} = barrel_docdb:put_doc(<<"test_source">>,
+                                   #{<<"id">> => <<"att_doc">>}),
+    {ok, _} = barrel_docdb:put_attachment(<<"test_source">>, <<"att_doc">>,
+                                          <<"note.txt">>, <<"hello">>),
+    {ok, TaskId} = barrel_rep_tasks:start_task(#{
+        source => <<"test_source">>,
+        target => <<"test_target">>,
+        mode => one_shot,
+        direction => push
+    }),
+    ok = wait_until(fun() ->
+        case barrel_rep_tasks:get_task(TaskId) of
+            {ok, #{status := completed}} -> true;
+            {ok, #{status := failed, error := Err}} ->
+                ct:fail({task_failed, Err});
+            _ -> false
+        end
+    end, 100, 100),
+    {ok, <<"hello">>} = barrel_docdb:get_attachment(
+        <<"test_target">>, <<"att_doc">>, <<"note.txt">>),
+    ok = barrel_rep_tasks:delete_task(TaskId),
+    ok.
+
+task_continuous_replicates_attachment_only_change(_Config) ->
+    {ok, TaskId} = barrel_rep_tasks:start_task(#{
+        source => <<"test_source">>,
+        target => <<"test_target">>,
+        mode => continuous,
+        direction => push
+    }),
+    {ok, _} = barrel_docdb:put_doc(<<"test_source">>,
+                                   #{<<"id">> => <<"idle_doc">>}),
+    ok = wait_until(doc_in(<<"test_target">>, <<"idle_doc">>), 50, 100),
+    %% No further doc-body change from here: attachments live on their own
+    %% feed, so a continuous task idling on the doc changes stream must
+    %% notice this on its own bounded wake, not because a doc write nudges
+    %% it (that's the bug this suite guards against).
+    {ok, _} = barrel_docdb:put_attachment(<<"test_source">>, <<"idle_doc">>,
+                                          <<"note.txt">>, <<"hi">>),
+    ok = wait_until(fun() ->
+        case barrel_docdb:get_attachment(<<"test_target">>, <<"idle_doc">>,
+                                         <<"note.txt">>) of
+            {ok, <<"hi">>} -> true;
+            _ -> false
+        end
+    end, 200, 60),
+    ok = barrel_rep_tasks:stop_task(TaskId),
+    ok = barrel_rep_tasks:delete_task(TaskId),
+    ok.
+
+task_attachments_disabled_survives_restart(_Config) ->
+    {ok, TaskId} = barrel_rep_tasks:start_task(#{
+        source => <<"test_source">>,
+        target => <<"test_target">>,
+        mode => continuous,
+        direction => push,
+        attachments => false
+    }),
+    {ok, #{config := Config0}} = barrel_rep_tasks:get_task(TaskId),
+    ?assertEqual(false, maps:get(attachments, Config0)),
+    %% stop/resume round-trips the config through config_to_map/
+    %% map_to_config: a dropped key here would silently re-enable
+    %% attachment replication after any restart
+    ok = barrel_rep_tasks:stop_task(TaskId),
+    ok = barrel_rep_tasks:resume_task(TaskId),
+    {ok, #{config := Config1}} = barrel_rep_tasks:get_task(TaskId),
+    ?assertEqual(false, maps:get(attachments, Config1)),
+    {ok, _} = barrel_docdb:put_doc(<<"test_source">>,
+                                   #{<<"id">> => <<"off_doc">>}),
+    {ok, _} = barrel_docdb:put_attachment(<<"test_source">>, <<"off_doc">>,
+                                          <<"f">>, <<"v">>),
+    ok = wait_until(doc_in(<<"test_target">>, <<"off_doc">>), 50, 100),
+    timer:sleep(1000),
+    ?assertEqual({error, not_found},
+                 barrel_docdb:get_attachment(<<"test_target">>, <<"off_doc">>,
+                                             <<"f">>)),
     ok = barrel_rep_tasks:stop_task(TaskId),
     ok = barrel_rep_tasks:delete_task(TaskId),
     ok.

--- a/apps/barrel_docdb/test/barrel_rep_att_SUITE.erl
+++ b/apps/barrel_docdb/test/barrel_rep_att_SUITE.erl
@@ -19,7 +19,14 @@
          checkpoint_resume/1,
          off_switch/1,
          mixed_docs_and_attachments/1,
-         floor_forces_resync/1]).
+         floor_forces_resync/1,
+         source_lacks_feed_reports_skipped/1,
+         target_lacks_feed_puts_land_without_lww/1,
+         s3_target_receives_puts_and_deletes/1,
+         s3_target_rejects_stale_replicated_write_minio/1,
+         s3_target_rejects_stale_replicated_write_garage/1,
+         bidirectional_lww_convergence_rocksdb_and_s3/1,
+         bidirectional_lww_convergence_s3_to_s3/1]).
 
 all() ->
     [basic_sync_and_digest_skip,
@@ -29,7 +36,14 @@ all() ->
      checkpoint_resume,
      off_switch,
      mixed_docs_and_attachments,
-     floor_forces_resync].
+     floor_forces_resync,
+     source_lacks_feed_reports_skipped,
+     target_lacks_feed_puts_land_without_lww,
+     s3_target_receives_puts_and_deletes,
+     s3_target_rejects_stale_replicated_write_minio,
+     s3_target_rejects_stale_replicated_write_garage,
+     bidirectional_lww_convergence_rocksdb_and_s3,
+     bidirectional_lww_convergence_s3_to_s3].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(barrel_docdb),
@@ -186,4 +200,278 @@ floor_forces_resync(Config) ->
                                                        <<"keep">>)
     after
         _ = barrel_docdb:delete_db(Src)
+    end.
+
+%%====================================================================
+%% Replication asymmetry: barrel_rep_att's "skipped" degrade only checks
+%% the SOURCE's feed support (barrel_rep_att:supports/1 gates on the
+%% transport, not the backend; the actual skip comes from the source's
+%% att_changes/4 call failing at runtime) -- nothing checks the target.
+%% Uses its own src/tgt pair (not the suite's shared per-testcase ones)
+%% since these need a non-default att_opts.backend.
+%%====================================================================
+
+source_lacks_feed_reports_skipped(Config) ->
+    Dir = ?config(dir, Config),
+    Src = <<"asym_nofeed_src">>,
+    Tgt = <<"asym_nofeed_tgt">>,
+    {ok, _} = barrel_docdb:create_db(Src, #{
+        data_dir => Dir,
+        att_opts => #{backend => barrel_docdb_test_att_backend_minimal}
+    }),
+    {ok, _} = barrel_docdb:create_db(Tgt, #{data_dir => Dir}),
+    try
+        {ok, _} = barrel_docdb:put_attachment(Src, <<"d">>, <<"f">>, <<"v">>),
+        {ok, R} = barrel_rep:replicate(Src, Tgt),
+        ?assertEqual(skipped, att_stats(R)),
+        %% the attachment never replicates: with no feed to enumerate
+        %% changes from, the sync phase has nothing to walk, even though
+        %% put/get on Src itself works fine
+        ?assertEqual({error, not_found},
+                     barrel_docdb:get_attachment(Tgt, <<"d">>, <<"f">>))
+    after
+        _ = barrel_docdb:delete_db(Src),
+        _ = barrel_docdb:delete_db(Tgt)
+    end.
+
+%% Puts/deletes are required callbacks, not feed-gated, so replicating
+%% INTO a feedless target still moves bytes -- but with no feed there to
+%% check origin_hlc against, an older value from the source can clobber
+%% a newer one already on the target, unlike RocksDB<->RocksDB (where the
+%% target's own feed would reject the stale write via barrel_att_feed:check/6).
+target_lacks_feed_puts_land_without_lww(Config) ->
+    Dir = ?config(dir, Config),
+    Src = <<"asym_target_nofeed_src">>,
+    Tgt = <<"asym_target_nofeed_tgt">>,
+    {ok, _} = barrel_docdb:create_db(Src, #{data_dir => Dir}),
+    {ok, _} = barrel_docdb:create_db(Tgt, #{
+        data_dir => Dir,
+        att_opts => #{backend => barrel_docdb_test_att_backend_minimal}
+    }),
+    try
+        %% the target's own, more recent state
+        {ok, _} = barrel_docdb:put_attachment(Tgt, <<"d">>, <<"f">>, <<"new">>),
+        %% the source has an older value for the same attachment
+        {ok, _} = barrel_docdb:put_attachment(Src, <<"d">>, <<"f">>, <<"old">>),
+        {ok, R} = barrel_rep:replicate(Src, Tgt),
+        ?assertMatch(#{atts_written := 1}, att_stats(R)),
+        ?assertEqual({ok, <<"old">>},
+                     barrel_docdb:get_attachment(Tgt, <<"d">>, <<"f">>))
+    after
+        _ = barrel_docdb:delete_db(Src),
+        _ = barrel_docdb:delete_db(Tgt)
+    end.
+
+%%====================================================================
+%% M2: barrel_att_s3 as a replication TARGET. barrel_att_s3_store's own
+%% suite (barrel_att_s3_SUITE) already unit-tests the LWW guard directly
+%% against the backend (origin_hlc_stale_put_ignored and friends); these
+%% prove the same guard is correctly wired end-to-end through
+%% barrel_rep_att/barrel_rep_transport_local when the target itself is
+%% S3-backed -- retiring the M1 "S3 should only be a replication source"
+%% limitation (barrel_att_s3 had no feed at all, so a target using it
+%% could never enforce LWW; see target_lacks_feed_puts_land_without_lww
+%% above for the general feedless case this used to fall into).
+%%
+%% barrel_docdb already references barrel_att_s3_store by bare atom (see
+%% barrel_att_store:backend_module/1) without a hard app dependency --
+%% is_available/1 probes for it at runtime -- so these tests need no
+%% special build wiring beyond running under a build that also has
+%% barrel_att_s3 (and so livery_s3) on the code path, i.e. `rebar3 as s3
+%% ct'. Skip cleanly (not fail) when that isn't the case, or when the
+%% real MinIO/Garage fixture isn't reachable -- same reasoning as
+%% barrel_att_s3_SUITE's own group skips.
+%%====================================================================
+
+s3_target_receives_puts_and_deletes(Config) ->
+    with_minio(fun(S3Opts) ->
+        run_s3_target_receives_puts_and_deletes(Config, S3Opts)
+    end).
+
+run_s3_target_receives_puts_and_deletes(Config, S3Opts) ->
+    Dir = ?config(dir, Config),
+    Src = <<"s3_basic_src">>,
+    Tgt = <<"s3_basic_tgt_minio">>,
+    {ok, _} = barrel_docdb:create_db(Src, #{data_dir => Dir}),
+    {ok, _} = barrel_docdb:create_db(Tgt, #{
+        data_dir => Dir,
+        att_opts => #{backend => s3, s3 => S3Opts}
+    }),
+    try
+        {ok, _} = barrel_docdb:put_attachment(Src, <<"d1">>, <<"a.txt">>, <<"alpha">>),
+        {ok, _} = barrel_docdb:put_attachment(Src, <<"d2">>, <<"b.bin">>,
+                                              binary:copy(<<"z">>, 200000)),
+        {ok, R1} = barrel_rep:replicate(Src, Tgt),
+        ?assertMatch(#{atts_written := 2, atts_skipped := 0}, att_stats(R1)),
+        {ok, <<"alpha">>} = barrel_docdb:get_attachment(Tgt, <<"d1">>, <<"a.txt">>),
+        {ok, Big} = barrel_docdb:get_attachment(Tgt, <<"d2">>, <<"b.bin">>),
+        ?assertEqual(200000, byte_size(Big)),
+        %% second run: nothing to do (checkpointed, zero re-transfer) --
+        %% exactly basic_sync_and_digest_skip's proof, now with an S3 target
+        {ok, R2} = barrel_rep:replicate(Src, Tgt),
+        ?assertMatch(#{atts_written := 0}, att_stats(R2)),
+
+        ok = barrel_docdb:delete_attachment(Src, <<"d1">>, <<"a.txt">>),
+        {ok, R3} = barrel_rep:replicate(Src, Tgt),
+        ?assertMatch(#{atts_deleted := 1}, att_stats(R3)),
+        ?assertEqual({error, not_found},
+                     barrel_docdb:get_attachment(Tgt, <<"d1">>, <<"a.txt">>)),
+
+        ok = barrel_docdb:delete_attachment(Src, <<"d2">>, <<"b.bin">>),
+        {ok, _} = barrel_rep:replicate(Src, Tgt)
+    after
+        _ = barrel_docdb:delete_db(Src),
+        _ = barrel_docdb:delete_db(Tgt)
+    end.
+
+s3_target_rejects_stale_replicated_write_minio(Config) ->
+    with_minio(fun(S3Opts) ->
+        run_s3_target_rejects_stale_replicated_write(Config, S3Opts,
+                                                     <<"s3_lww_src_minio">>,
+                                                     <<"s3_lww_tgt_minio">>)
+    end).
+
+s3_target_rejects_stale_replicated_write_garage(Config) ->
+    with_garage(fun(S3Opts) ->
+        run_s3_target_rejects_stale_replicated_write(Config, S3Opts,
+                                                     <<"s3_lww_src_garage">>,
+                                                     <<"s3_lww_tgt_garage">>)
+    end).
+
+%% A (RocksDB) writes first -- its own feed row gets the EARLIER origin,
+%% since barrel_hlc:new_hlc/0 draws from the single node-global clock and
+%% only ever advances. B (S3) writes second, so its own row is genuinely,
+%% provably LATER. Replicating A -> B therefore offers B a real (not
+%% contrived) stale write for the same attachment: a target with a working
+%% feed must reject it (atts_ignored, not atts_written) and keep its own
+%% newer value -- the exact behavior
+%% target_lacks_feed_puts_land_without_lww shows a feedless target cannot
+%% provide.
+run_s3_target_rejects_stale_replicated_write(Config, S3Opts, SrcName, TgtName) ->
+    Dir = ?config(dir, Config),
+    {ok, _} = barrel_docdb:create_db(SrcName, #{data_dir => Dir}),
+    {ok, _} = barrel_docdb:create_db(TgtName, #{
+        data_dir => Dir,
+        att_opts => #{backend => s3, s3 => S3Opts}
+    }),
+    try
+        {ok, _} = barrel_docdb:put_attachment(SrcName, <<"d">>, <<"f">>, <<"from a">>),
+        {ok, _} = barrel_docdb:put_attachment(TgtName, <<"d">>, <<"f">>, <<"from b">>),
+        {ok, R} = barrel_rep:replicate(SrcName, TgtName),
+        ?assertMatch(#{atts_written := 0, atts_ignored := 1}, att_stats(R)),
+        ?assertEqual({ok, <<"from b">>},
+                     barrel_docdb:get_attachment(TgtName, <<"d">>, <<"f">>)),
+        ok = barrel_docdb:delete_attachment(TgtName, <<"d">>, <<"f">>)
+    after
+        _ = barrel_docdb:delete_db(SrcName),
+        _ = barrel_docdb:delete_db(TgtName)
+    end.
+
+%% Mirrors bidirectional_lww_convergence (M1, RocksDB<->RocksDB) with B
+%% now S3-backed: both sides write the same attachment concurrently, sync
+%% both ways twice, and confirm both converge to the SAME value with a
+%% final idle round moving nothing -- the property that only holds if the
+%% S3 side's own feed is correctly guarding against oscillation.
+bidirectional_lww_convergence_rocksdb_and_s3(Config) ->
+    with_minio(fun(S3Opts) ->
+        run_bidirectional_lww_convergence(Config, undefined, S3Opts,
+                                          <<"s3_conv_a">>, <<"s3_conv_b_minio">>)
+    end).
+
+%% The genuine "S3 to S3" case: both peers are real, but different,
+%% S3-compatible stores (MinIO and Garage) -- proves convergence doesn't
+%% depend on anything specific to one implementation.
+bidirectional_lww_convergence_s3_to_s3(Config) ->
+    with_minio(fun(MinioOpts) ->
+        with_garage(fun(GarageOpts) ->
+            run_bidirectional_lww_convergence(Config, MinioOpts, GarageOpts,
+                                              <<"s3_conv_minio">>, <<"s3_conv_garage">>)
+        end)
+    end).
+
+run_bidirectional_lww_convergence(Config, AOpts, BOpts, AName, BName) ->
+    Dir = ?config(dir, Config),
+    AAttOpts = case AOpts of
+        undefined -> #{};
+        _ -> #{att_opts => #{backend => s3, s3 => AOpts}}
+    end,
+    BAttOpts = case BOpts of
+        undefined -> #{};
+        _ -> #{att_opts => #{backend => s3, s3 => BOpts}}
+    end,
+    {ok, _} = barrel_docdb:create_db(AName, maps:merge(#{data_dir => Dir}, AAttOpts)),
+    {ok, _} = barrel_docdb:create_db(BName, maps:merge(#{data_dir => Dir}, BAttOpts)),
+    try
+        {ok, _} = barrel_docdb:put_attachment(AName, <<"d">>, <<"f">>, <<"from a">>),
+        {ok, _} = barrel_docdb:put_attachment(BName, <<"d">>, <<"f">>, <<"from b">>),
+        {ok, _} = barrel_rep:replicate(AName, BName),
+        {ok, _} = barrel_rep:replicate(BName, AName),
+        {ok, _} = barrel_rep:replicate(AName, BName),
+        {ok, _} = barrel_rep:replicate(BName, AName),
+        {ok, VA} = barrel_docdb:get_attachment(AName, <<"d">>, <<"f">>),
+        {ok, VB} = barrel_docdb:get_attachment(BName, <<"d">>, <<"f">>),
+        ?assertEqual(VA, VB),
+        ?assert(lists:member(VA, [<<"from a">>, <<"from b">>])),
+        {ok, R} = barrel_rep:replicate(AName, BName),
+        ?assertMatch(#{atts_written := 0, atts_ignored := 0}, att_stats(R)),
+        ok = barrel_docdb:delete_attachment(AName, <<"d">>, <<"f">>)
+    after
+        _ = barrel_docdb:delete_db(AName),
+        _ = barrel_docdb:delete_db(BName)
+    end.
+
+%%====================================================================
+%% S3 fixture helpers (real MinIO/Garage, same conventions and defaults
+%% as apps/barrel_att_s3/test/barrel_att_s3_SUITE.erl -- see
+%% test/e2e/attachments-s3-setup.sh)
+%%====================================================================
+
+with_minio(Fun) ->
+    case s3_backend_available() andalso barrel_att_s3_test_support:minio_opts() of
+        false ->
+            {skip, s3_backend_not_available};
+        S3Opts ->
+            case s3_reachable(S3Opts) of
+                true -> Fun(S3Opts);
+                false -> {skip, {minio_not_reachable, maps:get(endpoint, S3Opts)}}
+            end
+    end.
+
+with_garage(Fun) ->
+    case s3_backend_available() andalso barrel_att_s3_test_support:garage_opts() of
+        false ->
+            {skip, s3_backend_not_available};
+        undefined ->
+            {skip, garage_credentials_not_configured};
+        S3Opts ->
+            case s3_reachable(S3Opts) of
+                true -> Fun(S3Opts);
+                false -> {skip, {garage_not_reachable, maps:get(endpoint, S3Opts)}}
+            end
+    end.
+
+%% barrel_att_s3 (and so livery_s3) is only on the code path under
+%% `rebar3 as s3 ...' -- outside it, barrel_att_store:is_available(s3)
+%% already returns false the same way, but checking livery_s3 directly
+%% here avoids a hard compile-time dependency on barrel_att_store's
+%% internal helper staying exported for this exact purpose.
+s3_backend_available() ->
+    case code:ensure_loaded(livery_s3) of
+        {module, livery_s3} -> true;
+        {error, _} -> false
+    end.
+
+%% Same probe as barrel_att_s3_test_support:reachable/1, plus (MinIO only)
+%% making sure the bucket itself exists -- Garage buckets/keys are
+%% provisioned externally (see test/e2e/attachments-s3-setup.sh) and can't
+%% be created by a scoped key, matching barrel_att_s3_SUITE's own
+%% init_per_group split.
+s3_reachable(#{bucket := Bucket} = S3Opts) ->
+    case barrel_att_s3_test_support:reachable(S3Opts) of
+        true ->
+            Client = livery_s3:new(maps:without([bucket], S3Opts)),
+            _ = livery_s3:create_bucket(Client, Bucket),
+            true;
+        false ->
+            false
     end.

--- a/apps/barrel_docdb/test/barrel_timeline_SUITE.erl
+++ b/apps/barrel_docdb/test/barrel_timeline_SUITE.erl
@@ -25,7 +25,8 @@
     delete_parent_branch_survives/1,
     list_branches_open_only/1,
     branch_sweeper_independent_floor/1,
-    merge_after_branch_sweep/1
+    merge_after_branch_sweep/1,
+    fork_checkpointless_backend_returns_clean_error/1
 ]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -39,7 +40,8 @@ all() ->
      fork_channels_inherited, branch_reopen_resumes_channels,
      inherited_rep_checkpoints_inert, delete_closed_branch_removes_files,
      delete_parent_branch_survives, list_branches_open_only,
-     branch_sweeper_independent_floor, merge_after_branch_sweep].
+     branch_sweeper_independent_floor, merge_after_branch_sweep,
+     fork_checkpointless_backend_returns_clean_error].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(barrel_docdb),
@@ -592,5 +594,29 @@ merge_after_branch_sweep(Config) ->
         {ok, _} = barrel_docdb:get_doc(Db0, <<"doomed">>)
     after
         _ = barrel_docdb:delete_db(Branch)
+    end,
+    ok.
+
+%% A backend without checkpoint/2 used to crash the caller: fork/6 did a
+%% bare {ok, ForkHlc} = checkpoint_to(...) match, and checkpoint_to returns
+%% {error, unsupported} for such a backend, badmatching into a catch-all
+%% that re-raised instead of returning a clean {error, _}. Uses its own
+%% parent/branch pair (not the suite's shared per-testcase db) since it
+%% needs a non-default att_opts.backend.
+fork_checkpointless_backend_returns_clean_error(Config) ->
+    DataDir = ?config(data_dir, Config),
+    Parent = <<"tl_nocheckpoint_parent">>,
+    Branch = <<"tl_nocheckpoint_branch">>,
+    {ok, _} = barrel_docdb:create_db(Parent, #{
+        data_dir => DataDir,
+        att_opts => #{backend => barrel_docdb_test_att_backend_minimal}
+    }),
+    try
+        ?assertMatch({error, _}, barrel_docdb:branch_db(Parent, Branch, #{})),
+        %% no half-created branch directory left behind
+        BranchPath = filename:join(DataDir, binary_to_list(Branch)),
+        ?assertNot(filelib:is_dir(BranchPath))
+    after
+        _ = barrel_docdb:delete_db(Parent)
     end,
     ok.

--- a/apps/barrel_server/src/barrel_server_dbs.erl
+++ b/apps/barrel_server/src/barrel_server_dbs.erl
@@ -8,7 +8,7 @@
 %%%-------------------------------------------------------------------
 -module(barrel_server_dbs).
 
--export([ensure/1, close/1, branch/3, destroy/1, list/0]).
+-export([ensure/1, ensure/2, close/1, branch/3, destroy/1, list/0]).
 
 -define(MAX_NAME_LEN, 128).
 
@@ -19,10 +19,31 @@
 %% @doc Return the (possibly newly opened) handle for `Name'.
 -spec ensure(binary()) -> {ok, barrel:db()} | {error, term()}.
 ensure(Name) when is_binary(Name) ->
+    ensure(Name, #{}).
+
+%% @doc Same as `ensure/1', with `Opts' (e.g. `#{docdb => #{att_opts =>
+%% ...}}') merged over the server-wide `open_opts()' baseline -- only
+%% takes effect on a cold open (genuinely new, or reopened after being
+%% closed): an already-open `Name' short-circuits in `barrel_dbs' before
+%% Opts is ever consulted.
+-spec ensure(binary(), map()) -> {ok, barrel:db()} | {error, term()}.
+ensure(Name, Opts) when is_binary(Name), is_map(Opts) ->
     case valid_name(Name) of
-        true -> barrel_dbs:ensure(Name, open_opts());
+        true -> barrel_dbs:ensure(Name, merge_opts(Opts));
         false -> {error, invalid_name}
     end.
+
+%% @private `barrel:open/2' reads `docdb'/`vectordb' as nested sub-maps
+%% (see barrel.erl:open_plain/2), so a flat maps:merge/2 of the caller's
+%% Opts over open_opts() would silently DROP any static `docdb' config
+%% this server was started with (e.g. an operator-set encryption spec)
+%% whenever a caller supplies its own `docdb' sub-map (`att_opts') --
+%% merge that one key one level deeper instead of wholesale replacing it.
+merge_opts(Opts) ->
+    Base = open_opts(),
+    BaseDocdb = maps:get(docdb, Base, #{}),
+    CallerDocdb = maps:get(docdb, Opts, #{}),
+    (maps:merge(Base, Opts))#{docdb => maps:merge(BaseDocdb, CallerDocdb)}.
 
 %% @doc Close and forget the database `Name'. Idempotent.
 -spec close(binary()) -> ok.

--- a/apps/barrel_server/src/barrel_server_http.erl
+++ b/apps/barrel_server/src/barrel_server_http.erl
@@ -113,12 +113,127 @@ health(_Req) ->
 %% Database lifecycle
 %%====================================================================
 
+%% @doc `Body' is optional (an empty body is `#{}', not an error, same as
+%% `with_json' everywhere else) -- a plain `PUT /db/:name' keeps behaving
+%% exactly as before. `att_opts' picks a non-default attachment backend
+%% (e.g. S3); see `att_opts_from_json/1'.
 create_db(Req) ->
     Name = livery_req:binding(<<"db">>, Req),
-    case barrel_server_dbs:ensure(Name) of
+    with_json(Req, fun(Body) ->
+        case att_opts_from_json(maps:get(<<"att_opts">>, Body, undefined)) of
+            {error, _} = Err ->
+                error_resp(Err);
+            {ok, undefined} ->
+                do_create_db(Name, #{});
+            {ok, AttOpts} ->
+                %% barrel:open/2 (barrel_server_dbs:ensure/2's eventual
+                %% callee) reads att_opts nested under `docdb', not at
+                %% the top level -- see barrel.erl:open_plain/2.
+                do_create_db(Name, #{docdb => #{att_opts => AttOpts}})
+        end
+    end).
+
+do_create_db(Name, Opts) ->
+    case barrel_server_dbs:ensure(Name, Opts) of
         {ok, _Db} -> json_resp(201, #{ok => true, db => Name});
         Err -> error_resp(Err)
     end.
+
+%% @private `undefined' (no `att_opts' key at all) passes through
+%% unchanged -- create_db keeps defaulting to the RocksDB backend.
+%% `backend' is an explicit whitelist match, not a generic atom
+%% conversion, so a bad value is a clean 400 rather than a crash. The `s3'
+%% sub-map is NOT a hardcoded field whitelist: barrel_att_s3_store's own
+%% contract is "everything except bucket/part_size passes straight to
+%% livery_s3:new/1", so keys convert via binary_to_existing_atom/2 instead
+%% -- every option livery_s3:new/1 or barrel_att_s3_store itself reads
+%% (bucket, endpoint, region, access_key_id, secret_access_key,
+%% session_token, part_size, ...) is already an atom that exists in the
+%% compiled code, so this needs no maintained list and safely rejects
+%% genuine garbage instead of minting new atoms.
+att_opts_from_json(undefined) ->
+    {ok, undefined};
+att_opts_from_json(#{<<"backend">> := BackendBin} = Json) ->
+    case backend_from_json(BackendBin) of
+        {error, _} = Err ->
+            Err;
+        {ok, Backend} ->
+            case ensure_backend_loaded(Backend) of
+                {error, _} = Err -> Err;
+                ok ->
+                    case s3_opts_from_json(maps:get(<<"s3">>, Json, #{})) of
+                        {error, _} = Err -> Err;
+                        {ok, S3Opts} -> check_required_s3_opts(Backend, S3Opts)
+                    end
+            end
+    end;
+att_opts_from_json(_) ->
+    {error, {bad_att_opts, missing_backend}}.
+
+backend_from_json(<<"blob">>) -> {ok, blob};
+backend_from_json(<<"s3">>) -> {ok, s3};
+backend_from_json(Other) -> {error, {bad_att_opts, {unknown_backend, Other}}}.
+
+%% @private `binary_to_existing_atom/2' in `s3_opts_from_json/1' only
+%% accepts a key whose atom is already registered in the VM -- correct, so
+%% a garbage key can never mint a new atom, but that registration happens
+%% when `livery_s3'/`barrel_att_s3_store' are *loaded*, which only happens
+%% on its own under the `s3'/`s3_server' profiles. A plain `server' build
+%% (e.g. CI's `rebar3 as server ct') never loads either module by itself,
+%% so every genuinely valid s3 option would otherwise be misreported as
+%% `unknown_s3_option'. Force the load here instead of hoping something
+%% else already did it, and report plainly when the backend truly isn't
+%% part of this build.
+ensure_backend_loaded(s3) ->
+    case code:ensure_loaded(livery_s3) of
+        {module, livery_s3} ->
+            {module, barrel_att_s3_store} = code:ensure_loaded(barrel_att_s3_store),
+            ok;
+        {error, _} ->
+            {error, {bad_att_opts, {backend_unavailable, s3}}}
+    end;
+ensure_backend_loaded(_) ->
+    ok.
+
+s3_opts_from_json(Json) when is_map(Json) ->
+    try
+        {ok, maps:fold(fun(K, V, Acc) ->
+            Acc#{binary_to_existing_atom(K, utf8) => V}
+        end, #{}, Json)}
+    catch
+        error:badarg -> {error, {bad_att_opts, {unknown_s3_option, redact_secrets(Json)}}}
+    end;
+s3_opts_from_json(_) ->
+    {error, {bad_att_opts, s3_must_be_object}}.
+
+%% @private `endpoint' has no default anywhere downstream (livery_s3:new/1
+%% does a bare maps:get(endpoint, Opts), no fallback) -- catch a missing
+%% one here with a clean 400 rather than let a raw {badkey, endpoint} term
+%% reach a caller. `bucket' doesn't need the same treatment:
+%% barrel_att_s3_store:open/2 already reports a clean {error,
+%% missing_bucket} for it.
+check_required_s3_opts(s3, S3Opts) ->
+    case maps:is_key(endpoint, S3Opts) of
+        true -> {ok, #{backend => s3, s3 => S3Opts}};
+        false -> {error, {bad_att_opts, {missing_required_s3_option, endpoint}}}
+    end;
+check_required_s3_opts(Backend, S3Opts) ->
+    {ok, #{backend => Backend, s3 => S3Opts}}.
+
+%% @private The caller's own submitted `s3' map is echoed back in the
+%% error (to name the offending key), but not their credentials -- an
+%% error response body can land in access logs, browser history, or a
+%% proxy's logs in ways the caller likely didn't intend, and even a
+%% single misspelled key would otherwise echo the whole map back.
+redact_secrets(Json) when is_map(Json) ->
+    maps:map(fun
+        (K, _V) when K =:= <<"secret_access_key">>;
+                    K =:= <<"access_key_id">>;
+                    K =:= <<"session_token">> ->
+            <<"[redacted]">>;
+        (_K, V) ->
+            V
+    end, Json).
 
 db_info(Req) ->
     with_db(Req, fun(Db) ->
@@ -746,19 +861,66 @@ emit_changes([C | Rest], Emit) ->
 %% Attachments
 %%====================================================================
 
+%% @doc `If-None-Match: *' / `If-Match: <etag>' opt into S3 conditional
+%% writes (`create_only'/`expected_etag' -- see barrel_att_s3_store); a
+%% backend that can't evaluate them (Garage) or doesn't understand them at
+%% all (the default RocksDB backend) is handled by the callee, not here.
 put_att(Req) ->
     with_db(Req, fun(Db) ->
         Id = livery_req:binding(<<"id">>, Req),
         Name = livery_req:binding(<<"name">>, Req),
-        case read_body(Req) of
-            {ok, Data} ->
-                case barrel:put_attachment(Db, Id, Name, Data) of
-                    {ok, Res} -> json_resp(201, jsonable(Res));
+        case att_write_opts(Req) of
+            {error, _} = Err ->
+                error_resp(Err);
+            {ok, Opts} ->
+                case read_body(Req) of
+                    {ok, Data} ->
+                        case barrel:put_attachment(Db, Id, Name, Data, Opts) of
+                            {ok, Res} -> json_resp(201, jsonable(Res));
+                            Err -> error_resp(Err)
+                        end;
                     Err -> error_resp(Err)
-                end;
-            Err -> error_resp(Err)
+                end
         end
     end).
+
+att_write_opts(Req) ->
+    case if_none_match_opt(Req) of
+        {error, _} = Err ->
+            Err;
+        {ok, CreateOnlyOpts} ->
+            %% if_match_opt/1 never fails (any If-Match value is a valid,
+            %% if possibly non-matching, etag) -- unlike if_none_match_opt/1
+            %% above, whose non-"*" values are rejected.
+            {ok, ExpectedEtagOpts} = if_match_opt(Req),
+            {ok, maps:merge(CreateOnlyOpts, ExpectedEtagOpts)}
+    end.
+
+%% `create_only' is a boolean in the Erlang API, not an etag -- only the
+%% wildcard form of If-None-Match has an equivalent to translate.
+if_none_match_opt(Req) ->
+    case livery_req:header(<<"if-none-match">>, Req, undefined) of
+        undefined -> {ok, #{}};
+        <<"*">> -> {ok, #{create_only => true}};
+        Other -> {error, {bad_if_none_match, Other}}
+    end.
+
+-spec if_match_opt(term()) -> {ok, map()}.
+if_match_opt(Req) ->
+    case livery_req:header(<<"if-match">>, Req, undefined) of
+        undefined -> {ok, #{}};
+        Etag -> {ok, #{expected_etag => unquote_etag(Etag)}}
+    end.
+
+%% HTTP etags are conventionally quoted ("abc123"); barrel_att_s3_store's
+%% own etag values (e.g. from get_info) are already unquoted internally.
+unquote_etag(<<$", Rest/binary>>) when byte_size(Rest) > 0 ->
+    case binary:last(Rest) of
+        $" -> binary:part(Rest, 0, byte_size(Rest) - 1);
+        _ -> <<$", Rest/binary>>
+    end;
+unquote_etag(Etag) ->
+    Etag.
 
 get_att(Req) ->
     with_db(Req, fun(Db) ->
@@ -990,7 +1152,27 @@ error_resp(invalid_name) -> json_resp(400, #{error => <<"invalid_name">>});
 error_resp(bad_json) -> json_resp(400, #{error => <<"bad_json">>});
 error_resp({invalid_provenance, _}) ->
     json_resp(400, #{error => <<"invalid_provenance">>});
+error_resp({bad_att_opts, Reason}) ->
+    json_resp(400, #{error => <<"bad_att_opts">>,
+                     reason => iolist_to_binary(io_lib:format("~p", [Reason]))});
 error_resp(conflict) -> json_resp(409, #{error => <<"conflict">>});
+error_resp({conflict, CurrentInfo}) ->
+    json_resp(409, jsonable(#{error => <<"conflict">>, current => CurrentInfo}));
+%% The store can't evaluate If-Match/If-None-Match at all (Garage) -- not
+%% a failed precondition (that's {conflict, _} above, 409: the store DID
+%% evaluate it and it lost), a materially different, non-retryable-the-
+%% same-way condition. Already fast at the backend level (conditional
+%% write support is probed once at open/2 and cached; no S3 call is
+%% attempted here), so nothing extra to do on the HTTP side either.
+error_resp(conditional_writes_unsupported) ->
+    json_resp(501, #{error => <<"conditional_writes_unsupported">>});
+error_resp({bad_if_none_match, _}) ->
+    json_resp(400, #{error => <<"bad_if_none_match">>});
+%% A freshly forked S3-backed branch: the local feed already knows this
+%% attachment exists, but the background copy sweep hasn't reached it yet
+%% (see barrel_att_s3_store's "Branching" moduledoc section). Transient,
+%% not a server error -- retry shortly.
+error_resp({att_sync_pending, _}) -> json_resp(503, #{error => <<"att_sync_pending">>});
 error_resp(bad_since) -> json_resp(400, #{error => <<"bad_since">>});
 error_resp(bad_until) -> json_resp(400, #{error => <<"bad_until">>});
 error_resp(bad_limit) -> json_resp(400, #{error => <<"bad_limit">>});

--- a/apps/barrel_server/test/barrel_server_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_SUITE.erl
@@ -27,7 +27,13 @@
     t_query_subscribe_requires_sse/1,
     t_query_subscribe_sse/1,
     t_not_found/1,
-    t_no_atom_leak/1
+    t_no_atom_leak/1,
+    t_create_db_att_opts_validation/1,
+    t_create_db_att_opts_missing_endpoint/1,
+    t_create_db_att_opts_redacts_secrets/1,
+    t_create_db_att_opts_blob_explicit/1,
+    t_attachment_conditional_headers_unenforced_on_blob/1,
+    t_attachment_bad_if_none_match/1
 ]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -41,7 +47,11 @@ all() ->
      t_changes_continuous, t_embedding,
      t_query_ndjson, t_query_get, t_query_params_json,
      t_query_parse_error, t_query_subscribe_requires_sse,
-     t_query_subscribe_sse, t_not_found, t_no_atom_leak].
+     t_query_subscribe_sse, t_not_found, t_no_atom_leak,
+     t_create_db_att_opts_validation, t_create_db_att_opts_missing_endpoint,
+     t_create_db_att_opts_redacts_secrets, t_create_db_att_opts_blob_explicit,
+     t_attachment_conditional_headers_unenforced_on_blob,
+     t_attachment_bad_if_none_match].
 
 init_per_suite(Config) ->
     %% Load first, then override env (application:load resets to .app defaults).
@@ -320,6 +330,11 @@ req_raw_h(Method, Url, Headers) ->
                                         <<>>, [with_body]),
     {S, Body}.
 
+%% Like req/3, but with caller-supplied headers (e.g. If-Match/
+%% If-None-Match) -- the response body is still JSON-decoded.
+req_h(Method, Url, Headers, Body) ->
+    decode(hackney:request(Method, list_to_binary(Url), Headers, Body, [with_body])).
+
 decode({ok, S, _H, Body}) ->
     Decoded = case Body of
         <<>> -> #{};
@@ -340,4 +355,117 @@ t_no_atom_leak(Config) ->
     ?assertError(badarg,
                  binary_to_existing_atom(list_to_binary(Name), utf8)),
     {200, _} = req(delete, B ++ "/db/" ++ Name, <<>>),
+    ok.
+
+%%====================================================================
+%% att_opts / conditional-write HTTP surface (no real S3 needed: these
+%% either fail validation before any backend is touched, or exercise the
+%% "blob" branch, which needs no bucket/credentials at all)
+%%====================================================================
+
+t_create_db_att_opts_validation(Config) ->
+    B = base(Config),
+    %% att_opts given but no backend key at all
+    {400, Err1} = req_json(put, B ++ "/db/attoptsbad1",
+                           #{<<"att_opts">> => #{}}),
+    ?assertEqual(<<"bad_att_opts">>, maps:get(<<"error">>, Err1)),
+    %% unknown backend value
+    {400, Err2} = req_json(put, B ++ "/db/attoptsbad2",
+                           #{<<"att_opts">> => #{<<"backend">> => <<"not-a-backend">>}}),
+    ?assertEqual(<<"bad_att_opts">>, maps:get(<<"error">>, Err2)),
+    %% s3 sub-map with a key that isn't a real livery_s3/barrel_att_s3
+    %% option -- exercises the binary_to_existing_atom safety rejection
+    {400, Err3} = req_json(put, B ++ "/db/attoptsbad3",
+                           #{<<"att_opts">> => #{<<"backend">> => <<"s3">>,
+                                                 <<"s3">> => #{<<"totally_bogus_option">> => <<"x">>}}}),
+    ?assertEqual(<<"bad_att_opts">>, maps:get(<<"error">>, Err3)),
+    %% malformed JSON body entirely -- still the pre-existing bad_json path
+    {400, Err4} = req(put, B ++ "/db/attoptsbad4", <<"{not json">>),
+    ?assertEqual(<<"bad_json">>, maps:get(<<"error">>, Err4)),
+    ok.
+
+%% endpoint has no default anywhere downstream (livery_s3:new/1 does a
+%% bare maps:get(endpoint, Opts), no fallback) -- omitting it must be a
+%% clean 400, not a raw {badkey, endpoint} term leaking through as a 500.
+%% Under a plain `server' build (no `s3'/`s3_server' profile, e.g. CI's
+%% `rebar3 as server ct') the s3 backend itself isn't compiled in, so the
+%% honest answer is `backend_unavailable' rather than the endpoint check
+%% -- both are still a clean 400 bad_att_opts, never unknown_s3_option or
+%% a 500.
+t_create_db_att_opts_missing_endpoint(Config) ->
+    B = base(Config),
+    {400, Err} = req_json(put, B ++ "/db/attoptsnoendpoint",
+                          #{<<"att_opts">> => #{<<"backend">> => <<"s3">>,
+                                                <<"s3">> => #{<<"bucket">> => <<"x">>,
+                                                              <<"access_key_id">> => <<"a">>,
+                                                              <<"secret_access_key">> => <<"b">>}}}),
+    ?assertEqual(<<"bad_att_opts">>, maps:get(<<"error">>, Err)),
+    Reason = maps:get(<<"reason">>, Err),
+    Needle = case code:ensure_loaded(livery_s3) of
+        {module, livery_s3} -> <<"endpoint">>;
+        {error, _} -> <<"s3">>
+    end,
+    ?assertNotEqual(nomatch, binary:match(Reason, Needle)),
+    ok.
+
+%% An unknown s3 key echoes the submitted map back (to name the
+%% offending key), but must not echo a submitted credential value along
+%% with it -- that response body can land in access logs, browser
+%% history, or a proxy's logs in ways the caller likely didn't intend.
+t_create_db_att_opts_redacts_secrets(Config) ->
+    B = base(Config),
+    {400, Err} = req_json(put, B ++ "/db/attoptsredact",
+                          #{<<"att_opts">> => #{<<"backend">> => <<"s3">>,
+                                                <<"s3">> => #{<<"bucket">> => <<"x">>,
+                                                              <<"endpoint">> => <<"http://x">>,
+                                                              <<"access_key_id">> => <<"AKIASECRETID">>,
+                                                              <<"secret_access_key">> => <<"topsecretvalue">>,
+                                                              <<"totally_bogus_option">> => <<"y">>}}}),
+    ?assertEqual(<<"bad_att_opts">>, maps:get(<<"error">>, Err)),
+    Reason = maps:get(<<"reason">>, Err),
+    ?assertEqual(nomatch, binary:match(Reason, <<"topsecretvalue">>)),
+    ?assertEqual(nomatch, binary:match(Reason, <<"AKIASECRETID">>)),
+    case code:ensure_loaded(livery_s3) of
+        {module, livery_s3} ->
+            %% the offending key name is still visible, for debuggability
+            ?assertNotEqual(nomatch, binary:match(Reason, <<"totally_bogus_option">>));
+        {error, _} ->
+            %% s3 backend not compiled into this build -- rejected before
+            %% the offending key is ever inspected, nothing to redact
+            ok
+    end,
+    ok.
+
+%% "blob" is the explicit, valid form of the default backend -- exercises
+%% the full att_opts parse-and-thread path succeeding, without needing
+%% real S3 infrastructure (bucket/credentials) at all.
+t_create_db_att_opts_blob_explicit(Config) ->
+    B = base(Config),
+    {201, Resp} = req_json(put, B ++ "/db/attoptsblob",
+                           #{<<"att_opts">> => #{<<"backend">> => <<"blob">>}}),
+    ?assertEqual(true, maps:get(<<"ok">>, Resp)),
+    {201, _} = req_json(put, url("/doc/d1", B), #{}),
+    ok.
+
+%% Documented, pre-existing limitation (not introduced by this change):
+%% create_only/expected_etag are S3-specific Opts keys the default
+%% RocksDB (blob) backend's put/6 never inspects -- the header reaches
+%% the backend, but isn't enforced. Two writes with the "only if absent"
+%% header both succeed rather than the second one conflicting.
+t_attachment_conditional_headers_unenforced_on_blob(Config) ->
+    B = base(Config),
+    {201, _} = req_json(put, url("/doc/cond-doc", B), #{}),
+    Headers = [{<<"if-none-match">>, <<"*">>}],
+    {201, _} = req_h(put, url("/doc/cond-doc/att/f.txt", B), Headers, <<"first">>),
+    {201, _} = req_h(put, url("/doc/cond-doc/att/f.txt", B), Headers, <<"second">>),
+    {200, Body} = req_raw(get, url("/doc/cond-doc/att/f.txt", B)),
+    ?assertEqual(<<"second">>, Body),
+    ok.
+
+t_attachment_bad_if_none_match(Config) ->
+    B = base(Config),
+    {201, _} = req_json(put, url("/doc/bad-inm-doc", B), #{}),
+    Headers = [{<<"if-none-match">>, <<"\"some-etag\"">>}],
+    {400, Err} = req_h(put, url("/doc/bad-inm-doc/att/f.txt", B), Headers, <<"x">>),
+    ?assertEqual(<<"bad_if_none_match">>, maps:get(<<"error">>, Err)),
     ok.

--- a/rebar.config
+++ b/rebar.config
@@ -111,6 +111,58 @@
             {dev_mode, false},
             {include_erts, true}
         ]}
+    ]},
+    %% Opt the S3 attachment backend into the build. Pulls livery_s3 (and
+    %% livery); kept out of the default (embeddable) build.
+    %%   rebar3 as s3 compile
+    {s3, [
+        {project_app_dirs, [
+            "apps/barrel_crypto",
+            "apps/barrel_docdb",
+            "apps/barrel_ngram",
+            "apps/barrel_vectordb",
+            "apps/barrel_embed",
+            "apps/barrel_rerank",
+            "apps/barrel",
+            "apps/barrel_spaces",
+            "apps/barrel_att_s3"
+        ]}
+    ]},
+    %% Combined S3-backend + network-server release, used only by the S3
+    %% attachment-backend e2e fixture (test/e2e/attachments-s3.sh) and its
+    %% CI job. relx release definitions don't merge across profiles (each
+    %% `relx` stanza fully replaces the prior one on `as s3,server`), so
+    %% this profile declares the release explicitly rather than combining
+    %% `s3` and `server`.
+    %%   rebar3 as s3_server,prod release -n barrel_server
+    {s3_server, [
+        {project_app_dirs, [
+            "apps/barrel_crypto",
+            "apps/barrel_docdb",
+            "apps/barrel_ngram",
+            "apps/barrel_vectordb",
+            "apps/barrel_embed",
+            "apps/barrel_rerank",
+            "apps/barrel",
+            "apps/barrel_spaces",
+            "apps/barrel_server",
+            "apps/barrel_att_s3"
+        ]},
+        {shell, [
+            {apps, [barrel_server]}
+        ]},
+        {relx, [
+            {release, {barrel_server, "1.2.0"}, [
+                barrel_server,
+                barrel_att_s3,
+                sasl,
+                runtime_tools,
+                instrument
+            ]},
+            {dev_mode, true},
+            {include_erts, false},
+            {extended_start_script, true}
+        ]}
     ]}
 ]}.
 

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -24,8 +24,14 @@ RUN git init -q -b main \
     && git -c user.email=build@barrel -c user.name=build commit -qm "e2e build"
 
 # barrel_faiss is not in the server release (it needs a system FAISS build), so
-# this compiles barrel_server and its actual deps only.
-RUN rebar3 as server,prod release -n barrel_server
+# this compiles barrel_server and its actual deps only. RELX_PROFILES/
+# RELX_BUILD_DIR let the attachments-s3 fixture build the `s3_server,prod`
+# combo instead (adds the barrel_att_s3/livery_s3 backend to the release);
+# the two args must stay in sync (RELX_BUILD_DIR is RELX_PROFILES with `,`
+# replaced by `+`, rebar3's own profile-combo directory naming).
+ARG RELX_PROFILES=server,prod
+ARG RELX_BUILD_DIR=server+prod
+RUN rebar3 as ${RELX_PROFILES} release -n barrel_server
 
 FROM debian:trixie-slim AS runtime
 
@@ -37,7 +43,8 @@ RUN apt-get update \
         libzstd1 zlib1g libbz2-1.0 liblz4-1 libsnappy1v5 \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=build /src/_build/server+prod/rel/barrel_server /opt/barrel_server
+ARG RELX_BUILD_DIR=server+prod
+COPY --from=build /src/_build/${RELX_BUILD_DIR}/rel/barrel_server /opt/barrel_server
 
 ENV PATH="/opt/barrel_server/bin:${PATH}"
 # Databases live under the release dir. Data is ephemeral: each E2E run starts

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -18,16 +18,77 @@ It builds the image, starts `peer-a` and `peer-b`, then:
 
 - writes documents to peer-a and pushes to peer-b, asserting convergence;
 - writes to peer-b and pulls into peer-a;
-- deletes a document on peer-a and re-pushes, asserting the delete propagates.
+- deletes a document on peer-a and re-pushes, asserting the delete propagates;
+- starts a continuous `barrel_rep_tasks` push task between the peers, writes
+  a doc and asserts it converges, then puts an attachment on that same doc
+  with **no further doc change** and asserts it converges too. Attachments
+  live on their own feed, independent of the document changes feed, so this
+  is the scenario that only passes once a continuous task notices
+  attachment-only activity on its own (bounded wake), not because a doc
+  write happens to nudge it.
 
 Exit 0 means every assertion passed. The script tears the stack down on exit.
 
 Replication is triggered inside a peer with `barrel_server eval`, which evaluates
-against the running node, so it runs the real `barrel_rep` algorithm against the
-other peer's `_sync` endpoints.
+against the running node, so it runs the real `barrel_rep` algorithm (or, for the
+continuous-task scenario, `barrel_rep_tasks:start_task/1`) against the other
+peer's `_sync` endpoints.
+
+## S3 attachment backend
+
+`attachments-s3.sh` brings up real MinIO and Garage containers plus two
+`barrel_server` peers built with the S3 attachment backend included (the
+`s3_server` rebar3 profile), and exercises it over real HTTP routes and a
+real network -- not the CT suite against the backend module directly (that's
+`apps/barrel_att_s3/test/barrel_att_s3_SUITE.erl`).
+
+```console
+$ test/e2e/attachments-s3.sh
+```
+
+peer-a keeps the default (RocksDB) attachment backend; peer-b's databases
+point their `att_opts` at MinIO or Garage. It:
+
+- provisions MinIO and Garage (`attachments-s3-setup.sh` -- see below), then
+  round-trips a small and a large (multipart-crossing) attachment against
+  each store, and confirms a delete actually 404s afterward;
+- exercises `create_only` write-conflict detection directly against the
+  running node with `barrel_server eval` (there is no HTTP-level
+  `If-Match`/`If-None-Match` wiring yet, so this is Erlang-API-only, same as
+  it is today outside of HTTP): confirms MinIO genuinely rejects a colliding
+  write, and confirms Garage refuses fast with
+  `conditional_writes_unsupported` rather than silently accepting an
+  unprotected write -- Garage cannot enforce this by its own documented
+  design, and the whole point of the capability probe in
+  `barrel_att_s3_store:open/2` is to fail loudly instead of pretending;
+- replicates a document and its attachment from peer-a (RocksDB) to peer-b
+  (S3/MinIO) over the real `barrel_rep` HTTP transport, confirming the
+  documented source-has-a-feed/target-doesn't asymmetry doesn't stop puts
+  from landing.
+
+### attachments-s3-setup.sh
+
+Starts `docker-compose.attachments-s3.yml` (MinIO + Garage + two peer
+images) and provisions both stores -- `barrel_att_s3_store:open/2` never
+creates a bucket itself, and Garage additionally needs a one-time layout
+assignment before it serves any S3 request at all. Used by both
+`attachments-s3.sh` and the `s3` CI leg; safe to run on its own for local
+iteration against the CT suite:
+
+```console
+$ eval "$(test/e2e/attachments-s3-setup.sh)"
+$ rebar3 as s3 ct --suite apps/barrel_att_s3/test/barrel_att_s3_SUITE
+```
+
+Idempotent for MinIO. Not idempotent for Garage past the first run -- Garage
+never reveals a key's secret again after creation, so re-running against an
+already-provisioned volume fails loudly rather than silently reusing a key
+whose secret is gone. Run `docker compose -f
+test/e2e/docker-compose.attachments-s3.yml down -v` first to start clean.
 
 ## Requirements
 
 Docker and the Compose plugin. The image builds the `barrel_server` release on
 Debian (compiling rocksdb and the vector NIF), so the first run takes a few
-minutes; later runs reuse the cached image.
+minutes; later runs reuse the cached image. `attachments-s3.sh` additionally
+pulls the `minio/minio`, `dxflrs/garage`, and `minio/mc` images.

--- a/test/e2e/attachments-s3-setup.sh
+++ b/test/e2e/attachments-s3-setup.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Brings up MinIO + Garage (docker-compose.attachments-s3.yml) and provisions
+# both: barrel_att_s3_store's open/2 never creates a bucket itself (confirmed
+# by reading it -- it only checks that `bucket` was configured), so nothing
+# put through this backend works until the bucket exists. Garage additionally
+# needs a one-time layout assignment before it serves any S3 request at all,
+# and (unlike MinIO) a Garage key can't create its own bucket either way.
+#
+# Usage:
+#   test/e2e/attachments-s3-setup.sh              # start + provision, print exports
+#   eval "$(test/e2e/attachments-s3-setup.sh)"    # ... and load them into the shell
+#
+# Idempotent for MinIO (bucket creation is `--ignore-existing`). NOT
+# idempotent for Garage past the first run: Garage never reveals a key's
+# secret again after creation, so re-running against an already-provisioned
+# volume fails loudly rather than silently reusing a key whose secret this
+# script can no longer print. Run `docker compose -f
+# docker-compose.attachments-s3.yml down -v` first to start clean.
+#
+# On success, prints `export FOO=bar` lines for the Garage credentials to
+# stdout ONLY -- all progress/log output goes to stderr, so the stdout stream
+# stays safe to eval. Exit 0 = both stores ready, non-zero = failed.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE="docker compose -f $DIR/docker-compose.attachments-s3.yml"
+BUCKET=barrel-att-s3-test
+KEY_NAME=barrel-att-s3-key
+
+log() { echo "$@" >&2; }
+
+log "--- starting minio + garage"
+$COMPOSE up -d minio garage
+
+log "--- waiting for minio"
+minio_up=0
+for _ in $(seq 1 30); do
+    if curl -fsS http://127.0.0.1:19000/minio/health/live >/dev/null 2>&1; then
+        minio_up=1; break
+    fi
+    sleep 1
+done
+[ "$minio_up" -eq 1 ] || { log "  minio did not become healthy"; exit 1; }
+log "  minio is up"
+
+# --network container:<name> shares the minio container's own network
+# namespace, so this reaches it on 127.0.0.1 regardless of the compose
+# project's network name (which depends on the directory this repo is
+# checked out into and isn't worth depending on here).
+log "--- ensuring minio bucket $BUCKET"
+docker run --rm --network container:barrel-att-s3-minio \
+    -e MC_HOST_local="http://minioadmin:minioadmin@127.0.0.1:9000" \
+    minio/mc mb --ignore-existing "local/$BUCKET" >&2
+
+log "--- waiting for garage rpc"
+garage_up=0
+for _ in $(seq 1 30); do
+    if $COMPOSE exec -T garage /garage node id -q >/dev/null 2>&1; then
+        garage_up=1; break
+    fi
+    sleep 1
+done
+[ "$garage_up" -eq 1 ] || { log "  garage did not become reachable"; exit 1; }
+log "  garage is up"
+
+NODE_ID=$($COMPOSE exec -T garage /garage node id -q 2>/dev/null | tr -d '\r\n')
+NODE_ID="${NODE_ID%%@*}"
+# `layout show`'s ID column prints only the first 16 hex chars of the full
+# node id; assign accepts any unambiguous prefix, so use the short form
+# consistently for both the membership check and the assign call itself.
+NODE_ID="${NODE_ID:0:16}"
+
+if $COMPOSE exec -T garage /garage layout show 2>/dev/null | grep -q "$NODE_ID"; then
+    log "--- garage layout already assigned"
+else
+    log "--- assigning garage layout"
+    $COMPOSE exec -T garage /garage layout assign -z dc1 -c 1G "$NODE_ID" >&2
+    VERSION=$($COMPOSE exec -T garage /garage layout show 2>/dev/null \
+        | grep -oE 'layout version: [0-9]+' | grep -oE '[0-9]+')
+    NEXT_VERSION=$((VERSION + 1))
+    $COMPOSE exec -T garage /garage layout apply --version "$NEXT_VERSION" >&2
+fi
+
+if $COMPOSE exec -T garage /garage bucket list 2>/dev/null | awk '{print $1}' | grep -qx "$BUCKET"; then
+    log "--- garage bucket $BUCKET already exists"
+else
+    log "--- creating garage bucket $BUCKET"
+    $COMPOSE exec -T garage /garage bucket create "$BUCKET" >&2
+fi
+
+if $COMPOSE exec -T garage /garage key list 2>/dev/null | awk '{print $2}' | grep -qx "$KEY_NAME"; then
+    log "!!! key $KEY_NAME already exists and its secret cannot be recovered"
+    log "!!! run '$COMPOSE down -v' to start from a clean volume, then retry"
+    exit 1
+fi
+
+log "--- creating garage key $KEY_NAME"
+KEY_OUT=$($COMPOSE exec -T garage /garage key create "$KEY_NAME" 2>/dev/null)
+ACCESS_KEY=$(echo "$KEY_OUT" | sed -n 's/^Key ID: //p' | tr -d '\r')
+SECRET_KEY=$(echo "$KEY_OUT" | sed -n 's/^Secret key: //p' | tr -d '\r')
+[ -n "$ACCESS_KEY" ] && [ -n "$SECRET_KEY" ] || { log "!!! could not parse garage key output"; exit 1; }
+
+log "--- authorizing $KEY_NAME on $BUCKET"
+$COMPOSE exec -T garage /garage bucket allow "$BUCKET" --key "$KEY_NAME" --read --write >&2
+
+log "--- ready"
+echo "export GARAGE_S3_TEST_ACCESS_KEY=$ACCESS_KEY"
+echo "export GARAGE_S3_TEST_SECRET_KEY=$SECRET_KEY"
+echo "export GARAGE_S3_TEST_BUCKET=$BUCKET"

--- a/test/e2e/attachments-s3.sh
+++ b/test/e2e/attachments-s3.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+#
+# End-to-end test for the S3 attachment storage backend (barrel_att_s3),
+# against real MinIO and Garage containers and a real barrel_server release
+# built with the S3 backend included (the `s3_server` rebar3 profile) --
+# not CT against the backend module directly (that's
+# apps/barrel_att_s3/test/barrel_att_s3_SUITE.erl), and not a mock store.
+#
+# peer-a keeps the default (RocksDB) attachment backend; peer-b's databases
+# point their att_opts at MinIO or Garage. Both run the same release image.
+#
+# Most databases below are still created via `barrel_server eval`
+# (barrel_docdb:create_db/2), for brevity in scenarios where HTTP db
+# creation isn't itself what's under test. `PUT /db/:name` also accepts
+# `att_opts` in a JSON body now (see the "backend selection over HTTP"
+# scenario) -- one database is created that way specifically, to prove the
+# HTTP surface itself works, not just the Erlang API underneath it.
+#
+# Usage: test/e2e/attachments-s3.sh   (from the umbrella root, or anywhere)
+# Requires: docker, docker compose. Exit 0 = pass, non-zero = fail.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE="docker compose -f $DIR/docker-compose.attachments-s3.yml"
+A=http://127.0.0.1:8093   # peer-a, published
+B=http://127.0.0.1:8094   # peer-b, published
+
+pass=0
+fail=0
+check() {  # check <description> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        echo "  ok   $1"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL $1: expected [$2], got [$3]"
+        fail=$((fail + 1))
+    fi
+}
+check_match() {  # check_match <description> <regex> <actual>
+    if echo "$3" | grep -qE "$2"; then
+        echo "  ok   $1"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL $1: pattern [$2] not found in [$3]"
+        fail=$((fail + 1))
+    fi
+}
+check_bool() {  # check_bool <description> <exit-code-already-captured>
+    # The condition itself must be evaluated by the CALLER (typically an
+    # `if ...; then rc=0; else rc=1; fi`), not inline here: under
+    # `set -e`, a non-zero exit from a plain statement kills the script
+    # before this function would ever see it.
+    if [ "$2" -eq 0 ]; then
+        echo "  ok   $1"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL $1"
+        fail=$((fail + 1))
+    fi
+}
+
+cleanup() {
+    echo "--- tearing down"
+    $COMPOSE down -v --remove-orphans >/dev/null 2>&1 || true
+    rm -f "$WORKDIR"/*.bin
+}
+WORKDIR=$(mktemp -d)
+trap cleanup EXIT
+
+echo "--- building peer image and starting the stack"
+$COMPOSE build peer-a
+echo "--- provisioning minio + garage"
+GARAGE_ENV=$("$DIR"/attachments-s3-setup.sh)
+eval "$GARAGE_ENV"
+
+echo "--- starting the peers"
+$COMPOSE up -d peer-a peer-b
+
+wait_healthy() {  # wait_healthy <base-url> <name>
+    for _ in $(seq 1 40); do
+        if curl -fsS "$1/health" >/dev/null 2>&1; then
+            echo "  $2 is up"
+            return 0
+        fi
+        sleep 2
+    done
+    echo "  $2 did not become healthy"; return 1
+}
+wait_healthy "$A" peer-a
+wait_healthy "$B" peer-b
+
+eval_b() {  # eval_b <erlang-expr>   -- runs inside peer-b, network-adjacent to minio/garage
+    $COMPOSE exec -T peer-b barrel_server eval "$1"
+}
+eval_a() {  # eval_a <erlang-expr>
+    $COMPOSE exec -T peer-a barrel_server eval "$1"
+}
+
+# --- MinIO-backed database: whole-blob round trip (small + multipart-crossing) ---
+
+MINIO_ATT_OPTS='#{backend => s3, s3 => #{bucket => <<"barrel-att-s3-test">>, endpoint => <<"http://minio:9000">>, region => <<"us-east-1">>, access_key_id => <<"minioadmin">>, secret_access_key => <<"minioadmin">>}}'
+
+echo "--- creating minio-backed db on peer-b"
+eval_b "barrel_docdb:create_db(<<\"s3db\">>, #{att_opts => $MINIO_ATT_OPTS})." >/dev/null
+curl -fsS -X PUT "$B/db/s3db/doc/doc1" -H 'content-type: application/json' -d '{"n":1}' >/dev/null
+
+echo "--- small attachment round trip (minio)"
+curl -fsS -X PUT "$B/db/s3db/doc/doc1/att/small.txt" \
+    -H 'content-type: text/plain' -d 'hello from the s3 backend e2e test' >/dev/null
+body=$(curl -fsS "$B/db/s3db/doc/doc1/att/small.txt")
+check "minio small attachment content" 'hello from the s3 backend e2e test' "$body"
+
+echo "--- large (multipart-crossing) attachment round trip (minio)"
+head -c 6000000 /dev/urandom > "$WORKDIR/large.bin"
+sum_before=$(shasum -a 256 "$WORKDIR/large.bin" | awk '{print $1}')
+curl -fsS -X PUT "$B/db/s3db/doc/doc1/att/large.bin" \
+    -H 'content-type: application/octet-stream' --data-binary "@$WORKDIR/large.bin" >/dev/null
+curl -fsS "$B/db/s3db/doc/doc1/att/large.bin" -o "$WORKDIR/large.roundtrip.bin"
+sum_after=$(shasum -a 256 "$WORKDIR/large.roundtrip.bin" | awk '{print $1}')
+check "minio large attachment digest" "$sum_before" "$sum_after"
+
+echo "--- delete + 404 (minio)"
+curl -fsS -X DELETE "$B/db/s3db/doc/doc1/att/small.txt" >/dev/null
+code=$(curl -s -o /dev/null -w '%{http_code}' "$B/db/s3db/doc/doc1/att/small.txt")
+check "minio attachment gone after delete" 404 "$code"
+
+# --- Garage-backed database: same whole-blob round trip ---
+
+GARAGE_ATT_OPTS="#{backend => s3, s3 => #{bucket => <<\"$GARAGE_S3_TEST_BUCKET\">>, endpoint => <<\"http://garage:3900\">>, region => <<\"garage\">>, access_key_id => <<\"$GARAGE_S3_TEST_ACCESS_KEY\">>, secret_access_key => <<\"$GARAGE_S3_TEST_SECRET_KEY\">>}}"
+
+echo "--- creating garage-backed db on peer-b"
+eval_b "barrel_docdb:create_db(<<\"garagedb\">>, #{att_opts => $GARAGE_ATT_OPTS})." >/dev/null
+curl -fsS -X PUT "$B/db/garagedb/doc/doc1" -H 'content-type: application/json' -d '{"n":1}' >/dev/null
+
+echo "--- attachment round trip (garage)"
+curl -fsS -X PUT "$B/db/garagedb/doc/doc1/att/note.txt" \
+    -H 'content-type: text/plain' -d 'hello from garage' >/dev/null
+body=$(curl -fsS "$B/db/garagedb/doc/doc1/att/note.txt")
+check "garage attachment content" 'hello from garage' "$body"
+curl -fsS -X DELETE "$B/db/garagedb/doc/doc1/att/note.txt" >/dev/null
+code=$(curl -s -o /dev/null -w '%{http_code}' "$B/db/garagedb/doc/doc1/att/note.txt")
+check "garage attachment gone after delete" 404 "$code"
+
+# --- Backend selection over HTTP: PUT /db/:name with att_opts in the body ---
+#
+# create_db/1 now parses an optional JSON body -- this creates an S3
+# (minio)-backed database purely over HTTP, no barrel_server eval
+# involved, and confirms the write actually landed in the minio bucket
+# (not silently RocksDB, which would round-trip the content identically
+# and so not be caught by a content check alone).
+
+echo "--- creating s3httpdb (minio) via PUT /db/:name with att_opts in the body"
+MINIO_ATT_OPTS_JSON='{"att_opts":{"backend":"s3","s3":{"bucket":"barrel-att-s3-test","endpoint":"http://minio:9000","region":"us-east-1","access_key_id":"minioadmin","secret_access_key":"minioadmin"}}}'
+create_resp=$(curl -fsS -X PUT "$B/db/s3httpdb" -H 'content-type: application/json' -d "$MINIO_ATT_OPTS_JSON")
+check_match "create_db with att_opts over HTTP succeeds" '"ok":true' "$create_resp"
+
+curl -fsS -X PUT "$B/db/s3httpdb/doc/doc1" -H 'content-type: application/json' -d '{"n":1}' >/dev/null
+curl -fsS -X PUT "$B/db/s3httpdb/doc/doc1/att/note.txt" \
+    -H 'content-type: text/plain' -d 'created via http att_opts' >/dev/null
+body=$(curl -fsS "$B/db/s3httpdb/doc/doc1/att/note.txt")
+check "s3httpdb attachment round trip" 'created via http att_opts' "$body"
+
+# hex("doc1") = 646f6331; the prefix is the db's own name on first open
+# (see barrel_att_s3_store's "Key scheme" moduledoc section). The `docker
+# run` itself must be the `if` condition, not a separate statement: under
+# `set -e`, a non-zero exit from a plain statement kills the script before
+# a later `[ $? -eq 0 ]` ever runs.
+if docker run --rm --network container:barrel-att-s3-minio \
+    -e MC_HOST_local="http://minioadmin:minioadmin@127.0.0.1:9000" \
+    minio/mc stat "local/barrel-att-s3-test/s3httpdb/646f6331/note.txt" >/dev/null 2>&1
+then rc=0; else rc=1; fi
+check_bool "s3httpdb object exists in the minio bucket (att_opts over HTTP genuinely selected S3)" "$rc"
+
+# --- Write-conflict detection: real behavior, not the doc's claim ---
+#
+# Two paths now: the original Erlang-API one (barrel_server eval, kept for
+# coverage of barrel_docdb:put_attachment/5 itself) and real HTTP headers
+# (If-None-Match/If-Match, now wired on the attachment PUT route).
+
+echo "--- create_only conflict detection (minio: verifiably enforced)"
+# `eval` echoes the final expression's own return value, not anything an
+# inner io:format prints (io:format/2 itself returns `ok` -- see
+# replication.sh's own note on this), so the conflicting put must be the
+# trailing expression, unwrapped.
+MINIO_CONFLICT='{ok, _} = barrel_docdb:put_attachment(<<"s3db">>, <<"doc1">>, <<"conf.txt">>, <<"first">>, #{create_only => true}), barrel_docdb:put_attachment(<<"s3db">>, <<"doc1">>, <<"conf.txt">>, <<"second">>, #{create_only => true}).'
+out=$(eval_b "$MINIO_CONFLICT" | tr -d '\r\n ')
+check_match "minio create_only conflict detected (erlang API)" '^\{error,\{conflict,' "$out"
+
+echo "--- create_only fails fast (garage: not structurally supported, by design)"
+GARAGE_CONFLICT='barrel_docdb:put_attachment(<<"garagedb">>, <<"doc1">>, <<"conf.txt">>, <<"first">>, #{create_only => true}).'
+out=$(eval_b "$GARAGE_CONFLICT" | tr -d '\r\n ')
+check "garage create_only refuses rather than pretends to protect (erlang API)" \
+    '{error,conditional_writes_unsupported}' "$out"
+
+echo "--- create_only conflict detection over real HTTP headers (minio)"
+code=$(curl -s -o /dev/null -w '%{http_code}' -X PUT "$B/db/s3httpdb/doc/doc1/att/http-conf.txt" \
+    -H 'If-None-Match: *' -H 'content-type: text/plain' -d 'first')
+check "minio If-None-Match: * succeeds on a fresh key" 201 "$code"
+code=$(curl -s -o /dev/null -w '%{http_code}' -X PUT "$B/db/s3httpdb/doc/doc1/att/http-conf.txt" \
+    -H 'If-None-Match: *' -H 'content-type: text/plain' -d 'second')
+check "minio If-None-Match: * conflicts on an existing key" 409 "$code"
+
+echo "--- create_only fails fast over real HTTP headers (garage) -- must not hang or retry"
+t0=$(date +%s)
+code=$(curl -s -o /dev/null -w '%{http_code}' -X PUT "$B/db/garagedb/doc/doc1/att/http-conf.txt" \
+    -H 'If-None-Match: *' -H 'content-type: text/plain' -d 'first')
+elapsed=$(( $(date +%s) - t0 ))
+check "garage If-None-Match: * fails fast (501)" 501 "$code"
+if [ "$elapsed" -le 5 ]; then rc=0; else rc=1; fi
+check_bool "garage conditional-write rejection was fast (${elapsed}s)" "$rc"
+
+# --- Replication asymmetry: RocksDB source -> S3(minio) target ---
+#
+# Mirrors replication.sh's push pattern, over the real HTTP transport
+# between two separate containers, landing on an S3-backed target this
+# time (barrel_rep_att_SUITE covers this at the CT level with a stub
+# backend; this confirms it live against a real store).
+
+echo "--- creating repdb (default backend) on peer-a, (s3/minio backend) on peer-b"
+curl -fsS -X PUT "$A/db/repdb" >/dev/null
+eval_b "barrel_docdb:create_db(<<\"repdb\">>, #{att_opts => $MINIO_ATT_OPTS})." >/dev/null
+
+curl -fsS -X PUT "$A/db/repdb/doc/doc1" -H 'content-type: application/json' -d '{"n":1}' >/dev/null
+curl -fsS -X PUT "$A/db/repdb/doc/doc1/att/note.txt" -H 'content-type: text/plain' -d 'replicated to s3' >/dev/null
+
+echo "--- push peer-a -> peer-b"
+PUSH='E = barrel_rep_transport_http:endpoint(<<"http://peer-b:8080/db/repdb">>), {ok, R} = barrel_rep:replicate(<<"repdb">>, E, #{target_transport => barrel_rep_transport_http}), io:format("~p~n", [R]).'
+eval_a "$PUSH" || { echo "  replication call failed"; fail=$((fail+1)); }
+
+code=$(curl -s -o /dev/null -w '%{http_code}' "$B/db/repdb/doc/doc1")
+check "peer-b (s3-backed) received doc1" 200 "$code"
+body=$(curl -fsS "$B/db/repdb/doc/doc1/att/note.txt" 2>/dev/null || true)
+check "peer-b (s3-backed) received the attachment via replication" 'replicated to s3' "$body"
+
+# --- Bidirectional replication: a real conflict, not just first delivery ---
+#
+# The section above only ever delivers a doc/attachment that never existed
+# on the target -- it doesn't exercise the S3 target's LWW guard. M1 could
+# not replicate INTO S3 with real conflict resolution at all (no feed); M2
+# adds one. This drives an actual concurrent write on both sides through
+# real HTTP replication (mirrors barrel_rep_att_SUITE's
+# bidirectional_lww_convergence_rocksdb_and_s3, over the wire instead of
+# the local transport CT uses) and checks convergence, not just delivery.
+
+echo "--- creating bidirdb: default backend on peer-a, minio-backed on peer-b"
+curl -fsS -X PUT "$A/db/bidirdb" >/dev/null
+eval_b "barrel_docdb:create_db(<<\"bidirdb\">>, #{att_opts => $MINIO_ATT_OPTS})." >/dev/null
+curl -fsS -X PUT "$A/db/bidirdb/doc/doc1" -H 'content-type: application/json' -d '{"n":1}' >/dev/null
+curl -fsS -X PUT "$B/db/bidirdb/doc/doc1" -H 'content-type: application/json' -d '{"n":1}' >/dev/null
+
+echo "--- both sides write the same attachment concurrently"
+curl -fsS -X PUT "$A/db/bidirdb/doc/doc1/att/f.txt" \
+    -H 'content-type: text/plain' -d 'from peer-a (rocksdb)' >/dev/null
+curl -fsS -X PUT "$B/db/bidirdb/doc/doc1/att/f.txt" \
+    -H 'content-type: text/plain' -d 'from peer-b (s3)' >/dev/null
+
+PUSH_A_TO_B='E = barrel_rep_transport_http:endpoint(<<"http://peer-b:8080/db/bidirdb">>), {ok, R} = barrel_rep:replicate(<<"bidirdb">>, E, #{target_transport => barrel_rep_transport_http}), io:format("~p~n", [R]).'
+PUSH_B_TO_A='E = barrel_rep_transport_http:endpoint(<<"http://peer-a:8080/db/bidirdb">>), {ok, R} = barrel_rep:replicate(<<"bidirdb">>, E, #{target_transport => barrel_rep_transport_http}), io:format("~p~n", [R]).'
+
+echo "--- syncing both ways twice"
+eval_a "$PUSH_A_TO_B" >/dev/null || { echo "  push a->b failed"; fail=$((fail+1)); }
+eval_b "$PUSH_B_TO_A" >/dev/null || { echo "  push b->a failed"; fail=$((fail+1)); }
+eval_a "$PUSH_A_TO_B" >/dev/null || { echo "  push a->b failed"; fail=$((fail+1)); }
+eval_b "$PUSH_B_TO_A" >/dev/null || { echo "  push b->a failed"; fail=$((fail+1)); }
+
+body_a=$(curl -fsS "$A/db/bidirdb/doc/doc1/att/f.txt")
+body_b=$(curl -fsS "$B/db/bidirdb/doc/doc1/att/f.txt")
+check "bidirectional convergence: both peers agree" "$body_a" "$body_b"
+
+echo "--- a further sync moves nothing (stable convergence)"
+IDLE_CHECK='E = barrel_rep_transport_http:endpoint(<<"http://peer-b:8080/db/bidirdb">>), {ok, R} = barrel_rep:replicate(<<"bidirdb">>, E, #{target_transport => barrel_rep_transport_http}), maps:get(att_sync, R).'
+out=$(eval_a "$IDLE_CHECK" | tr -d '\r\n ')
+check_match "idle round: nothing left to write" 'atts_written=>0' "$out"
+
+# --- Branching: fork an S3(minio)-backed database ---
+#
+# barrel_docdb:branch_db/3 has a real HTTP route (unlike att_opts on
+# create_db), so this drives it the same way a client would:
+# POST /db/:db/_timeline/branch. checkpoint/2 only does the cheap local
+# part synchronously; several attachments give the background copy sweep
+# actual work, so branch_db returning fast is a meaningful check, not
+# trivially true because there was nothing to copy.
+
+echo "--- creating s3branchparent (minio) with several attachments on peer-b"
+eval_b "barrel_docdb:create_db(<<\"s3branchparent\">>, #{att_opts => $MINIO_ATT_OPTS})." >/dev/null
+curl -fsS -X PUT "$B/db/s3branchparent/doc/doc1" -H 'content-type: application/json' -d '{"n":1}' >/dev/null
+for i in $(seq 1 15); do
+    curl -fsS -X PUT "$B/db/s3branchparent/doc/doc1/att/f$i.txt" \
+        -H 'content-type: text/plain' -d "attachment number $i" >/dev/null
+done
+
+echo "--- forking s3branchparent -> s3branchchild"
+branch_resp=$(curl -fsS -X POST "$B/db/s3branchparent/_timeline/branch" \
+    -H 'content-type: application/json' -d '{"name":"s3branchchild"}')
+check_match "branch_db over HTTP succeeds" '"ok":true' "$branch_resp"
+
+echo "--- reading an inherited attachment on the branch (may be 503 briefly while the copy sweep catches up)"
+body=""
+for _ in $(seq 1 40); do
+    code=$(curl -s -o "$WORKDIR/branch_att.txt" -w '%{http_code}' "$B/db/s3branchchild/doc/doc1/att/f1.txt")
+    if [ "$code" = "200" ]; then
+        body=$(cat "$WORKDIR/branch_att.txt")
+        break
+    fi
+    sleep 1
+done
+check "branch attachment converges to parent's content" 'attachment number 1' "$body"
+
+echo "--- branch write is independent of the parent"
+curl -fsS -X PUT "$B/db/s3branchchild/doc/doc1/att/branch-only.txt" \
+    -H 'content-type: text/plain' -d 'only on the branch' >/dev/null
+code=$(curl -s -o /dev/null -w '%{http_code}' "$B/db/s3branchparent/doc/doc1/att/branch-only.txt")
+check "parent does not see the branch's own write" 404 "$code"
+
+echo
+echo "=== $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/test/e2e/docker-compose.attachments-s3.yml
+++ b/test/e2e/docker-compose.attachments-s3.yml
@@ -1,0 +1,76 @@
+# MinIO + Garage + two barrel_server peers, for the S3 attachment-backend
+# test suite (apps/barrel_att_s3/test/barrel_att_s3_SUITE.erl, via the `s3`
+# CI leg) and test/e2e/attachments-s3.sh. peer-a stays on the default
+# (RocksDB) attachment backend; peer-b is built the same way but its
+# databases point their att_opts at MinIO or Garage -- same image, same
+# release, different runtime config, mirroring how a real deployment would
+# choose a backend per database.
+#
+# Garage needs a one-time layout/bucket/key bootstrap after it starts --
+# compose alone only starts the process. attachments-s3-setup.sh does that
+# and is the entry point both the CI leg and the e2e script use; it is safe
+# (and expected) to run this compose file on its own for local iteration.
+
+services:
+  minio:
+    image: minio/minio
+    container_name: barrel-att-s3-minio
+    command: ["server", "/data", "--console-address", ":9001"]
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "19000:9000"
+      - "19001:9001"
+
+  garage:
+    image: dxflrs/garage:v1.0.1
+    container_name: barrel-att-s3-garage
+    volumes:
+      - ./garage.toml:/etc/garage.toml:ro
+      - garage-meta:/var/lib/garage/meta
+      - garage-data:/var/lib/garage/data
+    ports:
+      - "13900:3900"
+      - "13901:3901"
+      - "13903:3903"
+
+  peer-a:
+    build:
+      context: ../..
+      dockerfile: test/e2e/Dockerfile
+      args:
+        RELX_PROFILES: s3_server,prod
+        RELX_BUILD_DIR: s3_server+prod
+    image: barrel-server-att-s3-e2e
+    container_name: barrel-att-s3-peer-a
+    ports:
+      - "8093:8080"
+    healthcheck:
+      test: ["CMD", "barrel_server", "ping"]
+      interval: 3s
+      timeout: 5s
+      retries: 20
+
+  peer-b:
+    # Reuse the image peer-a builds.
+    image: barrel-server-att-s3-e2e
+    container_name: barrel-att-s3-peer-b
+    depends_on:
+      peer-a:
+        condition: service_started
+      minio:
+        condition: service_started
+      garage:
+        condition: service_started
+    ports:
+      - "8094:8080"
+    healthcheck:
+      test: ["CMD", "barrel_server", "ping"]
+      interval: 3s
+      timeout: 5s
+      retries: 20
+
+volumes:
+  garage-meta:
+  garage-data:

--- a/test/e2e/garage.toml
+++ b/test/e2e/garage.toml
@@ -1,0 +1,25 @@
+# Garage config for the S3 attachment-backend test fixture (CI `s3` leg and
+# test/e2e/attachments-s3.sh). Single-node, single-replica -- a test fixture,
+# not a deployment reference. rpc_secret/admin_token below are fixture-only
+# values with no access to anything but this throwaway container's own data.
+#
+# Garage needs a one-time layout+bucket+key bootstrap after it starts; this
+# file alone only gets the process listening. See attachments-s3-setup.sh.
+
+metadata_dir = "/var/lib/garage/meta"
+data_dir = "/var/lib/garage/data"
+db_engine = "sqlite"
+replication_factor = 1
+
+rpc_bind_addr = "[::]:3901"
+rpc_public_addr = "127.0.0.1:3901"
+rpc_secret = "fd14c1f611d057cb83b4925f39d43334c61c0104a7e6ee66127fdaf7a73ce6a2"
+
+[s3_api]
+s3_region = "garage"
+api_bind_addr = "[::]:3900"
+root_domain = ".s3.garage.localhost"
+
+[admin]
+api_bind_addr = "[::]:3903"
+admin_token = "a69ecf899951d816c803ab7cbcc5b279"

--- a/test/e2e/replication.sh
+++ b/test/e2e/replication.sh
@@ -97,6 +97,59 @@ replicate peer-a "$PUSH_A_TO_B" || { echo "  replication call failed"; fail=$((f
 code=$(curl -s -o /dev/null -w '%{http_code}' "$B/db/$DB/doc/doc1")
 check "peer-b reflects the delete of doc1" 404 "$code"
 
+# --- continuous replication task + attachments (own database, so it
+# doesn't interact with the assertions above) ---
+#
+# barrel_rep_tasks:start_task/1 (mode => continuous) used to replicate
+# document bodies only: attachments live on their own feed, independent of
+# the document changes feed, and a continuous task subscribed only to the
+# doc feed never woke up for an attachment-only write. This checks the fix
+# over a real HTTP wire and real separate processes, not just in-VM CT.
+ATTDB=attdb
+echo "--- creating $ATTDB on both peers"
+curl -fsS -X PUT "$A/db/$ATTDB" >/dev/null
+curl -fsS -X PUT "$B/db/$ATTDB" >/dev/null
+
+echo "--- writing doc1 to peer-a, starting a continuous push task"
+curl -fsS -X PUT "$A/db/$ATTDB/doc/doc1" \
+    -H 'content-type: application/json' -d '{"n":1}' >/dev/null
+
+# `eval` echoes the final expression's own return value, not anything an
+# inner io:format call printed (that's why PUSH_A_TO_B/PULL_B_TO_A above
+# just show "ok": the return value of their own trailing io:format/2).
+# So the last expression here must evaluate to the task id itself; it
+# comes back ~p-formatted as a quoted string, hence the sed to unquote it.
+START_TASK='{ok, TaskId} = barrel_rep_tasks:start_task(#{source => <<"attdb">>, target => barrel_rep_transport_http:endpoint(<<"http://peer-b:8080/db/attdb">>), target_transport => barrel_rep_transport_http, mode => continuous, direction => push}), binary_to_list(TaskId).'
+TASK_ID=$($COMPOSE exec -T peer-a barrel_server eval "$START_TASK" \
+    | tr -d '\r\n' | sed -E 's/^"//; s/"$//') \
+    || { echo "  start_task failed"; fail=$((fail+1)); }
+echo "  task started: $TASK_ID"
+
+echo "--- waiting for doc1 to converge via the task"
+ok=0
+for _ in $(seq 1 20); do
+    code=$(curl -s -o /dev/null -w '%{http_code}' "$B/db/$ATTDB/doc/doc1")
+    if [ "$code" = "200" ]; then ok=1; break; fi
+    sleep 1
+done
+check "peer-b has doc1 via continuous task" 1 "$ok"
+
+echo "--- putting an attachment on doc1 with NO further doc change"
+curl -fsS -X PUT "$A/db/$ATTDB/doc/doc1/att/note.txt" \
+    -H 'content-type: text/plain' -d 'hello' >/dev/null
+
+echo "--- waiting for the attachment to converge (idle-wake path)"
+body=""
+for _ in $(seq 1 15); do
+    body=$(curl -fsS "$B/db/$ATTDB/doc/doc1/att/note.txt" 2>/dev/null || true)
+    if [ "$body" = "hello" ]; then break; fi
+    sleep 2
+done
+check "peer-b converged the attachment-only change" hello "$body"
+
+$COMPOSE exec -T peer-a barrel_server eval \
+    "barrel_rep_tasks:stop_task(<<\"$TASK_ID\">>)." >/dev/null 2>&1 || true
+
 echo
 echo "=== $pass passed, $fail failed"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
Adds barrel_att_s3, a pluggable barrel_att_backend implementation against
S3-compatible object stores (AWS S3, MinIO, Garage) via livery_s3. Kept
out of the default embeddable build behind a new `s3` rebar3 profile.

Covers whole-blob and streaming put/get/delete, opt-in write-conflict
detection (create_only/expected_etag) backed by a real per-store
capability probe, a local attachment feed so S3-backed databases are
full bidirectional replication participants, non-blocking eager-copy
branching (branch_db/3 returns immediately, attachment bytes catch up
in the background), and delete_db erasing the bucket objects under a
store's own prefix.

Both backend selection and write-conflict detection are reachable over
barrel_server's HTTP routes: PUT /db/:name accepts an att_opts JSON
body, and the attachment PUT route wires If-Match/If-None-Match to
create_only/expected_etag.

CI gains an `s3` leg (CT against real MinIO and Garage containers) and
an opt-in e2e job. Docs added under apps/barrel_att_s3/docs (getting
started, limitations, store-compatibility table).