### PR TITLE
Expose barrel_ngram at the umbrella level; pilot OTP 29; fix dialyzer findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ name: CI
 #   - server:   network server leg (pulls livery + transports)
 #   - s3:       optional S3 attachment-backend leg (real MinIO + Garage)
 #   - barrel-lite: TypeScript client (typecheck, build, unit tests)
-# Dev target is OTP 29; CI pins OTP 28 (image guaranteed, code builds on both).
+# Dev target is OTP 29; CI pins OTP 28 everywhere (image guaranteed, code
+# builds on both), except the leaf/barrel_embed leg, piloting the move to
+# OTP 29 (no NIF, no sibling umbrella deps -- an incompatibility surfaces
+# there cleanly before rolling OTP 29 out to the rest of CI).
 
 on:
   push:
@@ -52,11 +55,24 @@ jobs:
     name: Leaf (${{ matrix.app }})
     runs-on: ubuntu-latest
     container:
-      image: erlang:28
+      image: erlang:${{ matrix.otp }}
     strategy:
       fail-fast: false
       matrix:
-        app: [barrel_crypto, barrel_docdb, barrel_ngram, barrel_rerank, barrel_embed]
+        # otp pinned to 28 to match every other leg, except barrel_embed:
+        # piloting the OTP 29 dev target here first (no NIF, no sibling
+        # umbrella deps, so an incompatibility surfaces cleanly).
+        include:
+          - app: barrel_crypto
+            otp: '28'
+          - app: barrel_docdb
+            otp: '28'
+          - app: barrel_ngram
+            otp: '28'
+          - app: barrel_rerank
+            otp: '28'
+          - app: barrel_embed
+            otp: '29'
     steps:
       - uses: actions/checkout@v4
       - name: System dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to the Barrel umbrella are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and each app
 is versioned independently under [Semantic Versioning](https://semver.org/).
 
+## [2026-08-15] barrel_ngram corpus lifecycle hardening
+
+`barrel_ngram`'s `open/2`/`close/1` are now serialized per corpus by a
+one-shot lifecycle coordinator, backed by a corpus-level config file
+(database, shard count, tuning, postings codec) checked before any shard
+starts and committed only once every shard is up -- a mismatched reopen is
+now rejected instead of silently reindexing, rebinding to a different
+database, or orphaning an old shard set on a shard-count change. A
+database deleted and recreated under the same name is now detected both
+at open and continuously on every shard resubscribe. The regex analyzer
+fails closed on lazy/possessive quantifiers, PCRE control verbs, and
+unrecognized escapes instead of mis-parsing them as literal text; a
+positive `source`-verified match is now always re-confirmed against live
+`barrel_docdb` content before being returned. `open/2` validates every
+option up front, including the corpus name itself (closing a
+path-traversal risk). `barrel_docdb` gains `db_instance_id/1`, the
+read-only accessor this needed. `barrel_server`'s `ngram_search` MCP tool
+no longer silently stops returning results for a corpus indexed before
+this change -- it reindexes automatically on first use instead.
+
+| App | Version | Change |
+|-----|---------|--------|
+| barrel_ngram | 0.9.0 | corpus lifecycle lock + corpus-level config; database-instance recreation detection; regex parser soundness; live re-confirmation of `source`-verified matches; full `open/2` option validation. Breaking: `close/1` now returns `ok \| {error, term()}`; a corpus indexed before this change needs a fresh `data_dir` |
+| barrel_docdb | 1.3.0 | `db_instance_id/1` |
+| barrel_server | 1.5.0 | `ngram_search` auto-reindexes a pre-0.9.0 corpus instead of silently going empty |
+
 ## [2026-08-09] S3-compatible attachment backend
 
 New sibling app `barrel_att_s3` implements `barrel_att_backend` against

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ together, while each stays a standalone OTP application with its own public API.
 |-----|------|----------------|
 | `barrel` | `apps/barrel` | The embeddable database. Composes docdb + vectordb + crypto so a document, its blobs, and its vector share one id. Record mode, timeline (branch/PITR/merge), BQL. Pulls no transports. |
 | `barrel_docdb` | `apps/barrel_docdb` | The document layer. HLC version-vector MVCC, changes feed, replication, attachments (blobs), TTL, retained history, BQL query. Standalone embedded document database. |
+| `barrel_ngram` | `apps/barrel_ngram` | Exact substring and regex search over a `barrel_docdb` database via a byte-level trigram index. Opt-in behind the `server`/`s3`/`s3_server` profiles. |
 | `barrel_vectordb` | `apps/barrel_vectordb` | The vector layer. Local ANN indexes (HNSW, DiskANN, FAISS), BM25, hybrid search, quantization. Standalone embedded vector database. |
 | `barrel_embed` | `apps/barrel_embed` | Embedding generation across providers (local Python, Ollama, OpenAI, and more). Used by `barrel_vectordb` for text and hybrid search. |
 | `barrel_rerank` | `apps/barrel_rerank` | Cross-encoder reranking. Optional, used by `barrel_vectordb`. |
@@ -20,12 +21,12 @@ together, while each stays a standalone OTP application with its own public API.
 | `barrel_server` | `apps/barrel_server` | The network server. Exposes `barrel` over HTTP (REST/JSON) and MCP using `livery`. Opt-in behind the `server` profile. |
 | `barrel_faiss` | `apps/barrel_faiss` | Erlang NIF bindings for FAISS. Optional; needs the FAISS C++ library, so it is excluded from the default build. |
 
-Dependency direction (no cycles): `barrel_server` -> {`barrel`, `barrel_spaces`};
-`barrel_spaces` -> {`barrel`, `barrel_docdb`, `barrel_crypto`}; `barrel` ->
-{`barrel_docdb`, `barrel_vectordb`, `barrel_crypto`}; `barrel_vectordb` ->
-{`barrel_embed`, `barrel_crypto`} (optionally `barrel_faiss`, `barrel_rerank`);
-`barrel_docdb` -> `barrel_crypto`. Leaves: `barrel_crypto`, `barrel_embed`,
-`barrel_rerank`, `barrel_faiss`.
+Dependency direction (no cycles): `barrel_server` -> {`barrel`, `barrel_spaces`,
+`barrel_ngram`}; `barrel_spaces` -> {`barrel`, `barrel_docdb`, `barrel_crypto`};
+`barrel` -> {`barrel_docdb`, `barrel_vectordb`, `barrel_crypto`}; `barrel_vectordb`
+-> {`barrel_embed`, `barrel_crypto`} (optionally `barrel_faiss`, `barrel_rerank`);
+`barrel_ngram` -> `barrel_docdb`; `barrel_docdb` -> `barrel_crypto`. Leaves:
+`barrel_crypto`, `barrel_embed`, `barrel_rerank`, `barrel_faiss`.
 
 ## Build
 

--- a/apps/barrel_docdb/CHANGELOG.md
+++ b/apps/barrel_docdb/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-08-15
+
+### Added
+- `db_instance_id/1`: a stable per-database-INSTANCE identifier, not
+  per-name -- deleting a database and recreating one under the same name
+  mints a fresh id. Wraps the already-computed, already-persisted
+  `source_id` (now exported from `barrel_db_server` as `source_id/1`).
+  Added for `barrel_ngram`'s corpus lifecycle, which needs to detect a
+  database recreated under the same name while a corpus stays bound to
+  it; no new persisted state.
+
 ## [1.2.0] - 2026-08-09
 
 ### Added

--- a/apps/barrel_docdb/src/barrel_docdb.app.src
+++ b/apps/barrel_docdb/src/barrel_docdb.app.src
@@ -1,6 +1,6 @@
 {application, barrel_docdb, [
     {description, "Erlang document database with MVCC, queries, and replication"},
-    {vsn, "1.2.0"},
+    {vsn, "1.3.0"},
     {registered, [barrel_docdb_sup]},
     {mod, {barrel_docdb_app, []}},
     {applications, [

--- a/apps/barrel_docdb/src/barrel_rep_transport_http.erl
+++ b/apps/barrel_docdb/src/barrel_rep_transport_http.erl
@@ -531,8 +531,7 @@ ssl_options(#{url := Url}) ->
 method_bin(get) -> <<"GET">>;
 method_bin(post) -> <<"POST">>;
 method_bin(put) -> <<"PUT">>;
-method_bin(delete) -> <<"DELETE">>;
-method_bin(M) when is_binary(M) -> M.
+method_bin(delete) -> <<"DELETE">>.
 
 origin(Url) ->
     case binary:match(Url, <<"/db/">>) of

--- a/apps/barrel_rerank/src/barrel_rerank_venv.erl
+++ b/apps/barrel_rerank/src/barrel_rerank_venv.erl
@@ -194,8 +194,6 @@ venv_bin_dir(VenvPath) ->
     end.
 
 %% @private Install packages using pip
-install_packages(_Pip, []) ->
-    ok;
 install_packages(Pip, Packages) ->
     PackageStr = string:join(Packages, " "),
     Cmd = io_lib:format("~s install ~s", [Pip, PackageStr]),

--- a/apps/barrel_server/CHANGELOG.md
+++ b/apps/barrel_server/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.5.0] - 2026-08-15
+
+### Fixed
+- `ngram_search` no longer silently stops returning results for a
+  database whose corpus was indexed before `barrel_ngram` 0.9.0 (which
+  now rejects a corpus with no `corpus.meta` on open). It now reindexes
+  automatically on first use after the upgrade instead of leaving every
+  subsequent search permanently returning nothing.
+
 ## [1.4.0] - 2026-08-09
 
 ### Added

--- a/apps/barrel_server/src/barrel_server.app.src
+++ b/apps/barrel_server/src/barrel_server.app.src
@@ -1,6 +1,6 @@
 {application, barrel_server, [
     {description, "Multi-protocol server for the barrel edge database (REST/JSON over livery)"},
-    {vsn, "1.4.0"},
+    {vsn, "1.5.0"},
     {registered, [barrel_server_sup]},
     {mod, {barrel_server_app, []}},
     {applications, [

--- a/apps/barrel_server/src/barrel_server_http.erl
+++ b/apps/barrel_server/src/barrel_server_http.erl
@@ -960,7 +960,6 @@ vector_add(Req) ->
             end,
             case Res of
                 ok -> json_resp(201, #{ok => true, id => Id});
-                {ok, R} -> json_resp(201, jsonable(R));
                 Err -> error_resp(Err)
             end
         end)
@@ -1030,7 +1029,6 @@ read_body(Req) ->
 
 %% @private Render one batch element ({ok, Map} | {error, Reason}) as JSON.
 batch_result({ok, Map}) when is_map(Map) -> jsonable(Map);
-batch_result({ok, Other}) -> #{ok => true, result => Other};
 batch_result({error, Reason}) -> #{error => err_bin(Reason)}.
 
 %% Vectors are opt-in reads. The reader returns _embedding as a float
@@ -1080,16 +1078,13 @@ search_opts(Body) ->
 
 search_reply({ok, Hits}) when is_list(Hits) ->
     json_resp(200, #{hits => [hit(H) || H <- Hits]});
-search_reply(Hits) when is_list(Hits) ->
-    json_resp(200, #{hits => [hit(H) || H <- Hits]});
 search_reply(Err) ->
     error_resp(Err).
 
 %% @private Normalise a search hit to a JSON-safe map. Vector hits are already
 %% maps; BM25 hits are {Id, Score} tuples.
 hit({Id, Score}) -> #{key => Id, score => Score};
-hit(Map) when is_map(Map) -> jsonable(Map);
-hit(Other) -> Other.
+hit(Map) when is_map(Map) -> jsonable(Map).
 
 att_content_type(Db, Id, Name) ->
     case barrel:attachment_info(Db, Id, Name) of
@@ -1126,11 +1121,7 @@ wants_sse(Req) ->
     end.
 
 param(Key, Req) ->
-    case livery_req:query(Req) of
-        undefined -> undefined;
-        Raw ->
-            find_param(Key, uri_string:dissect_query(to_bin(Raw)))
-    end.
+    find_param(Key, uri_string:dissect_query(to_bin(livery_req:query(Req)))).
 
 find_param(_Key, []) -> undefined;
 find_param(Key, [{K, V} | T]) ->

--- a/apps/barrel_server/src/barrel_server_mcp_tools.erl
+++ b/apps/barrel_server/src/barrel_server_mcp_tools.erl
@@ -428,7 +428,40 @@ ensure_corpus(Name) ->
             ok;
         false ->
             DataDir = filename:join(server_data_dir(), "ngram"),
-            _ = barrel_ngram:open(Name, #{db => Name, data_dir => DataDir}),
+            Opts = #{db => Name, data_dir => DataDir},
+            case barrel_ngram:open(Name, Opts) of
+                ok ->
+                    ok;
+                {error, {legacy_corpus_requires_reindex, _}} ->
+                    %% a corpus indexed before barrel_ngram 0.9.0 has no
+                    %% corpus.meta and is rejected outright, with no
+                    %% migration path (db/shards were never recoverable
+                    %% from what a pre-0.9.0 corpus persisted) -- it is a
+                    %% purely derived index over the underlying database's
+                    %% changes feed, so wiping and reopening is safe: the
+                    %% background subscription rebuilds it from scratch.
+                    CorpusDir = filename:join(DataDir, Name),
+                    logger:warning(
+                        "barrel_server: ngram corpus ~s at ~s predates "
+                        "corpus.meta -- reindexing", [Name, CorpusDir]),
+                    ok = del_dir_r(CorpusDir),
+                    _ = barrel_ngram:open(Name, Opts),
+                    ok;
+                {error, _} ->
+                    %% any other failure: leave it be, exactly as before --
+                    %% a real problem surfaces downstream as
+                    %% {error, corpus_not_open} from run_ngram/3
+                    ok
+            end
+    end.
+
+del_dir_r(Dir) ->
+    case file:del_dir_r(Dir) of
+        ok -> ok;
+        {error, enoent} -> ok;
+        {error, Reason} ->
+            logger:warning("barrel_server: could not remove stale ngram "
+                            "corpus dir ~s: ~p", [Dir, Reason]),
             ok
     end.
 

--- a/apps/barrel_server/test/barrel_server_mcp_tools_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_mcp_tools_SUITE.erl
@@ -18,6 +18,7 @@
     t_query_subscribe_rejected/1,
     t_search/1,
     t_ngram_search/1,
+    t_ngram_search_legacy_reindex/1,
     t_changes_cursor/1,
     t_branch_merge/1,
     t_capability_scoping/1,
@@ -36,6 +37,7 @@ groups() ->
     [
         {open, [], [t_tools_list, t_db_doc_roundtrip, t_query_paging,
                     t_query_subscribe_rejected, t_search, t_ngram_search,
+                    t_ngram_search_legacy_reindex,
                     t_changes_cursor, t_branch_merge]},
         {locked, [], [t_capability_scoping, t_server_token_full]}
     ].
@@ -231,6 +233,38 @@ t_ngram_search(_Config) ->
         call(C, <<"ngram_search">>, #{<<"db">> => <<"mcp_ng">>,
                                       <<"mode">> => <<"regex">>,
                                       <<"query">> => <<"(unclosed">>}),
+    barrel_mcp_client:close(C),
+    ok.
+
+%% A corpus indexed before barrel_ngram 0.9.0 has real segments/manifest
+%% but no corpus.meta, and open/2 now rejects that outright with
+%% legacy_corpus_requires_reindex. ensure_corpus/1 must not let that
+%% leave ngram_search permanently returning nothing -- it wipes and
+%% reindexes automatically instead.
+t_ngram_search_legacy_reindex(_Config) ->
+    C = connect(#{}),
+    Db = <<"mcp_ng_legacy">>,
+    {false, _} = call(C, <<"db_create">>, #{<<"db">> => Db}),
+    {false, _} = call(C, <<"doc_put">>,
+                      #{<<"db">> => Db,
+                        <<"doc">> => #{<<"id">> => <<"a">>,
+                                       <<"body">> => <<"connect_timeout in the pool">>}}),
+    {false, #{<<"hits">> := H1}} =
+        call(C, <<"ngram_search">>, #{<<"db">> => Db,
+                                      <<"query">> => <<"connect_timeout">>}),
+    ?assertEqual([<<"a">>], [maps:get(<<"id">>, H) || H <- H1]),
+    %% close, then strip corpus.meta -- simulating a corpus indexed
+    %% before corpus.meta existed (real manifest/segments survive)
+    ok = barrel_ngram:close(Db),
+    DataDir0 = application:get_env(barrel_server, data_dir, "data"),
+    MetaPath = filename:join([DataDir0, "ngram", Db, "corpus.meta"]),
+    ?assert(filelib:is_regular(MetaPath)),
+    ok = file:delete(MetaPath),
+    %% the next search must not go permanently blind
+    {false, #{<<"hits">> := H2}} =
+        call(C, <<"ngram_search">>, #{<<"db">> => Db,
+                                      <<"query">> => <<"connect_timeout">>}),
+    ?assertEqual([<<"a">>], [maps:get(<<"id">>, H) || H <- H2]),
     barrel_mcp_client:close(C),
     ok.
 

--- a/apps/barrel_vectordb/src/barrel_vectordb_index_faiss.erl
+++ b/apps/barrel_vectordb/src/barrel_vectordb_index_faiss.erl
@@ -48,7 +48,7 @@
 %%====================================================================
 
 -record(faiss_state, {
-    index :: reference(),                              %% FAISS NIF reference
+    index :: barrel_faiss:index(),                     %% FAISS NIF handle (opaque)
     dimension :: pos_integer(),                        %% Vector dimension
     metric :: l2 | inner_product,                      %% FAISS metric type
     distance_fn :: cosine | euclidean,                 %% User-facing distance

--- a/rebar.config
+++ b/rebar.config
@@ -58,6 +58,21 @@
     {barrel_bql_parser, return_error, 2}
 ]}.
 
+%% Umbrella-level dialyzer: without this, `rebar3 dialyzer` at the root
+%% ignores every leaf app's own `plt_extra_apps` (ONLY applied when
+%% dialyzer runs inside that app's own directory), so a call into an
+%% external dep that isn't a project app -- mimerl (barrel_docdb),
+%% iommap/hackney/gen_batch_server (barrel_vectordb) -- shows up as an
+%% "Unknown function" false positive instead of being resolved against
+%% the dep's real PLT entry. Scoped to deps of apps always in the
+%% default `project_app_dirs' set; profile-gated apps (barrel_faiss,
+%% barrel_att_s3) keep resolving their own extra deps via their own
+%% `rebar.config' when dialyzed from inside their own directory.
+{dialyzer, [
+    {plt_extra_apps, [mimerl, rocksdb, public_key, inets, iommap,
+                      hackney, gen_batch_server]}
+]}.
+
 {profiles, [
     {test, [
         {deps, [{meck, "1.2.0"}]}


### PR DESCRIPTION
## Summary
- barrel_ngram's corpus lifecycle rework (0.9.0) now gets a root CHANGELOG entry and a README listing; barrel_docdb (1.3.0) and barrel_server (1.5.0) bump alongside it for their part of the change.
- barrel_server's ngram_search MCP tool auto-reindexes a corpus indexed before barrel_ngram 0.9.0 instead of silently returning nothing forever.
- barrel_embed's leaf CI leg now builds and tests on erlang:29 (piloting the OTP 29 dev target in CI, no NIF/sibling deps so an incompatibility surfaces cleanly).
- Fixed the actual source of the barrel_faiss dialyzer noise (an opaque type broken by a concrete record field type in barrel_vectordb_index_faiss), added the root-level dialyzer plt_extra_apps aggregation that xref already had, and removed the dead-code branches that surfaced once both were fixed.

rebar3 dialyzer is now clean on default, faiss, and server profiles.