### PR TITLE
Harden the vector store against stray messages; expose the db embedder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to the Barrel umbrella are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and each app
 is versioned independently under [Semantic Versioning](https://semver.org/).
 
+## [2026-08-23] Stray-message hardening and embed accessors
+
+`barrel_vectordb`'s store server traps exits but only handled call ops, so
+any `'EXIT'` or plain message reaching it killed the store; the managed-venv
+pip install in `barrel_embed`, run inside the store at startup, left exactly
+such an `'EXIT'` behind. The server now routes info/cast ops explicitly and
+ignores them, and `barrel_embed` runs its venv shell commands in a throwaway
+owner process so no port message can reach the caller. `barrel_vectordb` also
+declares `iommap` (disk BM25 / DiskANN) in `applications`. `barrel` gains
+`embed/2`, `embed_batch/2` and `embedder_info/1` on the handle, so callers can
+embed through the database's own embedder without reading handle fields. The
+same `applications` audit caught `mimerl` in `barrel_docdb`, `crypto` in
+`barrel_embed`, and `mimerl`/`livery` in `barrel_att_s3`.
+
+| App | Version | Change |
+|-----|---------|--------|
+| barrel_vectordb | 2.2.1 | info/cast ops no longer crash the store; `iommap` in `applications` |
+| barrel_embed | 2.3.2 | venv commands run their port in an owner process; no mailbox leak; `crypto` in `applications` |
+| barrel | 1.3.0 | `embed/2`, `embed_batch/2`, `embedder_info/1` |
+| barrel_docdb | 1.3.1 | `mimerl` in `applications` |
+| barrel_att_s3 | 0.1.1 | `mimerl` and `livery` in `applications` |
+
 ## [2026-08-15] barrel_ngram corpus lifecycle hardening
 
 `barrel_ngram`'s `open/2`/`close/1` are now serialized per corpus by a

--- a/apps/barrel/CHANGELOG.md
+++ b/apps/barrel/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.3.0] - 2026-08-23
+
+### Added
+- `embed/2`, `embed_batch/2` and `embedder_info/1` on the database handle:
+  embed text with the database's own embedder (the policy's on a record-mode
+  database, the vector store's on a plain one), so consumers no longer need to
+  reach into the handle's `embed` field.
+
 ## [1.2.0] - 2026-08-09
 
 ### Added

--- a/apps/barrel/README.md
+++ b/apps/barrel/README.md
@@ -81,3 +81,5 @@ Large attachments stream: `open_attachment_writer/4` + `write_attachment/2` +
 - Vectors: `vector_add/4,5`, `vector_add_batch/2`, `vector_get/2`,
   `vector_delete/2`, `search/3`, `search_vector/3`, `search_bm25/3`,
   `search_hybrid/3`, `vector_stats/1`
+- Embedding with the database's own embedder: `embed/2`, `embed_batch/2`,
+  `embedder_info/1`

--- a/apps/barrel/src/barrel.app.src
+++ b/apps/barrel/src/barrel.app.src
@@ -1,6 +1,6 @@
 {application, barrel, [
     {description, "Barrel: the embeddable edge-AI database composing the document and vector layers"},
-    {vsn, "1.2.0"},
+    {vsn, "1.3.0"},
     {registered, [barrel_sup]},
     {mod, {barrel_app, []}},
     {applications, [

--- a/apps/barrel/src/barrel.erl
+++ b/apps/barrel/src/barrel.erl
@@ -109,6 +109,13 @@
     vector_stats/1
 ]).
 
+%% Embedding through the database's own embedder
+-export([
+    embed/2,
+    embed_batch/2,
+    embedder_info/1
+]).
+
 -export_type([db/0, db_name/0]).
 
 %% Outbox tag carried by every record-mode write (and, via docdb
@@ -896,6 +903,31 @@ search_hybrid(#{embedding := _, embed := Embed, vstore := Store}, Query, Opts) -
     end;
 search_hybrid(#{vstore := Store}, Query, Opts) ->
     barrel_vectordb:search_hybrid(Store, Query, Opts).
+
+%% @doc Embed a text with the database's own embedder: the one the
+%% embedding policy configured on a record-mode database, the vector
+%% store's on a plain one. Same model and dimension as the indexed
+%% vectors, so the result can be passed to {@link search_vector/3}.
+-spec embed(db(), binary()) -> {ok, [float()]} | {error, term()}.
+embed(#{embedding := _, embed := Embed}, Text) ->
+    embed_one(Text, Embed);
+embed(#{vstore := Store}, Text) ->
+    barrel_vectordb:embed(Store, Text).
+
+%% @doc Embed several texts in one provider call (see {@link embed/2}).
+-spec embed_batch(db(), [binary()]) -> {ok, [[float()]]} | {error, term()}.
+embed_batch(#{embedding := _, embed := Embed}, Texts) ->
+    embed_many(Texts, Embed);
+embed_batch(#{vstore := Store}, Texts) ->
+    barrel_vectordb:embed_batch(Store, Texts).
+
+%% @doc Describe the database's embedder: `configured', `providers' and
+%% `dimension' (see `barrel_embed:info/1').
+-spec embedder_info(db()) -> {ok, map()}.
+embedder_info(#{embedding := _, embed := Embed}) ->
+    {ok, barrel_embed:info(Embed)};
+embedder_info(#{vstore := Store}) ->
+    barrel_vectordb:embedder_info(Store).
 
 %% @doc Vector store statistics.
 -spec vector_stats(db()) -> term().

--- a/apps/barrel/test/barrel_SUITE.erl
+++ b/apps/barrel/test/barrel_SUITE.erl
@@ -153,6 +153,12 @@ t_vectors(Config) ->
     %% covered where a model is available.
     ?assertEqual({error, embedder_not_configured},
                  barrel:search_hybrid(Db, <<"hello">>, #{k => 5})),
+    %% The embed accessors go through the store's embedder on a plain
+    %% database, so they report the same thing.
+    ?assertEqual({error, embedder_not_configured}, barrel:embed(Db, <<"hello">>)),
+    ?assertEqual({error, embedder_not_configured},
+                 barrel:embed_batch(Db, [<<"hello">>])),
+    ?assertEqual({ok, #{configured => false}}, barrel:embedder_info(Db)),
     ok = barrel:vector_delete(Db, <<"a">>),
     ?assertEqual(not_found, barrel:vector_get(Db, <<"a">>)),
     ok.

--- a/apps/barrel/test/barrel_record_SUITE.erl
+++ b/apps/barrel/test/barrel_record_SUITE.erl
@@ -34,6 +34,7 @@
          sync_delete_immediate/1,
          sync_batch_put/1,
          explicit_vector_skips_embedder/1,
+         embed_accessors/1,
          explicit_vector_dimension_check/1,
          search_end_to_end/1,
          vector_add_guards/1,
@@ -72,6 +73,7 @@ all() ->
      explicit_vector_skips_embedder,
      explicit_vector_dimension_check,
      search_end_to_end,
+     embed_accessors,
      vector_add_guards,
      byo_embedding_async,
      byo_embedding_sync_and_precedence,
@@ -130,6 +132,7 @@ meck_cases() ->
      explicit_vector_skips_embedder,
      explicit_vector_dimension_check,
      search_end_to_end,
+     embed_accessors,
      vector_add_guards,
      byo_embedding_async,
      byo_embedding_sync_and_precedence,
@@ -637,6 +640,19 @@ byo_embedding_not_path_indexed(Config) ->
     ?assertEqual(1, length(Rows)),
     {ok, NoRows, _} = barrel:find(Db, #{where => [{exists, [<<"_embedding">>]}]}),
     ?assertEqual(0, length(NoRows)),
+    ok = barrel:close(Db).
+
+embed_accessors(Config) ->
+    {ok, Db} = open_record(embed_acc_db, Config, #{fields => [<<"title">>]}),
+    %% Same embedder as the indexer: the vector matches what search_vector
+    %% is indexed with.
+    ?assertEqual({ok, mock_vec(<<"hello">>)}, barrel:embed(Db, <<"hello">>)),
+    ?assertEqual({ok, [mock_vec(<<"a">>), mock_vec(<<"b">>)]},
+                 barrel:embed_batch(Db, [<<"a">>, <<"b">>])),
+    ?assertEqual({ok, []}, barrel:embed_batch(Db, [])),
+    ?assertEqual({error, poison}, barrel:embed(Db, <<"poison">>)),
+    {ok, Info} = barrel:embedder_info(Db),
+    ?assertMatch(#{configured := _}, Info),
     ok = barrel:close(Db).
 
 vector_add_guards(Config) ->

--- a/apps/barrel_att_s3/CHANGELOG.md
+++ b/apps/barrel_att_s3/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.1.1] - 2026-08-23
+
+### Fixed
+- `mimerl` and `livery` are declared in the application's `applications`:
+  both are called directly but were only rebar deps, so a release that
+  derives its app list from `applications` could ship without them.
+
 ## [0.1.0] - 2026-08-09
 
 Initial release. `barrel_att_backend` implementation against S3-compatible

--- a/apps/barrel_att_s3/src/barrel_att_s3.app.src
+++ b/apps/barrel_att_s3/src/barrel_att_s3.app.src
@@ -1,6 +1,6 @@
 {application, barrel_att_s3, [
     {description, "S3-compatible attachment storage backend for barrel_docdb"},
-    {vsn, "0.1.0"},
+    {vsn, "0.1.1"},
     {registered, [barrel_att_s3_sup, barrel_att_s3_multipart_gc]},
     {mod, {barrel_att_s3_app, []}},
     {applications, [
@@ -17,6 +17,8 @@
         %% true in practice; declared for anything that loads this app in
         %% isolation.
         barrel_docdb,
+        mimerl,
+        livery,
         livery_s3
     ]},
     {env, []},

--- a/apps/barrel_docdb/CHANGELOG.md
+++ b/apps/barrel_docdb/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-08-23
+
+### Fixed
+- `mimerl` is declared in the application's `applications`: the attachment
+  store calls it unconditionally, but it was only a rebar dep, so a release
+  that derives its app list from `applications` shipped without it.
+
 ## [1.3.0] - 2026-08-15
 
 ### Added

--- a/apps/barrel_docdb/src/barrel_docdb.app.src
+++ b/apps/barrel_docdb/src/barrel_docdb.app.src
@@ -1,6 +1,6 @@
 {application, barrel_docdb, [
     {description, "Erlang document database with MVCC, queries, and replication"},
-    {vsn, "1.3.0"},
+    {vsn, "1.3.1"},
     {registered, [barrel_docdb_sup]},
     {mod, {barrel_docdb_app, []}},
     {applications, [
@@ -11,6 +11,7 @@
         rocksdb,
         hlc,
         match_trie,
+        mimerl,
         instrument,
         hackney,
         barrel_crypto

--- a/apps/barrel_embed/CHANGELOG.md
+++ b/apps/barrel_embed/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.3.2] - 2026-08-23
+
+### Fixed
+- The managed-venv shell commands (venv creation, pip install, uvloop check,
+  directory removal) run their port in a short-lived owner process. The port
+  used to be opened in the caller's process, leaving `{Port, _}` and, for a
+  caller trapping exits, `{'EXIT', Port, normal}` messages in its mailbox
+  after the command ended; `barrel_vectordb_server` (which traps exits and
+  initializes the embedder in its own process) crashed on that stray message.
+  A timeout no longer raises `badarg` when the port already closed.
+
 ## [2.3.1] - 2026-07-18
 
 ### Fixed

--- a/apps/barrel_embed/src/barrel_embed.app.src
+++ b/apps/barrel_embed/src/barrel_embed.app.src
@@ -1,11 +1,12 @@
 {application, barrel_embed,
  [{description, "Lightweight embedding generation for Erlang"},
-  {vsn, "2.3.1"},
+  {vsn, "2.3.2"},
   {registered, []},
   {mod, {barrel_embed_app, []}},
   {applications,
    [kernel,
     stdlib,
+    crypto,
     hackney
    ]},
   {env,[]},

--- a/apps/barrel_embed/src/barrel_embed_venv.erl
+++ b/apps/barrel_embed/src/barrel_embed_venv.erl
@@ -19,6 +19,10 @@
 %%%-------------------------------------------------------------------
 -module(barrel_embed_venv).
 
+-ifdef(TEST).
+-export([run_cmd/2]).
+-endif.
+
 -export([
     ensure_venv/0,
     create_venv/0,
@@ -258,11 +262,28 @@ run_cmd(Cmd) ->
     run_cmd(Cmd, 60000).  %% 60 second default timeout
 
 run_cmd(Cmd, Timeout) ->
-    Port = open_port(
-        {spawn, Cmd},
-        [exit_status, stderr_to_stdout, binary]
-    ),
-    collect_output(Port, [], Timeout).
+    %% A throwaway process owns the port so no port message (nor the 'EXIT'
+    %% a trap_exit caller would get) lands in the caller's mailbox.
+    Caller = self(),
+    Ref = make_ref(),
+    {Pid, MRef} = spawn_monitor(fun() ->
+        Caller ! {Ref, run_cmd_owner(Cmd, Timeout)}
+    end),
+    receive
+        {Ref, Result} ->
+            erlang:demonitor(MRef, [flush]),
+            Result;
+        {'DOWN', MRef, process, Pid, Reason} ->
+            {error, {port_owner_exit, Reason}}
+    end.
+
+%% Runs inside the owner process; its mailbox dies with it.
+run_cmd_owner(Cmd, Timeout) ->
+    try open_port({spawn, Cmd}, [exit_status, stderr_to_stdout, binary]) of
+        Port -> collect_output(Port, [], Timeout)
+    catch
+        error:Reason -> {error, {open_port, Reason}}
+    end.
 
 collect_output(Port, Acc, Timeout) ->
     receive
@@ -275,7 +296,7 @@ collect_output(Port, Acc, Timeout) ->
             Output = iolist_to_binary(lists:reverse(Acc)),
             {error, {exit_status, Status, binary_to_list(Output)}}
     after Timeout ->
-        port_close(Port),
+        _ = try port_close(Port) catch error:badarg -> ok end,
         {error, timeout}
     end.
 

--- a/apps/barrel_embed/test/barrel_embed_venv_tests.erl
+++ b/apps/barrel_embed/test/barrel_embed_venv_tests.erl
@@ -43,6 +43,16 @@ install_deps_test_() ->
      ]
     }.
 
+%% run_cmd/2 must never leave port or 'EXIT' messages in the caller's
+%% mailbox (a trap_exit caller such as barrel_vectordb_server would
+%% otherwise see them as stray ops).
+run_cmd_test_() ->
+    [
+     {"success leaves the caller's mailbox empty", fun test_run_cmd_mailbox_ok/0},
+     {"non-zero exit leaves the caller's mailbox empty", fun test_run_cmd_mailbox_error/0},
+     {"timeout leaves the caller's mailbox empty", fun test_run_cmd_mailbox_timeout/0}
+    ].
+
 %% Tests for barrel_embed wrapper functions
 barrel_embed_api_test_() ->
     {foreach,
@@ -290,4 +300,41 @@ check_python3(Python) ->
         "3\n" -> {ok, Python};
         "3" -> {ok, Python};
         _ -> {error, not_python3}
+    end.
+
+%%====================================================================
+%% Test Cases - run_cmd
+%%====================================================================
+
+test_run_cmd_mailbox_ok() ->
+    {Result, Msgs} = run_cmd_trapping("echo hello", 5000),
+    ?assertEqual({ok, "hello\n"}, Result),
+    ?assertEqual([], Msgs).
+
+test_run_cmd_mailbox_error() ->
+    {Result, Msgs} = run_cmd_trapping("sh -c 'echo oops; exit 3'", 5000),
+    ?assertEqual({error, {exit_status, 3, "oops\n"}}, Result),
+    ?assertEqual([], Msgs).
+
+test_run_cmd_mailbox_timeout() ->
+    {Result, Msgs} = run_cmd_trapping("sleep 5", 200),
+    ?assertEqual({error, timeout}, Result),
+    ?assertEqual([], Msgs).
+
+%% Run Cmd from a process that traps exits and report its mailbox once
+%% the port (and its owner) had time to finish.
+run_cmd_trapping(Cmd, Timeout) ->
+    Parent = self(),
+    Ref = make_ref(),
+    spawn(fun() ->
+        process_flag(trap_exit, true),
+        Result = barrel_embed_venv:run_cmd(Cmd, Timeout),
+        timer:sleep(200),
+        {messages, Msgs} = erlang:process_info(self(), messages),
+        Parent ! {Ref, Result, Msgs}
+    end),
+    receive
+        {Ref, Result, Msgs} -> {Result, Msgs}
+    after 15000 ->
+        error(run_cmd_test_timeout)
     end.

--- a/apps/barrel_vectordb/CHANGELOG.md
+++ b/apps/barrel_vectordb/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2026-08-23
+
+### Fixed
+- The store server no longer crashes on a message that is not a call. `init`
+  traps exits, so an `'EXIT'` from a port or linked helper ended in the store's
+  context (the managed-venv pip install of `barrel_embed` did exactly that), or
+  any message sent with `!` or `cast`, reached `handle_batch` as an
+  `{info, _}`/`{cast, _}` op with no matching clause and killed the store.
+  Such ops are now routed explicitly and ignored (`'EXIT' normal` silently,
+  the rest logged).
+- `iommap` is declared in the application's `applications`. It is a hard
+  runtime dependency of the disk BM25 and DiskANN files but was only listed as
+  a rebar dep, so a release that derives its app list from `applications`
+  shipped without it.
+
 ## [2.2.0] - 2026-07-18
 
 ### Added

--- a/apps/barrel_vectordb/src/barrel_vectordb.app.src
+++ b/apps/barrel_vectordb/src/barrel_vectordb.app.src
@@ -1,6 +1,6 @@
 {application, barrel_vectordb, [
     {description, "Embedded Erlang vector database with pluggable backends (HNSW, FAISS) and RocksDB for semantic search"},
-    {vsn, "2.2.0"},
+    {vsn, "2.2.1"},
     {registered, [barrel_vectordb_sup]},
     {mod, {barrel_vectordb_app, []}},
     {applications, [
@@ -10,6 +10,7 @@
         ssl,
         inets,
         rocksdb,
+        iommap,
         hackney,
         gen_batch_server,
         barrel_embed,

--- a/apps/barrel_vectordb/src/barrel_vectordb_server.erl
+++ b/apps/barrel_vectordb/src/barrel_vectordb_server.erl
@@ -368,36 +368,47 @@ init_crypto(Config, DbPath) ->
 %% @doc Handle a batch of operations.
 %% Partitions operations into reads (processed immediately) and writes (batched atomically).
 handle_batch(Ops, State) ->
-    %% Separate reads from writes
-    {Reads, Writes} = partition_ops(Ops),
+    {Others, Reads, Writes} = partition_ops(Ops),
+
+    %% Stray info/cast ops first: no reply, no storage access
+    {_, State1} = process_reads(Others, State),
 
     %% Process reads immediately (they don't modify state)
-    {ReadActions, State1} = process_reads(Reads, State),
+    {ReadActions, State2} = process_reads(Reads, State1),
 
     %% Process writes atomically in a single batch
-    {WriteActions, State2} = process_writes_atomic(Writes, State1),
+    {WriteActions, State3} = process_writes_atomic(Writes, State2),
 
-    {ok, ReadActions ++ WriteActions, State2}.
+    {ok, ReadActions ++ WriteActions, State3}.
 
-%% Partition operations into reads and writes
+%% Route ops: add/index calls go into one RocksDB batch, other calls run
+%% one by one, info/cast ops (no From) are handled explicitly, never crash.
 partition_ops(Ops) ->
-    lists:partition(fun(Op) ->
-        case Op of
-            {_, _, {add, _, _, _}} -> false;
-            {_, _, {add_vector, _, _, _, _}} -> false;
-            {_, _, {add_batch, _}} -> false;
-            {_, _, {add_vector_batch, _}} -> false;
-            {_, _, {index_only, _, _, _}} -> false;
-            {_, _, {index_only_batch, _}} -> false;
-            _ -> true  % reads: get, search, peek, stats, count, delete, update, upsert
+    lists:foldr(fun(Op, {Others, Reads, Writes}) ->
+        case classify_op(Op) of
+            write -> {Others, Reads, [Op | Writes]};
+            read -> {Others, [Op | Reads], Writes};
+            other -> {[Op | Others], Reads, Writes}
         end
-    end, Ops).
+    end, {[], [], []}, Ops).
 
-%% Process read operations (and delete/update/upsert which need immediate state access)
+classify_op({call, _, {add, _, _, _}}) -> write;
+classify_op({call, _, {add_vector, _, _, _, _}}) -> write;
+classify_op({call, _, {add_batch, _}}) -> write;
+classify_op({call, _, {add_vector_batch, _}}) -> write;
+classify_op({call, _, {index_only, _, _, _}}) -> write;
+classify_op({call, _, {index_only_batch, _}}) -> write;
+classify_op({call, _, _}) -> read;
+classify_op({cast, _}) -> other;
+classify_op({info, _}) -> other.
+
+%% Process ops one at a time; info/cast ops yield no reply action.
 process_reads(Reads, State) ->
     lists:foldl(fun(Op, {AccActions, AccState}) ->
-        {Action, NewState} = process_single_op(Op, AccState),
-        {[Action | AccActions], NewState}
+        case process_single_op(Op, AccState) of
+            {[], NewState} -> {AccActions, NewState};
+            {Action, NewState} -> {[Action | AccActions], NewState}
+        end
     end, {[], State}, Reads).
 
 %% Process a single operation (for reads and non-batched operations)
@@ -566,7 +577,24 @@ process_single_op({call, From, bm25_compact}, State) ->
     end;
 
 process_single_op({call, From, _Unknown}, State) ->
-    {{reply, From, {error, unknown_request}}, State}.
+    {{reply, From, {error, unknown_request}}, State};
+
+%% Non-call ops: 'EXIT' signals (init traps exits, so a port ended in the
+%% store's context delivers one), bare messages, casts. Never fatal.
+process_single_op({info, {'EXIT', _Pid, normal}}, State) ->
+    {[], State};
+process_single_op({info, {'EXIT', Pid, Reason}}, State) ->
+    logger:warning("barrel_vectordb_server ~p: linked process ~p exited: ~p",
+                   [self(), Pid, Reason]),
+    {[], State};
+process_single_op({info, Msg}, State) ->
+    logger:debug("barrel_vectordb_server ~p: ignoring message ~p",
+                 [self(), Msg]),
+    {[], State};
+process_single_op({cast, Msg}, State) ->
+    logger:debug("barrel_vectordb_server ~p: ignoring cast ~p",
+                 [self(), Msg]),
+    {[], State}.
 
 %% Process write operations atomically in a single RocksDB batch
 process_writes_atomic([], State) ->

--- a/apps/barrel_vectordb/test/barrel_vectordb_server_tests.erl
+++ b/apps/barrel_vectordb/test/barrel_vectordb_server_tests.erl
@@ -50,6 +50,17 @@ hybrid_test_() ->
      ]
     }.
 
+stray_message_test_() ->
+    {foreach,
+     fun setup_store/0,
+     fun cleanup_store/1,
+     [
+       {"a bare message does not kill the store", fun test_stray_info/0},
+       {"a cast does not kill the store", fun test_stray_cast/0},
+       {"an 'EXIT' signal does not kill the store", fun test_stray_exit/0}
+     ]
+    }.
+
 restart_rebuild_test() ->
     %% Standalone (owns its dir): the ANN index rebuilds from the vectors
     %% CF on restart, which includes index-only rows.
@@ -267,3 +278,38 @@ test_hybrid_query_vector_skips_embed() ->
     {ok, [_ | _]} = barrel_vectordb:search_hybrid(
         ?STORE, <<"alpha">>, #{k => 1, query_vector => [1.0, 0.0, 0.0]}),
     ok.
+
+%%====================================================================
+%% Stray messages (init traps exits, so these reach handle_batch as
+%% {info, _} / {cast, _} ops)
+%%====================================================================
+
+test_stray_info() ->
+    Pid = whereis_store(),
+    Pid ! {unexpected, make_ref()},
+    assert_store_alive(Pid).
+
+test_stray_cast() ->
+    Pid = whereis_store(),
+    ok = gen_batch_server:cast(Pid, unexpected_cast),
+    assert_store_alive(Pid).
+
+test_stray_exit() ->
+    Pid = whereis_store(),
+    %% What a port opened (and ended) inside the store delivers under
+    %% trap_exit; a non-normal reason must not kill it either.
+    Pid ! {'EXIT', self(), normal},
+    Pid ! {'EXIT', self(), {shutdown, stray}},
+    assert_store_alive(Pid).
+
+whereis_store() ->
+    Pid = barrel_vectordb_registry:whereis_name(
+        {vstore, atom_to_binary(?STORE, utf8)}),
+    ?assert(is_pid(Pid)),
+    Pid.
+
+assert_store_alive(Pid) ->
+    ok = barrel_vectordb:add_index_only(
+        ?STORE, <<"a">>, <<"text">>, [1.0, 0.0, 0.0]),
+    ?assertEqual(1, barrel_vectordb:count(?STORE)),
+    ?assert(is_process_alive(Pid)).

--- a/docs/guides/embedding.md
+++ b/docs/guides/embedding.md
@@ -94,6 +94,10 @@ Notes:
 - BM25 is opt-in: open with `vectordb => #{bm25_backend => memory}` (or `disk`).
 - `search_hybrid/3` and auto-embedding adds need an embedder configured via
   `barrel_embed`; without one they return `{error, embedder_not_configured}`.
+- To embed text yourself with the database's own embedder (same model and
+  dimension as the indexed vectors), use `barrel:embed/2`,
+  `barrel:embed_batch/2` and `barrel:embedder_info/1` on the handle; keep
+  the handle opaque rather than reading its fields.
 
 ## Changes
 

--- a/docs/guides/record-mode.md
+++ b/docs/guides/record-mode.md
@@ -60,6 +60,16 @@ Hits carry `key`, `score`, and the document-derived `text` and `metadata`.
 Updates re-embed; deletes remove the vector; documents without policy fields
 get no vector.
 
+To embed text with the policy's embedder yourself (for a `search_vector/3`
+query, or to store the vector elsewhere), use the handle rather than its
+fields:
+
+```erlang
+{ok, Vector}  = barrel:embed(Db, <<"fast fox">>),
+{ok, Vectors} = barrel:embed_batch(Db, [<<"a">>, <<"b">>]),
+{ok, #{dimension := Dim}} = barrel:embedder_info(Db).
+```
+
 ## Async and sync
 
 `mode => async` (default): writes return immediately and a supervised


### PR DESCRIPTION
barrel_vectordb_server traps exits but only handled call ops, so any 'EXIT' or plain message reaching it killed the store. The managed-venv pip install in barrel_embed left exactly such an 'EXIT' behind, because it opened its port in the caller's process. Non-call ops are now routed and ignored explicitly, and the venv shell commands run their port in a throwaway owner process so nothing leaks into the caller's mailbox.

barrel gains `embed/2`, `embed_batch/2` and `embedder_info/1` on the handle, so a consumer can embed through the database's own embedder without reading the handle's fields.

iommap was a hard runtime dep of barrel_vectordb missing from its `applications` list; the same audit found mimerl (barrel_docdb), crypto (barrel_embed) and mimerl/livery (barrel_att_s3). barrel_vectordb's use of barrel_docdb (optional docstore backend, not a rebar dep) is left undeclared on purpose.

Versions: barrel_vectordb 2.2.1, barrel_embed 2.3.2, barrel 1.3.0, barrel_docdb 1.3.1, barrel_att_s3 0.1.1.