### PR TITLE
barrel_rerank: run venv shell commands in a port owner process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ any `'EXIT'` or plain message reaching it killed the store; the managed-venv
 pip install in `barrel_embed`, run inside the store at startup, left exactly
 such an `'EXIT'` behind. The server now routes info/cast ops explicitly and
 ignores them, and `barrel_embed` runs its venv shell commands in a throwaway
-owner process so no port message can reach the caller. `barrel_vectordb` also
+owner process so no port message can reach the caller (`barrel_rerank`'s venv
+helper had the same leak and gets the same fix). `barrel_vectordb` also
 declares `iommap` (disk BM25 / DiskANN) in `applications`. `barrel` gains
 `embed/2`, `embed_batch/2` and `embedder_info/1` on the handle, so callers can
 embed through the database's own embedder without reading handle fields. The
@@ -25,6 +26,7 @@ same `applications` audit caught `mimerl` in `barrel_docdb`, `crypto` in
 | barrel | 1.3.0 | `embed/2`, `embed_batch/2`, `embedder_info/1` |
 | barrel_docdb | 1.3.1 | `mimerl` in `applications` |
 | barrel_att_s3 | 0.1.1 | `mimerl` and `livery` in `applications` |
+| barrel_rerank | 1.0.2 | venv commands run their port in an owner process; no mailbox leak |
 
 ## [2026-08-15] barrel_ngram corpus lifecycle hardening
 

--- a/apps/barrel_rerank/CHANGELOG.md
+++ b/apps/barrel_rerank/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0.2 (2026-08-23)
+
+- The venv shell commands (venv creation, pip install, uvloop check) run
+  their port in a short-lived owner process. The port used to be opened in
+  the caller's process, leaving `{Port, _}` and, for a caller trapping exits,
+  `{'EXIT', Port, normal}` messages in its mailbox after the command ended.
+  Same fix as barrel_embed 2.3.2.
+
 ## 1.0.1 (2026-07-18)
 
 - Fail fast on a Python startup exit instead of hanging the full timeout: the

--- a/apps/barrel_rerank/src/barrel_rerank.app.src
+++ b/apps/barrel_rerank/src/barrel_rerank.app.src
@@ -1,6 +1,6 @@
 {application, barrel_rerank, [
     {description, "Cross-encoder reranking for Erlang"},
-    {vsn, "1.0.1"},
+    {vsn, "1.0.2"},
     {registered, []},
     {mod, {barrel_rerank_app, []}},
     {applications, [kernel, stdlib]},

--- a/apps/barrel_rerank/src/barrel_rerank_venv.erl
+++ b/apps/barrel_rerank/src/barrel_rerank_venv.erl
@@ -31,6 +31,10 @@
 %%%-------------------------------------------------------------------
 -module(barrel_rerank_venv).
 
+-ifdef(TEST).
+-export([run_cmd/2]).
+-endif.
+
 -export([
     venv_path/0,
     ensure_venv/0,
@@ -204,19 +208,42 @@ install_packages(Pip, Packages) ->
 
 %% @private Run a shell command
 run_cmd(Cmd) ->
-    Port = open_port({spawn, Cmd}, [exit_status, stderr_to_stdout, binary]),
-    collect_output(Port, []).
+    run_cmd(Cmd, 600000).
 
-collect_output(Port, Acc) ->
+run_cmd(Cmd, Timeout) ->
+    %% A throwaway process owns the port so no port message (nor the 'EXIT'
+    %% a trap_exit caller would get) lands in the caller's mailbox.
+    Caller = self(),
+    Ref = make_ref(),
+    {Pid, MRef} = spawn_monitor(fun() ->
+        Caller ! {Ref, run_cmd_owner(Cmd, Timeout)}
+    end),
+    receive
+        {Ref, Result} ->
+            erlang:demonitor(MRef, [flush]),
+            Result;
+        {'DOWN', MRef, process, Pid, Reason} ->
+            {error, {port_owner_exit, Reason}}
+    end.
+
+%% Runs inside the owner process; its mailbox dies with it.
+run_cmd_owner(Cmd, Timeout) ->
+    try open_port({spawn, Cmd}, [exit_status, stderr_to_stdout, binary]) of
+        Port -> collect_output(Port, [], Timeout)
+    catch
+        error:Reason -> {error, {open_port, Reason}}
+    end.
+
+collect_output(Port, Acc, Timeout) ->
     receive
         {Port, {data, Data}} ->
-            collect_output(Port, [Data | Acc]);
+            collect_output(Port, [Data | Acc], Timeout);
         {Port, {exit_status, 0}} ->
             {ok, iolist_to_binary(lists:reverse(Acc))};
         {Port, {exit_status, Code}} ->
             Output = iolist_to_binary(lists:reverse(Acc)),
             {error, {exit_code, Code, Output}}
-    after 600000 ->
-        _ = try port_close(Port) catch _:_ -> ok end,
+    after Timeout ->
+        _ = try port_close(Port) catch error:badarg -> ok end,
         {error, timeout}
     end.

--- a/apps/barrel_rerank/test/barrel_rerank_venv_tests.erl
+++ b/apps/barrel_rerank/test/barrel_rerank_venv_tests.erl
@@ -34,3 +34,36 @@ is_valid_nonexistent_test() ->
     after
         application:unset_env(barrel_rerank, venv_path)
     end.
+
+%% run_cmd/2 must never leave port or 'EXIT' messages in the caller's
+%% mailbox (a trap_exit caller would otherwise see them as stray messages).
+run_cmd_mailbox_ok_test() ->
+    {Result, Msgs} = run_cmd_trapping("echo hello", 5000),
+    ?assertEqual({ok, <<"hello\n">>}, Result),
+    ?assertEqual([], Msgs).
+
+run_cmd_mailbox_error_test() ->
+    {Result, Msgs} = run_cmd_trapping("sh -c 'echo oops; exit 3'", 5000),
+    ?assertEqual({error, {exit_code, 3, <<"oops\n">>}}, Result),
+    ?assertEqual([], Msgs).
+
+run_cmd_mailbox_timeout_test() ->
+    {Result, Msgs} = run_cmd_trapping("sleep 5", 200),
+    ?assertEqual({error, timeout}, Result),
+    ?assertEqual([], Msgs).
+
+run_cmd_trapping(Cmd, Timeout) ->
+    Parent = self(),
+    Ref = make_ref(),
+    spawn(fun() ->
+        process_flag(trap_exit, true),
+        Result = barrel_rerank_venv:run_cmd(Cmd, Timeout),
+        timer:sleep(200),
+        {messages, Msgs} = erlang:process_info(self(), messages),
+        Parent ! {Ref, Result, Msgs}
+    end),
+    receive
+        {Ref, Result, Msgs} -> {Result, Msgs}
+    after 15000 ->
+        error(run_cmd_test_timeout)
+    end.


### PR DESCRIPTION
barrel_rerank_venv opened its pip/python ports in the caller's process, the same leak fixed in barrel_embed 2.3.2 (#30): port messages, and for a caller trapping exits the port's 'EXIT', stayed in the caller's mailbox after the command ended. The port now lives in a throwaway process that only hands back the result.

Version: barrel_rerank 1.0.2.