### PR TITLE
barrel 1.3.1: require barrel_vectordb 2.3 and OTP 26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ build, for the umbrella and for every Hex consumer.
 | App | Version | Change |
 |-----|---------|--------|
 | barrel_vectordb | 2.3.0 | store server is a gen_server with write coalescing; gen_batch_server removed; requires OTP 26+ |
+| barrel | 1.3.1 | requires barrel_vectordb 2.3 and OTP 26+ |
 
 ## [2026-08-23] Stray-message hardening and embed accessors
 

--- a/apps/barrel/CHANGELOG.md
+++ b/apps/barrel/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.3.1] - 2026-08-23
+
+### Changed
+- Requires `barrel_vectordb` 2.3 (the store server without gen_batch_server)
+  and OTP 26 or later, so a dependency on `barrel` resolves to a build that is
+  warning-free on OTP 29.
+
 ## [1.3.0] - 2026-08-23
 
 ### Added

--- a/apps/barrel/rebar.config
+++ b/apps/barrel/rebar.config
@@ -8,9 +8,12 @@
 {deps, [
     {barrel_crypto, "~> 1.0"},
     {barrel_docdb, "~> 1.0"},
-    {barrel_vectordb, "~> 2.1"},
+    {barrel_vectordb, "~> 2.3"},
     {barrel_embed, "~> 2.3"}
 ]}.
+
+%% barrel_vectordb 2.3 (gen_server store) needs OTP 26.
+{minimum_otp_vsn, "26"}.
 
 {project_plugins, [rebar3_hex, rebar3_ex_doc]}.
 

--- a/apps/barrel/src/barrel.app.src
+++ b/apps/barrel/src/barrel.app.src
@@ -1,6 +1,6 @@
 {application, barrel, [
     {description, "Barrel: the embeddable edge-AI database composing the document and vector layers"},
-    {vsn, "1.3.0"},
+    {vsn, "1.3.1"},
     {registered, [barrel_sup]},
     {mod, {barrel_app, []}},
     {applications, [


### PR DESCRIPTION
barrel 1.3.0 accepted any barrel_vectordb 2.1+, so a consumer with an older lock kept the gen_batch_server store and its OTP 29 warnings. The pin is now `~> 2.3` and barrel declares `minimum_otp_vsn` 26, the floor that comes with it. No code change.

Publish order: barrel_vectordb 2.3.0 first; the standalone `rebar3 hex build` + requirements check for barrel can only run once that version is on Hex (the pin does not resolve before).