### PR TITLE
barrel_spaces 1.1.0: adoptable for existing session stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to the Barrel umbrella are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and each app
 is versioned independently under [Semantic Versioning](https://semver.org/).
 
+## [2026-08-25] barrel_spaces adoptable for existing session stores
+
+Feedback from adopting the agent layer in an external product: sessions could
+only be caches (every mutation re-armed the TTL), listing filtered in Erlang
+over a full fold, ids were always minted so a corpus could not move in, and
+`accept/2` forced a session into existence. All four are lifted additively:
+`ttl => infinity`, indexed `list/2` filters, caller ids plus
+`import_session/2`/`import_message/3`, and `accept(Token, #{session =>
+false})`. The registry database name becomes configuration, and the two
+behaviors consumers already rely on, replicating the registry and granting
+capabilities on purely logical scopes, are documented as intended.
+
+| App | Version | Change |
+|-----|---------|--------|
+| barrel_spaces | 1.1.0 | durable sessions, indexed listing, import with ids, accept without session, configurable registry |
+
 ## [2026-08-23] barrel_vectordb store server without gen_batch_server
 
 `barrel_vectordb`'s per-store process is a plain `gen_server` again. The only

--- a/apps/barrel_spaces/CHANGELOG.md
+++ b/apps/barrel_spaces/CHANGELOG.md
@@ -3,6 +3,19 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.0] - 2026-08-25
+
+### Added
+- Sessions without expiry: `ttl => infinity` (or 0) creates a durable session the TTL machinery skips; `touch/2` and the other mutations return `{ok, 0}` for it.
+- Indexed session listing: `barrel_session:list/2` takes `match` (field path to value, resolved through the space database's path indexes) and `limit`; the `agent` filter now uses the same indexed path.
+- Session import: `create/2` accepts a caller-supplied `id`; `import_session/2` and `import_message/3` move an existing corpus in with its own ids and timestamps, without bypassing the schema.
+- `barrel_handoff:accept/2` with `session => false` accepts on the token discipline alone: no space open, no session created, for consumers with their own session model.
+- Token-to-handoff resolution reads a `handoff_token:` index doc written at create (scan fallback for pre-1.1 handoffs).
+- The registry database name is configurable (`registry_db` app env, default `_barrel_spaces`); replicating the registry, and the logical (space-less) capability scopes, are now documented as intended.
+
+### Fixed
+- README described `chain/2` as walking a handoff backwards; it chains forward (completes the presented handoff, mints the next one with lineage).
+
 ## [1.0.1] - 2026-07-11
 
 ### Fixed

--- a/apps/barrel_spaces/README.md
+++ b/apps/barrel_spaces/README.md
@@ -107,8 +107,10 @@ token, not by being granted anything up front.
 ```
 
 `accept/2` opens the shared space and creates a fresh session in it; the
-from-agent's context is read in place, never copied. `chain/2` walks a handoff
-back through the agents that touched it.
+from-agent's context is read in place, never copied. Pass `session => false`
+to accept on the token discipline alone, with no space opened and no session
+created. `chain/2` hands the task forward: it completes the presented handoff
+and mints the next one carrying parent/root/depth lineage.
 
 A runnable version of this whole flow, compiled and executed by
 `barrel_agent_example_SUITE`, lives at

--- a/apps/barrel_spaces/src/barrel_caps.erl
+++ b/apps/barrel_spaces/src/barrel_caps.erl
@@ -9,6 +9,19 @@
 %%% a ladder: `read < write < admin' (admin covers grants, drops,
 %%% branch/merge, and handoff issuance). A token is shown ONCE at
 %%% grant time; treat it like a password.
+%%%
+%%% The granted scope is any binary id: grant/2 does not require a
+%%% space database to exist, so purely logical scopes (a tenant id, a
+%%% handoff id) get revocable, hash-at-rest, rights-laddered tokens
+%%% without a single space being created. This is intended and
+%%% supported.
+%%%
+%%% The registry is a regular barrel database (name from the
+%%% `registry_db' app env of barrel_spaces). Replicating it is
+%%% intended: grant docs are authorization state, so a token minted on
+%%% one node verifies on any node the registry reaches, and revocation
+%%% (`revoked_at', a normal doc update) propagates at replication
+%%% speed. Verification itself is always a local read.
 %%% @end
 %%%-------------------------------------------------------------------
 -module(barrel_caps).

--- a/apps/barrel_spaces/src/barrel_handoff.erl
+++ b/apps/barrel_spaces/src/barrel_handoff.erl
@@ -80,6 +80,12 @@ create(SpaceId, #{task_name := TaskName} = Opts)
                 <<"created_at">> => barrel_spaces:now_ms()
             },
             {ok, _} = barrel_docdb:put_doc(Registry, Doc),
+            TokenId = maps:get(<<"token_id">>, Grant),
+            {ok, _} = barrel_docdb:put_doc(Registry, #{
+                <<"id">> => <<"handoff_token:", TokenId/binary>>,
+                <<"type">> => <<"handoff_token">>,
+                <<"handoff">> => Hid
+            }),
             {ok, #{handoff_id => Hid, token => Token}};
         {error, _} = Err ->
             Err
@@ -113,11 +119,14 @@ get(Hid) when is_binary(Hid) ->
 %% @doc Accept a handoff by presenting its token. Opts: `agent' (the
 %% acceptor's name), `open_opts' (runtime open options for the space,
 %% e.g. its encryption spec), `session' (map passed to
-%% barrel_session:create). Returns the shared space handle and a fresh
-%% session in it; the from-agent's context is read in place.
+%% barrel_session:create, or `false' to accept WITHOUT opening the
+%% space or creating a session: the token discipline alone, for
+%% consumers with their own session model). Returns the shared space
+%% handle and a fresh session in it (both absent with
+%% `session => false'); the from-agent's context is read in place.
 -spec accept(binary(), map()) ->
-    {ok, #{handoff := map(), space := barrel_spaces:space(),
-           session := binary()}} |
+    {ok, #{handoff := map(), space => barrel_spaces:space(),
+           session => binary()}} |
     {error, term()}.
 accept(Token, Opts) when is_binary(Token), is_map(Opts) ->
     case resolve(Token) of
@@ -134,7 +143,15 @@ accept(Token, Opts) when is_binary(Token), is_map(Opts) ->
                     case barrel_docdb:put_doc(
                              barrel_spaces:registry_db(), Flipped) of
                         {ok, _} ->
-                            open_accepted(Hid, SpaceId, Agent, Opts);
+                            case maps:get(session, Opts, #{}) of
+                                false ->
+                                    {ok, Accepted} = get(Hid),
+                                    {ok, #{handoff =>
+                                               public(Accepted)}};
+                                _ ->
+                                    open_accepted(Hid, SpaceId, Agent,
+                                                  Opts)
+                            end;
                         {error, conflict} ->
                             {error, already_accepted};
                         {error, {conflict, _}} ->
@@ -222,19 +239,31 @@ chain(Token, #{task_name := _} = CreateOpts) when is_binary(Token) ->
 %% Internal
 %%====================================================================
 
-%% The handoff of a token: token id -> registry scan (the registry is
-%% small metadata; an index is a later optimization).
+%% The handoff of a token: token id -> `handoff_token:' index doc
+%% (written at create); handoffs created before the index existed
+%% fall back to a registry scan.
 resolve(Token) ->
     case barrel_caps:token_id(Token) of
         {ok, TokenId} ->
-            {ok, Handoffs} = list(#{}),
-            case [H || #{<<"token_id">> := T} = H <- Handoffs,
-                       T =:= TokenId] of
-                [Doc] -> {ok, Doc};
-                [] -> {error, not_found}
+            Registry = barrel_spaces:registry_db(),
+            case barrel_docdb:get_doc(Registry,
+                                      <<"handoff_token:",
+                                        TokenId/binary>>) of
+                {ok, #{<<"handoff">> := Hid}} ->
+                    get(Hid);
+                {error, not_found} ->
+                    resolve_scan(TokenId)
             end;
         error ->
             {error, invalid_token}
+    end.
+
+resolve_scan(TokenId) ->
+    {ok, Handoffs} = list(#{}),
+    case [H || #{<<"token_id">> := T} = H <- Handoffs,
+               T =:= TokenId] of
+        [Doc] -> {ok, Doc};
+        [] -> {error, not_found}
     end.
 
 open_accepted(Hid, SpaceId, Agent, Opts) ->

--- a/apps/barrel_spaces/src/barrel_session.erl
+++ b/apps/barrel_spaces/src/barrel_session.erl
@@ -13,6 +13,12 @@
 %%% (barrel_spaces_janitor) then collects the orphaned message docs.
 %%% add_message writes the message and slides the session in two
 %%% writes (not atomic; a crash between them loses only the slide).
+%%%
+%%% A session created with `ttl => infinity' (stored as 0) never
+%%% expires: a durable record the TTL machinery skips. Existing
+%%% corpora move in through create's `id' option, import_session/2
+%%% and import_message/3, so no consumer has to write `session:'
+%%% documents by hand.
 %%% @end
 %%%-------------------------------------------------------------------
 -module(barrel_session).
@@ -22,7 +28,9 @@
          touch/2,
          delete/2,
          list/1, list/2,
+         import_session/2,
          add_message/3,
+         import_message/3,
          get_messages/2, get_messages/3,
          set_data/4, get_data/3,
          set_summary/3,
@@ -39,31 +47,80 @@
 create(Space) ->
     create(Space, #{}).
 
-%% @doc Create a session. Opts: `agent' (binary), `ttl' (seconds,
-%% default the space's session_ttl or 3600), `data', `metadata'.
+%% @doc Create a session. Opts: `agent' (binary), `ttl' (seconds;
+%% `infinity' or 0 = never expires, stored as 0; default the space's
+%% session_ttl or 3600), `data', `metadata', `id' (caller-supplied
+%% session id, no `:' allowed; creating an existing id fails with a
+%% conflict).
 -spec create(barrel_spaces:space(), map()) ->
     {ok, binary()} | {error, term()}.
 create(#{id := SpaceId, db := Db}, Opts) when is_map(Opts) ->
-    Sid = barrel_spaces:new_id(<<"ses_">>),
-    Ttl = maps:get(ttl, Opts, default_ttl(SpaceId)),
-    Now = barrel_spaces:now_ms(),
-    Doc = #{
-        <<"id">> => <<"session:", Sid/binary>>,
-        <<"type">> => <<"session">>,
-        <<"session">> => Sid,
-        <<"agent">> => maps:get(agent, Opts, <<>>),
-        <<"data">> => maps:get(data, Opts, #{}),
-        <<"metadata">> => maps:get(metadata, Opts, #{}),
-        <<"summary">> => <<>>,
-        <<"pinned">> => [],
-        <<"ttl">> => Ttl,
-        <<"created_at">> => Now,
-        <<"updated_at">> => Now
-    },
-    case barrel:put_doc(Db, Doc, #{expires_at => Now + Ttl * 1000}) of
-        {ok, _} -> {ok, Sid};
-        {error, _} = Err -> Err
+    Sid = maps:get(id, Opts, barrel_spaces:new_id(<<"ses_">>)),
+    case valid_sid(Sid) of
+        true ->
+            Ttl = normalize_ttl(maps:get(ttl, Opts,
+                                         default_ttl(SpaceId))),
+            Now = barrel_spaces:now_ms(),
+            Doc = #{
+                <<"id">> => <<"session:", Sid/binary>>,
+                <<"type">> => <<"session">>,
+                <<"session">> => Sid,
+                <<"agent">> => maps:get(agent, Opts, <<>>),
+                <<"data">> => maps:get(data, Opts, #{}),
+                <<"metadata">> => maps:get(metadata, Opts, #{}),
+                <<"summary">> => <<>>,
+                <<"pinned">> => [],
+                <<"ttl">> => Ttl,
+                <<"created_at">> => Now,
+                <<"updated_at">> => Now
+            },
+            case barrel:put_doc(Db, Doc, expiry_opts(Now, Ttl)) of
+                {ok, _} -> {ok, Sid};
+                {error, _} = Err -> Err
+            end;
+        false ->
+            {error, invalid_session_id}
     end.
+
+%% @doc Import a session under its own id (the migration path: no
+%% generated ids, timestamps preserved, this module keeps owning the
+%% document schema). Map keys: `id' (required, no `:'), `agent',
+%% `data', `metadata', `summary', `pinned', `ttl' (seconds; 0 or
+%% `infinity' = never, the DEFAULT for imports), `created_at' and
+%% `updated_at' (unix ms, default now). A ttl > 0 arms expiry from
+%% `updated_at' (sliding semantics; touch/2 restarts the clock).
+%% Fails with a conflict if the session already exists.
+-spec import_session(barrel_spaces:space(), map()) ->
+    {ok, binary()} | {error, term()}.
+import_session(#{db := Db}, #{id := Sid} = SessionMap) ->
+    case valid_sid(Sid) of
+        true ->
+            Now = barrel_spaces:now_ms(),
+            Ttl = normalize_ttl(maps:get(ttl, SessionMap, 0)),
+            UpdatedAt = maps:get(updated_at, SessionMap, Now),
+            Doc = #{
+                <<"id">> => <<"session:", Sid/binary>>,
+                <<"type">> => <<"session">>,
+                <<"session">> => Sid,
+                <<"agent">> => maps:get(agent, SessionMap, <<>>),
+                <<"data">> => maps:get(data, SessionMap, #{}),
+                <<"metadata">> => maps:get(metadata, SessionMap, #{}),
+                <<"summary">> => maps:get(summary, SessionMap, <<>>),
+                <<"pinned">> => maps:get(pinned, SessionMap, []),
+                <<"ttl">> => Ttl,
+                <<"created_at">> => maps:get(created_at, SessionMap,
+                                             Now),
+                <<"updated_at">> => UpdatedAt
+            },
+            case barrel:put_doc(Db, Doc, expiry_opts(UpdatedAt, Ttl)) of
+                {ok, _} -> {ok, Sid};
+                {error, _} = Err -> Err
+            end;
+        false ->
+            {error, invalid_session_id}
+    end;
+import_session(_Space, _SessionMap) ->
+    {error, id_required}.
 
 %% @doc The session document (expired sessions read as not found).
 -spec get(barrel_spaces:space(), binary()) ->
@@ -71,7 +128,8 @@ create(#{id := SpaceId, db := Db}, Opts) when is_map(Opts) ->
 get(#{db := Db}, Sid) when is_binary(Sid) ->
     barrel:get_doc(Db, <<"session:", Sid/binary>>).
 
-%% @doc Slide the session's TTL without changing it.
+%% @doc Slide the session's TTL without changing it. Returns
+%% `{ok, 0}' for a session without expiry.
 -spec touch(barrel_spaces:space(), binary()) ->
     {ok, non_neg_integer()} | {error, term()}.
 touch(Space, Sid) ->
@@ -93,22 +151,35 @@ delete(#{db := Db} = Space, Sid) when is_binary(Sid) ->
 list(Space) ->
     list(Space, #{}).
 
-%% @doc Live sessions, optionally filtered by `agent'.
--spec list(barrel_spaces:space(), map()) -> {ok, [map()]}.
+%% @doc Live sessions, filtered and optionally bounded. Opts:
+%% <ul>
+%% <li>`agent' - exact match on the agent field</li>
+%% <li>`match' - `#{FieldPath => Value}': equality conditions on
+%%     session fields (`<<"data.user_id">>' or
+%%     `[<<"data">>, <<"user_id">>]'), resolved through the space
+%%     database's path indexes; the supported query path for spaces
+%%     holding thousands of sessions</li>
+%% <li>`limit' - max sessions returned</li>
+%% </ul>
+-spec list(barrel_spaces:space(), map()) ->
+    {ok, [map()]} | {error, term()}.
 list(#{db := #{docdb := DbBin}}, Opts) ->
     Agent = maps:get(agent, Opts, undefined),
-    {ok, Sessions} = barrel_docdb:fold_docs(
-        DbBin,
-        fun(#{<<"type">> := <<"session">>} = Doc, Acc) ->
-                case Agent =:= undefined
-                     orelse maps:get(<<"agent">>, Doc, <<>>) =:= Agent of
-                    true -> {ok, [Doc | Acc]};
-                    false -> {ok, Acc}
-                end;
-           (_Doc, Acc) ->
-                {ok, Acc}
-        end, [], #{id_prefix => <<"session:">>}),
-    {ok, lists:reverse(Sessions)}.
+    Match = maps:get(match, Opts, #{}),
+    Limit = maps:get(limit, Opts, infinity),
+    case Agent =:= undefined andalso map_size(Match) =:= 0 of
+        true ->
+            {ok, Sessions} = barrel_docdb:fold_docs(
+                DbBin,
+                fun(#{<<"type">> := <<"session">>} = Doc, Acc) ->
+                        {ok, [Doc | Acc]};
+                   (_Doc, Acc) ->
+                        {ok, Acc}
+                end, [], #{id_prefix => <<"session:">>}),
+            {ok, take(lists:reverse(Sessions), Limit)};
+        false ->
+            find_sessions(DbBin, Agent, Match, Limit)
+    end.
 
 %%====================================================================
 %% Messages
@@ -140,6 +211,40 @@ add_message(#{db := Db} = Space, Sid, #{role := Role,
                     {ok, MsgId};
                 {error, _} = Err ->
                     Err
+            end;
+        {error, _} = Err ->
+            Err
+    end.
+
+%% @doc Import a message with its own timestamp (the chronological id
+%% derives from it). Map keys: `role' and `content' (required), `ts'
+%% (unix ms, default now), `seq' (disambiguates messages inside one
+%% millisecond, default a fresh monotonic value), `metadata'. Does
+%% not slide the session's TTL.
+-spec import_message(barrel_spaces:space(), binary(), map()) ->
+    {ok, binary()} | {error, term()}.
+import_message(#{db := Db} = Space, Sid, #{role := Role,
+                                           content := Content} = Msg) ->
+    case get(Space, Sid) of
+        {ok, _} ->
+            Ts = maps:get(ts, Msg, barrel_spaces:now_ms()),
+            MsgId = case maps:find(seq, Msg) of
+                {ok, Seq} -> msg_id(Ts, Seq);
+                error -> msg_id(Ts)
+            end,
+            Doc = #{
+                <<"id">> => <<"session:", Sid/binary, ":msg:",
+                              MsgId/binary>>,
+                <<"type">> => <<"message">>,
+                <<"session">> => Sid,
+                <<"role">> => Role,
+                <<"content">> => Content,
+                <<"metadata">> => maps:get(metadata, Msg, #{}),
+                <<"ts">> => Ts
+            },
+            case barrel:put_doc(Db, Doc) of
+                {ok, _} -> {ok, MsgId};
+                {error, _} = Err -> Err
             end;
         {error, _} = Err ->
             Err
@@ -258,13 +363,18 @@ list_pinned(Space, Sid) ->
 %%====================================================================
 
 %% Every mutation slides the TTL: rewrite the doc with a fresh
-%% expires_at derived from the session's own ttl.
+%% expires_at derived from the session's own ttl (0 = durable: the
+%% expiry stays cleared and callers get {ok, 0}).
 update(#{db := Db} = Space, Sid, Fun) ->
     case get(Space, Sid) of
         {ok, Doc} ->
             Now = barrel_spaces:now_ms(),
-            Ttl = maps:get(<<"ttl">>, Doc, ?DEFAULT_TTL),
-            ExpiresAt = Now + Ttl * 1000,
+            Ttl = normalize_ttl(maps:get(<<"ttl">>, Doc,
+                                         ?DEFAULT_TTL)),
+            ExpiresAt = case Ttl of
+                0 -> 0;
+                _ -> Now + Ttl * 1000
+            end,
             Updated = (Fun(Doc))#{<<"updated_at">> => Now},
             case barrel:put_doc(Db, Updated,
                                 #{expires_at => ExpiresAt}) of
@@ -284,11 +394,91 @@ default_ttl(SpaceId) ->
 %% zero-padded ms timestamp + zero-padded monotonic sequence: strict
 %% chronological id order even for messages inside one millisecond
 msg_id(NowMs) ->
+    msg_id(NowMs, erlang:unique_integer([positive, monotonic])).
+
+msg_id(NowMs, Seq0) ->
     Ts = integer_to_binary(NowMs),
     TsPad = binary:copy(<<"0">>, 20 - byte_size(Ts)),
-    Seq = integer_to_binary(erlang:unique_integer([positive, monotonic])),
+    Seq = integer_to_binary(Seq0),
     SeqPad = binary:copy(<<"0">>, 20 - byte_size(Seq)),
     <<TsPad/binary, Ts/binary, "-", SeqPad/binary, Seq/binary>>.
 
 take(List, infinity) -> List;
 take(List, N) -> lists:sublist(List, N).
+
+%% ttl: `infinity' and 0 both mean "never expires", stored as 0.
+normalize_ttl(infinity) -> 0;
+normalize_ttl(Ttl) when is_integer(Ttl), Ttl >= 0 -> Ttl.
+
+%% expires_at write option: 0 clears any expiry on the doc.
+expiry_opts(_Base, 0) -> #{expires_at => 0};
+expiry_opts(Base, Ttl) -> #{expires_at => Base + Ttl * 1000}.
+
+%% Caller-supplied ids share the `session:' keyspace with the
+%% `\:msg:' suffix, so a colon inside one is ambiguous.
+valid_sid(Sid) when is_binary(Sid), byte_size(Sid) > 0 ->
+    binary:match(Sid, <<":">>) =:= nomatch;
+valid_sid(_) ->
+    false.
+
+split_path(Path) when is_list(Path) -> Path;
+split_path(Path) when is_binary(Path) ->
+    binary:split(Path, <<".">>, [global]).
+
+%% Filtered listing through the query engine: equality conditions
+%% intersect the database's path posting lists instead of folding
+%% every session. Just-expired sessions the sweeper has not
+%% tombstoned yet are dropped for parity with the fold path (their
+%% expiry is updated_at + ttl by construction).
+find_sessions(DbBin, Agent, Match, Limit) ->
+    Conds0 = [{path, [<<"type">>], <<"session">>}],
+    Conds1 = case Agent of
+        undefined -> Conds0;
+        _ -> [{path, [<<"agent">>], Agent} | Conds0]
+    end,
+    Conds = maps:fold(
+        fun(Path, Value, Acc) ->
+            [{path, split_path(Path), Value} | Acc]
+        end, Conds1, Match),
+    Spec = case Limit of
+        infinity -> #{where => Conds};
+        _ -> #{where => Conds, limit => Limit}
+    end,
+    case find_all(DbBin, Spec, undefined, [], Limit) of
+        {ok, Rows} ->
+            %% find returns #{<<"id">>, <<"doc">>} rows
+            Docs = [maps:get(<<"doc">>, R, R) || R <- Rows],
+            Now = barrel_spaces:now_ms(),
+            {ok, take([D || D <- Docs, live_session(D, Now)], Limit)};
+        {error, _} = Err ->
+            Err
+    end.
+
+%% Drain find's continuations (the spec limit sizes chunks rather
+%% than bounding the total); stop once Limit docs are in hand.
+find_all(DbBin, Spec, Cont, Acc, Limit) ->
+    Opts = case Cont of
+        undefined -> #{};
+        _ -> #{continuation => Cont}
+    end,
+    case barrel_docdb:find(DbBin, Spec, Opts) of
+        {ok, Docs, #{has_more := true, continuation := Next}} ->
+            Acc1 = [Docs | Acc],
+            Got = lists:sum([length(L) || L <- Acc1]),
+            case Limit =/= infinity andalso Got >= Limit of
+                true -> {ok, lists:append(lists:reverse(Acc1))};
+                false -> find_all(DbBin, Spec, Next, Acc1, Limit)
+            end;
+        {ok, Docs, _Meta} ->
+            {ok, lists:append(lists:reverse([Docs | Acc]))};
+        {error, _} = Err ->
+            Err
+    end.
+
+live_session(#{<<"ttl">> := 0}, _Now) ->
+    true;
+live_session(#{<<"ttl">> := Ttl, <<"updated_at">> := U}, Now)
+  when is_integer(Ttl), is_integer(U) ->
+    U + Ttl * 1000 > Now;
+live_session(_Doc, _Now) ->
+    true.

--- a/apps/barrel_spaces/src/barrel_spaces.app.src
+++ b/apps/barrel_spaces/src/barrel_spaces.app.src
@@ -1,6 +1,6 @@
 {application, barrel_spaces, [
     {description, "Barrel agent layer: spaces (shared context databases), capability tokens, sessions with TTL, and handoffs"},
-    {vsn, "1.0.1"},
+    {vsn, "1.1.0"},
     {registered, [barrel_spaces_sup]},
     {mod, {barrel_spaces_app, []}},
     {applications, [

--- a/apps/barrel_spaces/src/barrel_spaces.erl
+++ b/apps/barrel_spaces/src/barrel_spaces.erl
@@ -44,22 +44,31 @@
 %% holds small metadata docs and needs no vector store).
 -spec ensure_registry() -> ok.
 ensure_registry() ->
-    case barrel_docdb:open_db(?REGISTRY_DB) of
+    Name = configured_registry(),
+    case barrel_docdb:open_db(Name) of
         {ok, _} ->
             ok;
         {error, _} ->
-            case barrel_docdb:create_db(?REGISTRY_DB) of
+            case barrel_docdb:create_db(Name) of
                 {ok, _} -> ok;
                 {error, already_exists} -> ok
             end
     end.
 
 %% @doc The registry database name (documents: `space:Id', `grant:Id',
-%% `handoff:Id').
+%% `handoff:Id', `handoff_token:TokenId'). Configurable through the
+%% `registry_db' application env of barrel_spaces (default
+%% `_barrel_spaces'); set it before first use. The registry is a
+%% regular barrel database: opening it through barrel_dbs alongside
+%% this layer, and replicating it, are both supported (see the spaces
+%% guide on what replicating grants means).
 -spec registry_db() -> binary().
 registry_db() ->
     ok = ensure_registry(),
-    ?REGISTRY_DB.
+    configured_registry().
+
+configured_registry() ->
+    application:get_env(barrel_spaces, registry_db, ?REGISTRY_DB).
 
 %% @doc Create a space. Options:
 %% <ul>

--- a/apps/barrel_spaces/test/barrel_caps_SUITE.erl
+++ b/apps/barrel_spaces/test/barrel_caps_SUITE.erl
@@ -18,12 +18,14 @@
     t_list_strips_hashes/1
 ]).
 
+-export([t_logical_scope_custom_registry/1]).
+
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
 
 all() ->
     [t_grant_and_verify, t_rights_ladder, t_verify_matrix, t_revoke,
-     t_auth_context, t_drop_space_revokes, t_list_strips_hashes].
+     t_auth_context, t_drop_space_revokes, t_list_strips_hashes, t_logical_scope_custom_registry].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(barrel_spaces),
@@ -168,3 +170,25 @@ t_list_strips_hashes(Config) ->
 %% shape stays valid but the hash cannot match
 flip_b32($a) -> $b;
 flip_b32(_) -> $a.
+
+t_logical_scope_custom_registry(_Config) ->
+    %% a configured registry name plus a purely logical scope: tokens
+    %% without any space database behind them
+    ok = application:set_env(barrel_spaces, registry_db,
+                             <<"_caps_alt_registry">>),
+    try
+        {ok, Token, Grant} = barrel_caps:grant(<<"tenant-42">>,
+                                               #{rights => [read]}),
+        ?assertEqual(<<"tenant-42">>, maps:get(<<"space">>, Grant)),
+        {ok, _} = barrel_caps:verify(Token, <<"tenant-42">>, read),
+        %% the grant doc lives in the configured registry
+        {ok, TokenId} = barrel_caps:token_id(Token),
+        {ok, _} = barrel_docdb:get_doc(<<"_caps_alt_registry">>,
+                                       <<"grant:", TokenId/binary>>),
+        ok = barrel_caps:revoke(Token),
+        ?assertEqual({error, revoked},
+                     barrel_caps:verify(Token, <<"tenant-42">>, read))
+    after
+        application:unset_env(barrel_spaces, registry_db)
+    end,
+    ok.

--- a/apps/barrel_spaces/test/barrel_handoff_SUITE.erl
+++ b/apps/barrel_spaces/test/barrel_handoff_SUITE.erl
@@ -20,13 +20,15 @@
     t_discovery_via_changes/1
 ]).
 
+-export([t_accept_without_session/1]).
+
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
 
 all() ->
     [t_two_agent_by_reference, t_bad_tokens, t_double_accept,
      t_complete_revokes, t_chain, t_list_filters,
-     t_discovery_via_changes].
+     t_discovery_via_changes, t_accept_without_session].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(barrel_spaces),
@@ -184,4 +186,25 @@ t_discovery_via_changes(Config) ->
     {ok, Changes, _} = barrel_docdb:get_changes(Registry, Since),
     Ids = [maps:get(id, C) || C <- Changes],
     ?assert(lists:member(<<"handoff:", Hid/binary>>, Ids)),
+    ok.
+
+t_accept_without_session(Config) ->
+    #{id := SpaceId} = Space = ?config(space, Config),
+    {ok, #{token := Token}} = barrel_handoff:create(Space, #{
+        task_name => <<"external sessions">>,
+        from_agent => <<"a">>, to_agent => <<"b">>}),
+    {ok, Res} = barrel_handoff:accept(Token, #{agent => <<"b">>,
+                                               session => false}),
+    %% only the handoff comes back: no space handle, no session
+    ?assertEqual([handoff], maps:keys(Res)),
+    ?assertEqual(<<"accepted">>,
+                 maps:get(<<"status">>, maps:get(handoff, Res))),
+    {ok, Sessions} = barrel_session:list(Space),
+    ?assertEqual([], Sessions),
+    %% the CAS and the completion discipline are unchanged
+    ?assertEqual({error, already_accepted},
+                 barrel_handoff:accept(Token, #{session => false})),
+    {ok, _} = barrel_handoff:complete(Token, #{result => <<"ok">>}),
+    ?assertEqual({error, revoked},
+                 barrel_caps:verify(Token, SpaceId, read)),
     ok.

--- a/apps/barrel_spaces/test/barrel_session_SUITE.erl
+++ b/apps/barrel_spaces/test/barrel_session_SUITE.erl
@@ -20,13 +20,15 @@
     t_list_by_agent/1
 ]).
 
+-export([t_no_ttl_durable/1, t_import_with_ids/1, t_list_match_indexed/1]).
+
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
 
 all() ->
     [t_create_get_touch, t_sliding_ttl, t_messages_chronological,
      t_message_ranges, t_data_summary_pinned, t_delete_cascade,
-     t_janitor_orphans, t_list_by_agent].
+     t_janitor_orphans, t_list_by_agent, t_no_ttl_durable, t_import_with_ids, t_list_match_indexed].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(barrel_spaces),
@@ -188,4 +190,74 @@ t_list_by_agent(Config) ->
     ?assertEqual(2, length(Alice)),
     {ok, Bob} = barrel_session:list(Space, #{agent => <<"bob">>}),
     ?assertEqual(1, length(Bob)),
+    ok.
+
+t_no_ttl_durable(Config) ->
+    #{id := SpaceId} = Space = ?config(space, Config),
+    {ok, Sid} = barrel_session:create(Space, #{agent => <<"keeper">>,
+                                               ttl => infinity}),
+    {ok, Doc} = barrel_session:get(Space, Sid),
+    ?assertEqual(0, maps:get(<<"ttl">>, Doc)),
+    {ok, 0} = barrel_session:touch(Space, Sid),
+    {ok, 0} = barrel_session:set_data(Space, Sid, <<"k">>, 1),
+    %% the TTL sweeper never collects it
+    {ok, _} = barrel_docdb:sweep_ttl(SpaceId),
+    {ok, _} = barrel_session:get(Space, Sid),
+    %% ttl => 0 means the same thing
+    {ok, Sid2} = barrel_session:create(Space, #{ttl => 0}),
+    {ok, 0} = barrel_session:touch(Space, Sid2),
+    ok.
+
+t_import_with_ids(Config) ->
+    Space = ?config(space, Config),
+    %% caller-supplied id on create; duplicates conflict, colons refused
+    {ok, <<"legacy-1">>} =
+        barrel_session:create(Space, #{id => <<"legacy-1">>}),
+    ?assertMatch({error, _},
+                 barrel_session:create(Space, #{id => <<"legacy-1">>})),
+    ?assertEqual({error, invalid_session_id},
+                 barrel_session:create(Space, #{id => <<"a:b">>})),
+    %% import preserves timestamps; default ttl is never
+    T0 = barrel_spaces:now_ms() - 86400000,
+    {ok, <<"legacy-2">>} = barrel_session:import_session(Space, #{
+        id => <<"legacy-2">>, agent => <<"old-bot">>,
+        data => #{<<"user_id">> => <<"u1">>},
+        created_at => T0, updated_at => T0}),
+    {ok, Doc} = barrel_session:get(Space, <<"legacy-2">>),
+    ?assertEqual(T0, maps:get(<<"created_at">>, Doc)),
+    ?assertEqual(0, maps:get(<<"ttl">>, Doc)),
+    ?assertEqual({error, id_required},
+                 barrel_session:import_session(Space, #{agent => <<"x">>})),
+    %% messages with their own timestamps sort chronologically and do
+    %% not slide the session
+    {ok, _} = barrel_session:import_message(Space, <<"legacy-2">>,
+        #{role => <<"user">>, content => <<"first">>,
+          ts => T0, seq => 1}),
+    {ok, _} = barrel_session:import_message(Space, <<"legacy-2">>,
+        #{role => <<"assistant">>, content => <<"second">>,
+          ts => T0 + 1000, seq => 2}),
+    {ok, [M1, M2]} = barrel_session:get_messages(Space, <<"legacy-2">>),
+    ?assertEqual(<<"first">>, maps:get(<<"content">>, M1)),
+    ?assertEqual(<<"second">>, maps:get(<<"content">>, M2)),
+    ok.
+
+t_list_match_indexed(Config) ->
+    Space = ?config(space, Config),
+    {ok, S1} = barrel_session:create(Space, #{agent => <<"a1">>,
+        data => #{<<"user_id">> => <<"u1">>}}),
+    {ok, _S2} = barrel_session:create(Space, #{agent => <<"a1">>,
+        data => #{<<"user_id">> => <<"u2">>}}),
+    {ok, S3} = barrel_session:create(Space, #{agent => <<"a2">>,
+        data => #{<<"user_id">> => <<"u1">>}}),
+    {ok, ByUser} = barrel_session:list(Space, #{
+        match => #{<<"data.user_id">> => <<"u1">>}}),
+    ?assertEqual(lists:sort([S1, S3]),
+                 lists:sort([maps:get(<<"session">>, D) || D <- ByUser])),
+    %% agent composes with match; paths also accept key lists
+    {ok, Both} = barrel_session:list(Space, #{agent => <<"a1">>,
+        match => #{[<<"data">>, <<"user_id">>] => <<"u1">>}}),
+    ?assertEqual([S1], [maps:get(<<"session">>, D) || D <- Both]),
+    {ok, Limited} = barrel_session:list(Space, #{agent => <<"a1">>,
+                                                 limit => 1}),
+    ?assertEqual(1, length(Limited)),
     ok.

--- a/docs/guides/spaces.md
+++ b/docs/guides/spaces.md
@@ -75,6 +75,47 @@ messages.
 ok = barrel_session:delete(Space, Sid).   %% cascades to messages
 ```
 
+### Durable sessions
+
+Pass `ttl => infinity` (or 0) to create a session that never expires: a
+record, not a cache. Mutations on it return `{ok, 0}` instead of an expiry
+time, and the TTL sweeper skips it.
+
+```erlang
+{ok, Rec} = barrel_session:create(Space, #{agent => <<"alice">>,
+                                           ttl => infinity}),
+{ok, 0} = barrel_session:touch(Space, Rec).
+```
+
+### Filtered listing
+
+`list/2` filters through the space database's path indexes, so a space
+holding thousands of sessions does not pay a full fold:
+
+```erlang
+{ok, Mine} = barrel_session:list(Space, #{
+    match => #{<<"data.user_id">> => <<"u1">>},   %% any field path
+    agent => <<"alice">>,                         %% composes with match
+    limit => 50}).
+```
+
+### Importing an existing corpus
+
+Sessions and messages move in with their own ids and timestamps; the
+module keeps owning the document schema:
+
+```erlang
+{ok, _} = barrel_session:create(Space, #{id => <<"legacy-1">>}),
+{ok, _} = barrel_session:import_session(Space, #{
+    id => <<"legacy-2">>, agent => <<"old-bot">>,
+    data => #{<<"user_id">> => <<"u1">>},
+    created_at => 1750000000000, updated_at => 1750000100000}),
+    %% ttl defaults to never for imports; ttl > 0 arms from updated_at
+{ok, _} = barrel_session:import_message(Space, <<"legacy-2">>, #{
+    role => <<"user">>, content => <<"hello">>,
+    ts => 1750000050000, seq => 1}).   %% does not slide the TTL
+```
+
 ### Document TTL (the machinery underneath)
 
 Sessions ride a general primitive that works on any barrel database: the
@@ -111,6 +152,12 @@ read in place, nothing is copied.
 {ok, #{handoff := H, space := BobSpace, session := BobSid}} =
     barrel_handoff:accept(HandoffToken, #{agent => <<"bob">>}),
 
+%% or accept on the token discipline alone (no space opened, no
+%% session created), for consumers with their own session model:
+%% {ok, #{handoff := H2}} =
+%%     barrel_handoff:accept(HandoffToken, #{agent => <<"bob">>,
+%%                                           session => false}),
+
 %% work happens in the shared space, then:
 {ok, _} = barrel_handoff:complete(HandoffToken,
                                   #{result => <<"shipped">>}),
@@ -138,6 +185,18 @@ capability tokens work as bearers there (and only there). See
   and handoff issuance. Verification is local (the registry is a database
   on the same node); tokens are random, stored hashed, compared in constant
   time.
+- The registry database name comes from the `registry_db` app env of
+  `barrel_spaces` (default `_barrel_spaces`); set it before first use. The
+  registry is a regular barrel database: opening it through `barrel_dbs`
+  alongside this layer is supported.
+- Replicating the registry is intended. Grant documents are authorization
+  state, so replication is what makes a token minted on one node verify on
+  another; the flip side is that revocation propagates at replication
+  speed. Keep the registry's replication tight if revocation latency
+  matters to you.
+- `barrel_caps:grant/2` does not require the space to exist. Granting on a
+  purely logical scope (a tenant id, a handoff id) is supported: revocable,
+  hash-at-rest, rights-laddered tokens with no space database behind them.
 - The registry (`_barrel_spaces`) holds space, grant, and handoff documents
   as regular docs: folds and the changes feed see them.
 - An encrypted space needs its encryption spec on every open, including


### PR DESCRIPTION
Feedback from adopting the agent layer in barrel_memory: barrel_caps went in cleanly, barrel_session and barrel_handoff could not. Five gaps, all lifted additively.

- Durable sessions: `ttl => infinity` (or 0) never expires; mutations return `{ok, 0}` and the TTL sweeper skips it.
- Indexed listing: `list/2` takes `match` (field path to value) plus `agent` and `limit`, resolved through the space database's path indexes instead of a full fold.
- Migration path: `create/2` accepts a caller id; `import_session/2` and `import_message/3` move an existing corpus in with its own ids and timestamps, so no consumer has to write `session:` documents by hand.
- `accept(Token, #{session => false})` keeps the token discipline (CAS, revoke on complete) without opening the space or creating a session, for consumers with their own session model. Token resolution now reads a `handoff_token:` index doc (scan fallback for older handoffs); the README's `chain/2` direction is corrected.
- The registry database name is configuration (`registry_db` app env). Replicating the registry and granting capabilities on purely logical scopes are documented as intended.

Green on OTP 29 and 28: eunit 671, ct 883 (5 new cases), xref and dialyzer at the pre-existing barrel_faiss baseline.