### PR TITLE
barrel_vectordb 2.4.0: persist the index graph, load it at open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the Barrel umbrella are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and each app
 is versioned independently under [Semantic Versioning](https://semver.org/).
 
+## [2026-08-25] barrel_vectordb index persistence
+
+Opening a vector store used to rebuild the whole HNSW/FAISS graph from the
+vectors column family, making cold opens O(N) inserts and minutes-long for
+large stores. The graph now persists at close and checkpoint, versioned by a
+write sequence committed atomically with every vector write, and loads in one
+read when it provably matches the data; any doubt falls back to the rebuild.
+
+| App | Version | Change |
+|-----|---------|--------|
+| barrel_vectordb | 2.4.0 | index graph persisted and loaded at open; write-seq versioning; index_origin in stats |
+
 ## [2026-08-25] barrel_spaces adoptable for existing session stores
 
 Feedback from adopting the agent layer in an external product: sessions could

--- a/apps/barrel_vectordb/CHANGELOG.md
+++ b/apps/barrel_vectordb/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2026-08-25
+
+### Added
+- The HNSW/FAISS index graph persists to the store's RocksDB (`hnsw_graph` column family) at close and checkpoint, and `barrel_vectordb:persist_index/1` forces it. On open, a graph that provably matches the vectors column family (write-sequence, config fingerprint, checksum) loads directly instead of being rebuilt vector by vector; anything doubtful falls back to the rebuild. `stats/1` reports `index_origin` (`new` | `loaded` | `rebuilt`).
+- HNSW serializer format v3 records the quantization method (v2/v1 still deserialize).
+
+### Fixed
+- A store killed before its first checkpoint reopened with an empty index: the rebuild was gated on the persisted meta blob, which only close and checkpoint wrote. The index now always rebuilds from the vectors column family when no loadable graph exists.
+- `delete/2` updated the in-RAM index after the RocksDB commit and skipped it on docstore errors; `update`/`upsert` dropped the new index on post-commit errors. Both now mutate before commit and keep the index on post-commit failures, like the batched write path.
+
+### Changed
+- Store supervisor shutdown raised to 30s so a large index persist can finish on close.
+
 ## [2.3.0] - 2026-08-23
 
 ### Changed

--- a/apps/barrel_vectordb/README.md
+++ b/apps/barrel_vectordb/README.md
@@ -687,6 +687,16 @@ rebar3 as bench_faiss shell
 barrel_vectordb_backend_bench:run_all().
 ```
 
+## Index persistence
+
+The in-memory HNSW/FAISS graph persists into the store's RocksDB at close
+and on `barrel_vectordb:checkpoint/1` or `persist_index/1`. On open, a
+graph that still matches the stored vectors (write sequence, config,
+checksum) loads directly; otherwise the index rebuilds from the vectors
+column family. `stats/1` reports how the index came up:
+`index_origin => new | loaded | rebuilt`. A store killed before any
+persist simply rebuilds; no data is lost either way.
+
 ## Architecture
 
 - **Storage**: RocksDB with column families

--- a/apps/barrel_vectordb/src/barrel_vectordb.app.src
+++ b/apps/barrel_vectordb/src/barrel_vectordb.app.src
@@ -1,6 +1,6 @@
 {application, barrel_vectordb, [
     {description, "Embedded Erlang vector database with pluggable backends (HNSW, FAISS) and RocksDB for semantic search"},
-    {vsn, "2.3.0"},
+    {vsn, "2.4.0"},
     {registered, [barrel_vectordb_sup]},
     {mod, {barrel_vectordb_app, []}},
     {applications, [

--- a/apps/barrel_vectordb/src/barrel_vectordb.erl
+++ b/apps/barrel_vectordb/src/barrel_vectordb.erl
@@ -123,6 +123,7 @@
 %% API - Maintenance
 -export([
     checkpoint/1,
+    persist_index/1,
     destroy/1
 ]).
 
@@ -739,6 +740,13 @@ embedder_info(Store) ->
 -spec checkpoint(store()) -> ok.
 checkpoint(Store) ->
     barrel_vectordb_server:checkpoint(Store).
+
+%% @doc Persist the in-memory index graph to the store's RocksDB now.
+%% Also done at close and checkpoint; on the next open a graph that
+%% still matches the stored vectors loads instead of rebuilding.
+-spec persist_index(store()) -> ok | {error, term()}.
+persist_index(Store) ->
+    barrel_vectordb_server:persist_index(Store).
 
 %%====================================================================
 %% Internal Functions

--- a/apps/barrel_vectordb/src/barrel_vectordb_hnsw.erl
+++ b/apps/barrel_vectordb/src/barrel_vectordb_hnsw.erl
@@ -425,8 +425,8 @@ clamp(V, _Min, _Max) -> V.
 -spec serialize(hnsw_index()) -> binary().
 serialize(#hnsw_index{entry_point = EP, max_layer = MaxLayer, nodes = Nodes,
                        config = Config, size = Size, dimension = Dim}) ->
-    %% Version 2: includes full graph structure for fast loading
-    Version = 2,
+    %% Version 3: v2 plus a quantization-method byte in the config.
+    Version = 3,
     EPBin = case EP of
         undefined -> <<0:16>>;
         _ -> <<(byte_size(EP)):16, EP/binary>>
@@ -435,7 +435,8 @@ serialize(#hnsw_index{entry_point = EP, max_layer = MaxLayer, nodes = Nodes,
         (Config#hnsw_config.m):16,
         (Config#hnsw_config.m_max0):16,
         (Config#hnsw_config.ef_construction):16,
-        (distance_fn_to_int(Config#hnsw_config.distance_fn)):8
+        (distance_fn_to_int(Config#hnsw_config.distance_fn)):8,
+        (quantization_to_int(Config#hnsw_config.quantization)):8
     >>,
     NodesList = maps:to_list(Nodes),
     NodesBin = << <<(serialize_node_full(Id, Node))/binary>> || {Id, Node} <- NodesList >>,
@@ -443,6 +444,26 @@ serialize(#hnsw_index{entry_point = EP, max_layer = MaxLayer, nodes = Nodes,
 
 %% @doc Deserialize index from binary
 -spec deserialize(binary()) -> {ok, hnsw_index()} | {error, term()}.
+deserialize(<<3:8, Size:32, MaxLayer:8, Dim:16, Rest/binary>>) ->
+    %% Version 3: only scalar-quantized graphs load (the live insert
+    %% path always scalar-quantizes); anything else must rebuild.
+    try
+        {EP, Rest1} = deserialize_entry_point(Rest),
+        {Config, Rest2} = deserialize_config_v3(Rest1),
+        {Nodes, <<>>} = deserialize_nodes(Rest2, Size, #{}),
+        {ok, #hnsw_index{
+            entry_point = EP,
+            max_layer = MaxLayer,
+            nodes = Nodes,
+            config = Config,
+            size = Size,
+            dimension = Dim
+        }}
+    catch
+        throw:unsupported_quantization ->
+            {error, unsupported_quantization};
+        _:Reason -> {error, {deserialization_failed, Reason}}
+    end;
 deserialize(<<2:8, Size:32, MaxLayer:8, Dim:16, Rest/binary>>) ->
     %% Version 2: full graph structure
     try
@@ -872,6 +893,28 @@ deserialize_entry_point(<<0:16, Rest/binary>>) ->
     {undefined, Rest};
 deserialize_entry_point(<<Len:16, EP:Len/binary, Rest/binary>>) ->
     {EP, Rest}.
+
+deserialize_config_v3(<<M:16, MMax0:16, EfC:16, DistFnInt:8, QInt:8,
+                        Rest/binary>>) ->
+    case QInt of
+        0 -> ok;
+        _ -> erlang:throw(unsupported_quantization)
+    end,
+    Config = #hnsw_config{
+        m = M,
+        m_max0 = MMax0,
+        ef_construction = EfC,
+        ml = 1.0 / math:log(M),
+        distance_fn = int_to_distance_fn(DistFnInt),
+        quantization = scalar
+    },
+    {Config, Rest}.
+
+quantization_to_int(scalar) -> 0;
+quantization_to_int(none) -> 1;
+quantization_to_int(turboquant) -> 2;
+quantization_to_int(subspace_turboquant) -> 3;
+quantization_to_int(_Other) -> 255.
 
 deserialize_config(<<M:16, MMax0:16, EfC:16, DistFnInt:8, Rest/binary>>) ->
     Config = #hnsw_config{

--- a/apps/barrel_vectordb/src/barrel_vectordb_server.erl
+++ b/apps/barrel_vectordb/src/barrel_vectordb_server.erl
@@ -1148,11 +1148,11 @@ load_index_graph(Db, CfHnsw, Dimension, IndexConfig, IndexModule) ->
                     CurSeq = read_index_seq(Db, CfHnsw),
                     CurFp = index_fingerprint(IndexModule, Dimension,
                                               IndexConfig),
-                    case Seq =:= CurSeq andalso Fp =:= CurFp of
-                        true ->
+                    if
+                        Seq =:= CurSeq, Fp =:= CurFp ->
                             load_graph_chunks(Db, CfHnsw, NChunks, Crc,
                                               IndexModule);
-                        false ->
+                        true ->
                             not_loadable
                     end;
                 _Other ->

--- a/apps/barrel_vectordb/src/barrel_vectordb_server.erl
+++ b/apps/barrel_vectordb/src/barrel_vectordb_server.erl
@@ -54,6 +54,7 @@
     count/1,
     embedder_info/1,
     checkpoint/1,
+    persist_index/1,
     bm25_info/1,
     bm25_compact/1
 ]).
@@ -63,6 +64,12 @@
          terminate/2, code_change/3]).
 
 -type store_ref() :: atom() | binary() | pid().
+
+%% Reserved hnsw_graph CF keys (doc ids never start with "__hnsw_").
+-define(HNSW_SEQ_KEY, <<"__hnsw_seq__">>).
+-define(HNSW_GRAPH_HEADER_KEY, <<"__hnsw_graph__">>).
+-define(HNSW_GRAPH_CHUNK_PREFIX, <<"__hnsw_graph__:">>).
+-define(GRAPH_CHUNK_SIZE, 8388608).
 
 -record(state, {
     name :: binary(),
@@ -87,7 +94,14 @@
     %% Encryption context: none, or the key + EncryptedEnv shared by
     %% this store's RocksDBs and disk indexes. Retained here because
     %% the NIF frees the env when the handle is garbage collected.
-    crypto = none :: barrel_vectordb_crypto:ctx()
+    crypto = none :: barrel_vectordb_crypto:ctx(),
+    %% Graph persistence: seq is bumped inside every index-mutating
+    %% RocksDB batch; the persisted graph records the seq it reflects,
+    %% so load only trusts an exact match. graph_dirty marks an in-RAM
+    %% index that may diverge from committed data (persist refuses).
+    index_seq = 0 :: non_neg_integer(),
+    graph_dirty = false :: boolean(),
+    index_origin = new :: new | loaded | rebuilt
 }).
 
 %%====================================================================
@@ -254,6 +268,12 @@ embedder_info(Store) ->
 checkpoint(Store) ->
     gen_server:call(ref(Store), checkpoint).
 
+%% @doc Persist the index graph to RocksDB now (also done at close and
+%% checkpoint); the next open loads it instead of rebuilding.
+-spec persist_index(store_ref()) -> ok | {error, term()}.
+persist_index(Store) ->
+    gen_server:call(ref(Store), persist_index, ?LONG_TIMEOUT).
+
 %%====================================================================
 %% gen_server callbacks
 %%====================================================================
@@ -321,7 +341,7 @@ init_stores(Name, Config, DbPath, Dimension, Docstore, IndexModule,
             end,
             %% Load or create vector index
             case load_or_create_index(Db, CfHandles, Dimension, IndexConfig1, IndexModule) of
-                {ok, Index} ->
+                {ok, Index, Origin} ->
                     %% Initialize BM25 index if configured
                     BM25Backend = maps:get(bm25_backend, Config, none),
                     case init_bm25(DbPath, BM25Backend, Config, Crypto) of
@@ -342,7 +362,10 @@ init_stores(Name, Config, DbPath, Dimension, Docstore, IndexModule,
                                 bm25_index = BM25Index,
                                 bm25_backend = BM25Backend,
                                 docstore = Docstore,
-                                crypto = Crypto
+                                crypto = Crypto,
+                                index_seq = read_index_seq(
+                                    Db, maps:get(hnsw, CfHandles)),
+                                index_origin = Origin
                             },
                             {ok, State};
                         {error, BM25Error} ->
@@ -417,8 +440,8 @@ handle_read({delete, Id}, State) ->
     case do_delete(Id, State) of
         {ok, NewState} ->
             {ok, NewState};
-        {error, _} = Error ->
-            {Error, State}
+        {error, Reason, NewState} ->
+            {{error, Reason}, NewState}
     end;
 
 handle_read({update, Id, Text, Metadata}, State) ->
@@ -431,14 +454,14 @@ handle_read({update, Id, Text, Metadata}, State) ->
                             case do_add(Id, Text, Metadata, Vector, State1) of
                                 {ok, NewState} ->
                                     {ok, NewState};
-                                {error, _} = Error ->
-                                    {Error, State}
+                                {error, Reason, NewState} ->
+                                    {{error, Reason}, NewState}
                             end;
                         {error, _} = Error ->
-                            {Error, State}
+                            {Error, State1}
                     end;
-                {error, _} = Error ->
-                    {Error, State}
+                {error, Reason, State1} ->
+                    {{error, Reason}, State1}
             end;
         not_found ->
             {not_found, State};
@@ -456,14 +479,14 @@ handle_read({upsert, Id, Text, Metadata}, State) ->
                             case do_add(Id, Text, Metadata, Vector, State1) of
                                 {ok, NewState} ->
                                     {ok, NewState};
-                                {error, _} = Error ->
-                                    {Error, State}
+                                {error, Reason, NewState} ->
+                                    {{error, Reason}, NewState}
                             end;
                         {error, _} = Error ->
-                            {Error, State}
+                            {Error, State1}
                     end;
-                {error, _} = Error ->
-                    {Error, State}
+                {error, Reason, State1} ->
+                    {{error, Reason}, State1}
             end;
         not_found ->
             case do_embed(Text, State) of
@@ -471,8 +494,8 @@ handle_read({upsert, Id, Text, Metadata}, State) ->
                     case do_add(Id, Text, Metadata, Vector, State) of
                         {ok, NewState} ->
                             {ok, NewState};
-                        {error, _} = Error ->
-                            {Error, State}
+                        {error, Reason, NewState} ->
+                            {{error, Reason}, NewState}
                     end;
                 {error, _} = Error ->
                     {Error, State}
@@ -517,6 +540,7 @@ handle_read(stats, #state{index = Index, index_module = Mod,
         dimension => Dim,
         count => Mod:size(Index),
         index => Mod:info(Index),
+        index_origin => State#state.index_origin,
         config => Config
     },
     {{ok, Stats}, State};
@@ -531,7 +555,11 @@ handle_read(embedder_info, #state{embed_state = EmbedState} = State) ->
 handle_read(checkpoint, #state{db = Db, cf_hnsw = CfHnsw,
                                                     index = Index, index_module = Mod} = State) ->
     _ = persist_index_meta(Db, CfHnsw, Index, Mod),
+    _ = persist_index_graph(State),
     {ok, State};
+
+handle_read(persist_index, State) ->
+    {persist_index_graph(State), State};
 
 %% BM25 search
 handle_read({search_bm25, Query, Opts}, State) ->
@@ -601,7 +629,8 @@ code_change(_OldVsn, State, _Extra) ->
 process_writes_atomic([], State) ->
     {[], State};
 process_writes_atomic(Writes, #state{db = Db, cf_vectors = CfV, cf_metadata = CfM,
-                                      cf_text = CfT, docstore = Docstore,
+                                      cf_text = CfT, cf_hnsw = CfH,
+                                      docstore = Docstore, index_seq = Seq0,
                                       index = Index, index_module = Mod, dimension = Dim} = State) ->
     {ok, Batch} = rocksdb:batch(),
 
@@ -644,6 +673,16 @@ process_writes_atomic(Writes, #state{db = Db, cf_vectors = CfV, cf_metadata = Cf
             %% Insert into index (batch or individual)
             case insert_vectors_to_index(lists:reverse(VectorsForIndex), Index, Mod, SupportsBatchInsert) of
                 {ok, NewIndex} ->
+                    %% Same-batch seq bump keeps load's staleness check
+                    %% exact (skipped when nothing was written).
+                    Seq1 = case VectorsForIndex of
+                        [] -> Seq0;
+                        _ ->
+                            S1 = Seq0 + 1,
+                            ok = rocksdb:batch_put(Batch, CfH,
+                                                   ?HNSW_SEQ_KEY, <<S1:64>>),
+                            S1
+                    end,
                     %% Commit the RocksDB batch atomically, then (for an external
                     %% docstore only) write text/metadata. Vector-first, doc-second.
                     case rocksdb:write_batch(Db, Batch, []) of
@@ -652,7 +691,8 @@ process_writes_atomic(Writes, #state{db = Db, cf_vectors = CfV, cf_metadata = Cf
                             %% so update it once the rocksdb write succeeds.
                             {ok, NewBM25} = bm25_add_all(State#state.bm25_index,
                                                          lists:reverse(Bm25Pairs)),
-                            StateOk = State#state{index = NewIndex, bm25_index = NewBM25},
+                            StateOk = State#state{index = NewIndex, bm25_index = NewBM25,
+                                                  index_seq = Seq1},
                             case docstore_multi_put(Docstore, lists:reverse(DocPairs)) of
                                 ok ->
                                     Replies = [{reply, From, Reply} || {From, Reply} <- Replies0],
@@ -665,7 +705,7 @@ process_writes_atomic(Writes, #state{db = Db, cf_vectors = CfV, cf_metadata = Cf
                         {error, Reason} ->
                             ErrorReplies = [{reply, From, {error, {db_error, Reason}}}
                                            || {From, _} <- Replies0],
-                            {ErrorReplies, State}
+                            {ErrorReplies, maybe_graph_dirty(Mod, State)}
                     end;
                 {error, Reason} ->
                     ErrorReplies = [{reply, From, {error, {index_error, Reason}}}
@@ -948,9 +988,11 @@ prepare_batch_embeddings(Docs, State) ->
 
 terminate(_Reason, #state{db = Db, index = Index, index_module = Mod, cf_hnsw = CfHnsw,
                           bm25_index = BM25, bm25_backend = BM25Backend,
-                          docstore = Docstore}) ->
-    %% Persist index metadata before closing
+                          docstore = Docstore} = State) ->
+    %% Persist index metadata and graph before closing (best effort;
+    %% a kill mid-persist just means a rebuild on the next open)
     _ = persist_index_meta(Db, CfHnsw, Index, Mod),
+    _ = persist_index_graph(State),
     %% Close index if backend supports it (e.g., FAISS releases NIF resources)
     _ = maybe_close_index(Mod, Index),
     %% The disk BM25 backend holds file + nested RocksDB handles
@@ -1006,21 +1048,35 @@ init_rocksdb(DbPath, Env) ->
             {error, Reason}
     end.
 
-%% Load existing index or create new one
+%% Load existing index or create a new one; the third element says
+%% how the index came to be (new | loaded | rebuilt).
 load_or_create_index(Db, CfHandles, Dimension, IndexConfig, IndexModule) ->
     case IndexModule of
         barrel_vectordb_diskann ->
             %% DiskANN manages its own persistence - use open/new directly
             load_or_create_diskann(IndexConfig, Dimension);
         _ ->
-            %% HNSW/FAISS - rebuild from vectors stored in RocksDB
             CfHnsw = maps:get(hnsw, CfHandles),
             CfVectors = maps:get(vectors, CfHandles),
-            case load_index_meta(Db, CfHnsw) of
-                {ok, _IndexMeta} ->
-                    rebuild_from_vectors(Db, CfVectors, Dimension, IndexConfig, IndexModule);
-                not_found ->
-                    IndexModule:new(IndexConfig#{dimension => Dimension})
+            case load_index_graph(Db, CfHnsw, Dimension, IndexConfig,
+                                  IndexModule) of
+                {ok, Index} ->
+                    {ok, Index, loaded};
+                not_loadable ->
+                    %% Always rebuild from the vectors CF (empty CF =
+                    %% fresh index): rebuilding used to be gated on the
+                    %% meta blob, so a killed store that never
+                    %% checkpointed reopened with an empty index.
+                    case rebuild_from_vectors(Db, CfVectors, Dimension, IndexConfig, IndexModule) of
+                        {ok, Index} ->
+                            Origin = case IndexModule:size(Index) of
+                                0 -> new;
+                                _ -> rebuilt
+                            end,
+                            {ok, Index, Origin};
+                        {error, _} = Err ->
+                            Err
+                    end
             end
     end.
 
@@ -1031,7 +1087,7 @@ load_or_create_diskann(Config, Dimension) ->
     ok = filelib:ensure_dir(filename:join(BasePath, "dummy")),
     case barrel_vectordb_diskann:open(BasePath, #{crypto => Crypto}) of
         {ok, Index} ->
-            {ok, Index};
+            {ok, Index, loaded};
         %% key/matrix failures must fail the store open, not silently
         %% recreate a fresh index over the data
         {error, wrong_encryption_key} = Err ->
@@ -1042,26 +1098,150 @@ load_or_create_diskann(Config, Dimension) ->
             Err;
         {error, _} ->
             %% No existing index or failed to open - create new
-            barrel_vectordb_diskann:new(Config#{dimension => Dimension, storage_mode => disk})
-    end.
-
-%% Load index metadata from storage
-load_index_meta(Db, CfHnsw) ->
-    case rocksdb:get(Db, CfHnsw, ?HNSW_META_KEY, []) of
-        {ok, Binary} ->
-            try
-                Meta = binary_to_term(Binary),
-                {ok, Meta}
-            catch
-                _:_ -> not_found
-            end;
-        not_found ->
-            not_found;
-        {error, _} ->
-            not_found
+            case barrel_vectordb_diskann:new(Config#{dimension => Dimension,
+                                                     storage_mode => disk}) of
+                {ok, Index} -> {ok, Index, new};
+                {error, _} = Err -> Err
+            end
     end.
 
 %% Persist index metadata
+%% FAISS mutates its NIF handle during insert; a failed commit after
+%% that leaves the graph ahead of the data, so persisting is unsafe.
+maybe_graph_dirty(barrel_vectordb_index_faiss, State) ->
+    State#state{graph_dirty = true};
+maybe_graph_dirty(_Mod, State) ->
+    State.
+
+read_index_seq(Db, CfHnsw) ->
+    case rocksdb:get(Db, CfHnsw, ?HNSW_SEQ_KEY, []) of
+        {ok, <<Seq:64>>} -> Seq;
+        _ -> 0
+    end.
+
+%% What must match for a stored graph to be loadable; the canonical
+%% term is stored (not a hash) so mismatches are debuggable.
+index_fingerprint(barrel_vectordb_index_hnsw, Dim, IndexConfig) ->
+    #{v => 1, backend => hnsw, dimension => Dim,
+      config => maps:with([m, m_max0, ef_construction, distance_fn,
+                           quantization], IndexConfig)};
+index_fingerprint(barrel_vectordb_index_faiss, Dim, IndexConfig) ->
+    #{v => 1, backend => faiss, dimension => Dim,
+      config => maps:with([index_type, metric, nlist, nprobe],
+                          IndexConfig)};
+index_fingerprint(Mod, Dim, _IndexConfig) ->
+    #{v => 1, backend => Mod, dimension => Dim}.
+
+index_config(barrel_vectordb_index_faiss, Config) ->
+    maps:get(faiss, Config, #{});
+index_config(_Mod, Config) ->
+    maps:get(hnsw, Config, #{}).
+
+%% Load the stored graph when it provably matches the vectors CF:
+%% exact write seq, same config fingerprint, checksum intact.
+load_index_graph(Db, CfHnsw, Dimension, IndexConfig, IndexModule) ->
+    case rocksdb:get(Db, CfHnsw, ?HNSW_GRAPH_HEADER_KEY, []) of
+        {ok, HeaderBin} ->
+            try binary_to_term(HeaderBin) of
+                #{v := 1, seq := Seq, fingerprint := Fp, crc32 := Crc,
+                  nchunks := NChunks} ->
+                    CurSeq = read_index_seq(Db, CfHnsw),
+                    CurFp = index_fingerprint(IndexModule, Dimension,
+                                              IndexConfig),
+                    case Seq =:= CurSeq andalso Fp =:= CurFp of
+                        true ->
+                            load_graph_chunks(Db, CfHnsw, NChunks, Crc,
+                                              IndexModule);
+                        false ->
+                            not_loadable
+                    end;
+                _Other ->
+                    not_loadable
+            catch
+                _:_ -> not_loadable
+            end;
+        _ ->
+            not_loadable
+    end.
+
+load_graph_chunks(Db, CfHnsw, NChunks, Crc, IndexModule) ->
+    try
+        Chunks = [begin
+                      {ok, C} = rocksdb:get(Db, CfHnsw, chunk_key(N), []),
+                      C
+                  end || N <- lists:seq(0, NChunks - 1)],
+        Bin = iolist_to_binary(Chunks),
+        Crc = erlang:crc32(Bin),
+        case IndexModule:deserialize(Bin) of
+            {ok, Index} ->
+                {ok, Index};
+            {error, Reason} ->
+                error_logger:warning_msg(
+                    "barrel_vectordb: stored index graph rejected (~p), rebuilding~n",
+                    [Reason]),
+                not_loadable
+        end
+    catch
+        _:_ -> not_loadable
+    end.
+
+chunk_key(N) ->
+    <<?HNSW_GRAPH_CHUNK_PREFIX/binary, N:32>>.
+
+chunk_binary(Bin, Size) when byte_size(Bin) =< Size ->
+    [Bin];
+chunk_binary(Bin, Size) ->
+    <<C:Size/binary, Rest/binary>> = Bin,
+    [C | chunk_binary(Rest, Size)].
+
+%% Persist the serialized graph in ONE batch (delete-range of old
+%% chunks + chunk puts + header) so a crash never mixes generations.
+persist_index_graph(#state{graph_dirty = true, db = Db,
+                           cf_hnsw = CfHnsw}) ->
+    %% The in-RAM graph may not match committed data: drop the header
+    %% so the next open rebuilds.
+    _ = rocksdb:delete(Db, CfHnsw, ?HNSW_GRAPH_HEADER_KEY, []),
+    {error, graph_dirty};
+persist_index_graph(#state{index_module = barrel_vectordb_diskann}) ->
+    ok;
+persist_index_graph(#state{db = Db, cf_hnsw = CfHnsw, index = Index,
+                           index_module = Mod, dimension = Dim,
+                           config = Config, index_seq = Seq}) ->
+    try Mod:serialize(Index) of
+        Bin when is_binary(Bin) ->
+            Chunks = chunk_binary(Bin, ?GRAPH_CHUNK_SIZE),
+            Header = term_to_binary(#{v => 1, seq => Seq,
+                fingerprint => index_fingerprint(Mod, Dim,
+                                                 index_config(Mod, Config)),
+                crc32 => erlang:crc32(Bin),
+                nchunks => length(Chunks),
+                total_size => byte_size(Bin)}),
+            {ok, Batch} = rocksdb:batch(),
+            try
+                ok = rocksdb:batch_delete_range(Batch, CfHnsw,
+                        ?HNSW_GRAPH_CHUNK_PREFIX,
+                        <<?HNSW_GRAPH_CHUNK_PREFIX/binary,
+                          16#FFFFFFFF:32>>),
+                _ = lists:foldl(
+                    fun(C, N) ->
+                        ok = rocksdb:batch_put(Batch, CfHnsw,
+                                               chunk_key(N), C),
+                        N + 1
+                    end, 0, Chunks),
+                ok = rocksdb:batch_put(Batch, CfHnsw,
+                                       ?HNSW_GRAPH_HEADER_KEY, Header),
+                rocksdb:write_batch(Db, Batch, [])
+            after
+                rocksdb:release_batch(Batch)
+            end
+    catch
+        Class:Reason ->
+            error_logger:warning_msg(
+                "barrel_vectordb: index persist failed: ~p:~p~n",
+                [Class, Reason]),
+            {error, {persist_failed, Reason}}
+    end.
+
 persist_index_meta(Db, CfHnsw, Index, Mod) ->
     %% Use the index module's info function to get metadata
     Info = Mod:info(Index),
@@ -1117,8 +1297,11 @@ do_embed_batch(Texts, #state{embed_state = EmbedState}) ->
     barrel_embed:embed_batch(Texts, EmbedState).
 
 %% Add a document
+%% Returns {ok, State} | {error, Reason, State}: post-commit failures
+%% carry the committed index/seq so it never goes stale vs the data.
 do_add(Id, Text, Metadata, Vector, #state{db = Db, cf_vectors = CfV,
                                           cf_metadata = CfM, cf_text = CfT,
+                                          cf_hnsw = CfH, index_seq = Seq0,
                                           index = Index, index_module = Mod,
                                           bm25_index = BM25Index,
                                           docstore = Docstore} = State) ->
@@ -1129,28 +1312,34 @@ do_add(Id, Text, Metadata, Vector, #state{db = Db, cf_vectors = CfV,
         ok = rocksdb:batch_put(Batch, CfV, Id, VectorBin),
         DocPairs = put_docdata_to_batch(Docstore, Batch, CfM, CfT, Id, Text, Metadata),
 
-        %% Index updated in-memory only (rebuilt from vectors on startup)
         case Mod:insert(Index, Id, Vector) of
             {ok, NewIndex} ->
+                Seq1 = Seq0 + 1,
+                ok = rocksdb:batch_put(Batch, CfH, ?HNSW_SEQ_KEY,
+                                       <<Seq1:64>>),
                 case rocksdb:write_batch(Db, Batch, []) of
                     ok ->
+                        StateOk = State#state{index = NewIndex,
+                                              index_seq = Seq1},
                         case docstore_multi_put(Docstore, DocPairs) of
                             ok ->
-                                %% Also add to BM25 index if enabled
                                 case bm25_add(BM25Index, Id, Text) of
                                     {ok, NewBM25Index} ->
-                                        {ok, State#state{index = NewIndex, bm25_index = NewBM25Index}};
+                                        {ok, StateOk#state{bm25_index = NewBM25Index}};
                                     {error, Reason} ->
-                                        {error, {bm25_error, Reason}}
+                                        {error, {bm25_error, Reason},
+                                         StateOk}
                                 end;
                             {error, DsReason} ->
-                                {error, {docstore_error, DsReason}}
+                                {error, {docstore_error, DsReason},
+                                 StateOk}
                         end;
                     {error, Reason} ->
-                        {error, {db_error, Reason}}
+                        {error, {db_error, Reason},
+                         maybe_graph_dirty(Mod, State)}
                 end;
             {error, Reason} ->
-                {error, Reason}
+                {error, Reason, State}
         end
     after
         rocksdb:release_batch(Batch)
@@ -1181,31 +1370,46 @@ do_get(Id, #state{db = Db, cf_vectors = CfV, cf_metadata = CfM, cf_text = CfT,
     end.
 
 %% Delete a document
+%% Returns {ok, State} | {error, Reason, State} (see do_add). The
+%% index mutates before the commit so both stay in step.
 do_delete(Id, #state{db = Db, cf_vectors = CfV, cf_metadata = CfM,
                      cf_text = CfT, cf_hnsw = CfH, index = Index, index_module = Mod,
+                     index_seq = Seq0,
                      bm25_index = BM25Index, docstore = Docstore} = State) ->
     {ok, Batch} = rocksdb:batch(),
     try
         ok = rocksdb:batch_delete(Batch, CfV, Id),
         ok = delete_docdata_from_batch(Docstore, Batch, CfM, CfT, Id),
-        ok = rocksdb:batch_delete(Batch, CfH, Id),
+        %% Legacy per-id graph keys; never touch the reserved ones.
+        case Id of
+            <<"__hnsw_", _/binary>> -> ok;
+            _ -> ok = rocksdb:batch_delete(Batch, CfH, Id)
+        end,
 
-        case rocksdb:write_batch(Db, Batch, []) of
-            ok ->
-                case docstore_delete(Docstore, Id) of
+        case Mod:delete(Index, Id) of
+            {ok, NewIndex} ->
+                Seq1 = Seq0 + 1,
+                ok = rocksdb:batch_put(Batch, CfH, ?HNSW_SEQ_KEY,
+                                       <<Seq1:64>>),
+                case rocksdb:write_batch(Db, Batch, []) of
                     ok ->
-                        case Mod:delete(Index, Id) of
-                            {ok, NewIndex} ->
-                                %% Also remove from BM25 index if enabled
-                                {ok, NewBM25Index} = bm25_remove(BM25Index, Id),
-                                {ok, State#state{index = NewIndex, bm25_index = NewBM25Index}};
-                            {error, Reason} -> {error, Reason}
+                        {ok, NewBM25Index} = bm25_remove(BM25Index, Id),
+                        StateOk = State#state{index = NewIndex,
+                                              index_seq = Seq1,
+                                              bm25_index = NewBM25Index},
+                        case docstore_delete(Docstore, Id) of
+                            ok ->
+                                {ok, StateOk};
+                            {error, DsReason} ->
+                                {error, {docstore_error, DsReason},
+                                 StateOk}
                         end;
-                    {error, DsReason} ->
-                        {error, {docstore_error, DsReason}}
+                    {error, Reason} ->
+                        {error, {db_error, Reason},
+                         maybe_graph_dirty(Mod, State)}
                 end;
             {error, Reason} ->
-                {error, {db_error, Reason}}
+                {error, Reason, State}
         end
     after
         rocksdb:release_batch(Batch)

--- a/apps/barrel_vectordb/src/barrel_vectordb_store_sup.erl
+++ b/apps/barrel_vectordb/src/barrel_vectordb_store_sup.erl
@@ -43,7 +43,7 @@ init([]) ->
     Store = #{id => barrel_vectordb_store,
               start => {barrel_vectordb, start_link, []},
               restart => temporary,
-              shutdown => 5000,
+              shutdown => 30000,
               type => worker,
               modules => [barrel_vectordb_server]},
     {ok, {SupFlags, [Store]}}.

--- a/apps/barrel_vectordb/test/barrel_vectordb_crypto_tests.erl
+++ b/apps/barrel_vectordb/test/barrel_vectordb_crypto_tests.erl
@@ -112,6 +112,8 @@ test_roundtrip() ->
                                         #{}, [0.0, 1.0, 0.0]),
         stop_store(),
         {ok, _} = start_store(TestDir, #{crypto => #{key => ?KEY1}}),
+        %% the persisted graph loads through the EncryptedEnv
+        {ok, #{index_origin := loaded}} = barrel_vectordb:stats(?STORE),
         {ok, [#{key := <<"a">>}]} =
             barrel_vectordb:search_vector(?STORE, [1.0, 0.0, 0.0],
                                           #{k => 1})

--- a/apps/barrel_vectordb/test/barrel_vectordb_index_faiss_tests.erl
+++ b/apps/barrel_vectordb/test/barrel_vectordb_index_faiss_tests.erl
@@ -335,4 +335,19 @@ test_faiss_store_persistence() ->
 
     %% Document should still be accessible
     {ok, Doc} = barrel_vectordb:get(faiss_test_store, <<"persist1">>),
-    ?assertEqual(<<"persistent doc">>, maps:get(text, Doc)).
+    ?assertEqual(<<"persistent doc">>, maps:get(text, Doc)),
+
+    %% Restart: the serialized FAISS graph loads instead of rebuilding
+    {ok, Dir} = barrel_vectordb_server:get_db_path(faiss_test_store),
+    ok = barrel_vectordb:stop(faiss_test_store),
+    timer:sleep(100),
+    {ok, _} = barrel_vectordb:start_link(#{
+        name => faiss_test_store,
+        path => Dir,
+        dimension => 4,
+        backend => faiss
+    }),
+    {ok, Stats} = barrel_vectordb:stats(faiss_test_store),
+    ?assertEqual(loaded, maps:get(index_origin, Stats)),
+    {ok, Doc2} = barrel_vectordb:get(faiss_test_store, <<"persist1">>),
+    ?assertEqual(<<"persistent doc">>, maps:get(text, Doc2)).

--- a/apps/barrel_vectordb/test/barrel_vectordb_tests.erl
+++ b/apps/barrel_vectordb/test/barrel_vectordb_tests.erl
@@ -35,6 +35,9 @@ api_test_() ->
         {"stats returns store info", fun test_stats/0},
         {"checkpoint persists index", fun test_checkpoint/0},
         {"persistence reload", fun test_persistence_reload/0},
+        {"reload loads persisted graph", fun test_reload_loaded_graph/0},
+        {"kill after write forces rebuild", fun test_stale_graph_rebuilt/0},
+        {"config change forces rebuild", fun test_config_change_rebuilt/0},
         {"concurrent add_vector batching", fun test_concurrent_add_vector/0},
         {"multiple writers stress test", fun test_multiple_writers/0},
         {"search with include options", fun test_search_include_options/0}
@@ -371,6 +374,77 @@ test_persistence_reload() ->
     %% Cleanup
     ok = barrel_vectordb:stop(persist_test_store),
     os:cmd("rm -rf " ++ PersistDir).
+
+test_reload_loaded_graph() ->
+    Dir = "/tmp/barrel_vectordb_graph_load_test_" ++
+          integer_to_list(erlang:unique_integer([positive])),
+    Cfg = #{name => graph_load_store, path => Dir, dimension => 3,
+            hnsw => #{m => 4, ef_construction => 20}},
+    {ok, _} = barrel_vectordb:start_link(Cfg),
+    ok = barrel_vectordb:add_vector(graph_load_store, <<"g1">>, <<"t1">>,
+                                    #{}, [1.0, 0.0, 0.0]),
+    ok = barrel_vectordb:add_vector(graph_load_store, <<"g2">>, <<"t2">>,
+                                    #{}, [0.0, 1.0, 0.0]),
+    ok = barrel_vectordb:add_vector(graph_load_store, <<"g3">>, <<"t3">>,
+                                    #{}, [0.0, 0.0, 1.0]),
+    ok = barrel_vectordb:delete(graph_load_store, <<"g3">>),
+    ok = barrel_vectordb:stop(graph_load_store),
+    timer:sleep(100),
+
+    {ok, _} = barrel_vectordb:start_link(Cfg),
+    {ok, Stats} = barrel_vectordb:stats(graph_load_store),
+    ?assertEqual(loaded, maps:get(index_origin, Stats)),
+    ?assertEqual(2, barrel_vectordb:count(graph_load_store)),
+    {ok, [First | _]} = barrel_vectordb:search_vector(graph_load_store,
+                                                      [0.0, 1.0, 0.0],
+                                                      #{k => 2}),
+    ?assertEqual(<<"g2">>, maps:get(key, First)),
+    ok = barrel_vectordb:stop(graph_load_store),
+    os:cmd("rm -rf " ++ Dir).
+
+test_stale_graph_rebuilt() ->
+    Dir = "/tmp/barrel_vectordb_graph_stale_test_" ++
+          integer_to_list(erlang:unique_integer([positive])),
+    Cfg = #{name => graph_stale_store, path => Dir, dimension => 3,
+            hnsw => #{m => 4, ef_construction => 20}},
+    {ok, Pid} = barrel_vectordb:start_link(Cfg),
+    ok = barrel_vectordb:add_vector(graph_stale_store, <<"s1">>, <<"t1">>,
+                                    #{}, [1.0, 0.0, 0.0]),
+    ok = barrel_vectordb:persist_index(graph_stale_store),
+    %% a write after the persist makes the stored graph stale
+    ok = barrel_vectordb:add_vector(graph_stale_store, <<"s2">>, <<"t2">>,
+                                    #{}, [0.0, 1.0, 0.0]),
+    unlink(Pid),
+    MRef = monitor(process, Pid),
+    exit(Pid, kill),
+    receive {'DOWN', MRef, _, _, _} -> ok end,
+
+    {ok, _} = barrel_vectordb:start_link(Cfg),
+    {ok, Stats} = barrel_vectordb:stats(graph_stale_store),
+    ?assertEqual(rebuilt, maps:get(index_origin, Stats)),
+    ?assertEqual(2, barrel_vectordb:count(graph_stale_store)),
+    ok = barrel_vectordb:stop(graph_stale_store),
+    os:cmd("rm -rf " ++ Dir).
+
+test_config_change_rebuilt() ->
+    Dir = "/tmp/barrel_vectordb_graph_cfg_test_" ++
+          integer_to_list(erlang:unique_integer([positive])),
+    Cfg = #{name => graph_cfg_store, path => Dir, dimension => 3,
+            hnsw => #{m => 4, ef_construction => 20}},
+    {ok, _} = barrel_vectordb:start_link(Cfg),
+    ok = barrel_vectordb:add_vector(graph_cfg_store, <<"c1">>, <<"t1">>,
+                                    #{}, [1.0, 0.0, 0.0]),
+    ok = barrel_vectordb:stop(graph_cfg_store),
+    timer:sleep(100),
+
+    {ok, _} = barrel_vectordb:start_link(Cfg#{hnsw =>
+                                                  #{m => 8,
+                                                    ef_construction => 20}}),
+    {ok, Stats} = barrel_vectordb:stats(graph_cfg_store),
+    ?assertEqual(rebuilt, maps:get(index_origin, Stats)),
+    ?assertEqual(1, barrel_vectordb:count(graph_cfg_store)),
+    ok = barrel_vectordb:stop(graph_cfg_store),
+    os:cmd("rm -rf " ++ Dir).
 
 test_concurrent_add_vector() ->
     %% Spawn multiple processes adding vectors concurrently

--- a/apps/barrel_vectordb/test/barrel_vectordb_tests.erl
+++ b/apps/barrel_vectordb/test/barrel_vectordb_tests.erl
@@ -37,6 +37,8 @@ api_test_() ->
         {"persistence reload", fun test_persistence_reload/0},
         {"reload loads persisted graph", fun test_reload_loaded_graph/0},
         {"kill after write forces rebuild", fun test_stale_graph_rebuilt/0},
+        {"changed object after persist forces rebuild",
+         fun test_changed_object_rebuilt/0},
         {"config change forces rebuild", fun test_config_change_rebuilt/0},
         {"concurrent add_vector batching", fun test_concurrent_add_vector/0},
         {"multiple writers stress test", fun test_multiple_writers/0},
@@ -424,6 +426,37 @@ test_stale_graph_rebuilt() ->
     ?assertEqual(rebuilt, maps:get(index_origin, Stats)),
     ?assertEqual(2, barrel_vectordb:count(graph_stale_store)),
     ok = barrel_vectordb:stop(graph_stale_store),
+    os:cmd("rm -rf " ++ Dir).
+
+test_changed_object_rebuilt() ->
+    Dir = "/tmp/barrel_vectordb_graph_chg_test_" ++
+          integer_to_list(erlang:unique_integer([positive])),
+    Cfg = #{name => graph_chg_store, path => Dir, dimension => 3,
+            hnsw => #{m => 4, ef_construction => 20}},
+    {ok, Pid} = barrel_vectordb:start_link(Cfg),
+    ok = barrel_vectordb:add_vector(graph_chg_store, <<"c1">>, <<"t1">>,
+                                    #{}, [1.0, 0.0, 0.0]),
+    ok = barrel_vectordb:persist_index(graph_chg_store),
+    %% the object CHANGES after the persist (overwrite, then a kill so
+    %% no later persist can catch up)
+    ok = barrel_vectordb:add_vector(graph_chg_store, <<"c1">>, <<"t1b">>,
+                                    #{}, [0.0, 1.0, 0.0]),
+    unlink(Pid),
+    MRef = monitor(process, Pid),
+    exit(Pid, kill),
+    receive {'DOWN', MRef, _, _, _} -> ok end,
+
+    {ok, _} = barrel_vectordb:start_link(Cfg),
+    {ok, Stats} = barrel_vectordb:stats(graph_chg_store),
+    ?assertEqual(rebuilt, maps:get(index_origin, Stats)),
+    %% the rebuilt index serves the CHANGED vector, not the persisted one
+    {ok, Doc} = barrel_vectordb:get(graph_chg_store, <<"c1">>),
+    ?assertEqual([0.0, 1.0, 0.0], maps:get(vector, Doc)),
+    {ok, [First | _]} = barrel_vectordb:search_vector(graph_chg_store,
+                                                     [0.0, 1.0, 0.0],
+                                                     #{k => 1}),
+    ?assertEqual(<<"c1">>, maps:get(key, First)),
+    ok = barrel_vectordb:stop(graph_chg_store),
     os:cmd("rm -rf " ++ Dir).
 
 test_config_change_rebuilt() ->


### PR DESCRIPTION
Opening a vector store rebuilt the in-memory HNSW/FAISS graph from the vectors column family on every open: O(N) inserts, minutes for large stores. Cold-open sanity at 5k x 64-dim: loaded 66 ms vs rebuilt 1211 ms.

- The graph serializes into the store's `hnsw_graph` CF at close, at `checkpoint/1`, and via the new `barrel_vectordb:persist_index/1`. Persist is one atomic batch (delete-range of old chunks, 8 MiB chunk puts, header with write seq, config fingerprint, crc32), so a crash never mixes generations.
- A `__hnsw_seq__` counter is bumped inside every index-mutating RocksDB batch; open loads the graph only when sequence, fingerprint, and checksum all match, and falls back to the rebuild otherwise. `stats/1` reports `index_origin => new | loaded | rebuilt`.
- HNSW serializer v3 records the quantization method (v2/v1 still deserialize; non-scalar refuses and rebuilds). A `graph_dirty` guard keeps a diverged FAISS NIF graph from being persisted.
- Fixes: a store killed before its first checkpoint reopened with an empty index (rebuild was gated on the persisted meta blob; it now always rebuilds from the vectors CF); `delete`/`update`/`upsert` could leave the in-memory index out of step with committed data (index now mutates before commit, post-commit errors keep the committed index).
- Store supervisor shutdown raised to 30 s for large-graph persists. Encryption needs nothing: the CF lives under the store's EncryptedEnv.

Green on OTP 29 and 28: eunit 674 (3 new persistence cases), ct 883, dialyzer and xref at the pre-existing faiss baselines; faiss profile 16/16 including a serialize/restart/loaded round-trip; encrypted reopen asserts loaded.