### PR TITLE
Align relx release versions with the app versions

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -110,7 +110,7 @@
             {apps, [barrel_server]}
         ]},
         {relx, [
-            {release, {barrel_server, "1.2.0"}, [
+            {release, {barrel_server, "1.5.0"}, [
                 barrel_server,
                 sasl,
                 runtime_tools,
@@ -167,7 +167,7 @@
             {apps, [barrel_server]}
         ]},
         {relx, [
-            {release, {barrel_server, "1.2.0"}, [
+            {release, {barrel_server, "1.5.0"}, [
                 barrel_server,
                 barrel_att_s3,
                 sasl,
@@ -184,7 +184,7 @@
 %% Umbrella release skeleton. The primary deliverables are `rebar3 compile` and
 %% the test suites; release assembly can be refined in a later change.
 {relx, [
-    {release, {barrel, "1.1.0"}, [
+    {release, {barrel, "1.3.1"}, [
         barrel_crypto,
         barrel_docdb,
         barrel_vectordb,


### PR DESCRIPTION
The `barrel_server` release definitions (server and s3_server profiles) said 1.2.0 while the app is 1.5.0, and the `barrel` release said 1.1.0 while the app is 1.3.1; both were left behind by the last release rounds. Both releases assemble.