### PR TITLE
barrel_spaces 1.2.0: caller-owned pin and message ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the Barrel umbrella are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and each app
 is versioned independently under [Semantic Versioning](https://semver.org/).
 
+## [2026-08-26] barrel_spaces caller-owned pin and message ids
+
+Feedback from the barrel_memory migration onto 1.1.0: sessions, data,
+summary and TTL map cleanly, but pins discarded a caller's id, timestamp
+and metadata, and imported messages were keyed by a derived id rather
+than the caller's. Both now accept caller ids, with duplicates refused
+loudly as conflicts, and message listing orders by timestamp so
+non-chronological ids stay in order.
+
+| App | Version | Change |
+|-----|---------|--------|
+| barrel_spaces | 1.2.0 | caller ids for pins and imported messages; get_messages ordered by ts |
+
 ## [2026-08-25] barrel_vectordb index persistence
 
 Opening a vector store used to rebuild the whole HNSW/FAISS graph from the

--- a/apps/barrel_spaces/CHANGELOG.md
+++ b/apps/barrel_spaces/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.0] - 2026-08-26
+
+### Added
+- `pin_context/3` takes caller-supplied `id`, `pinned_at`, and `metadata` (defaults unchanged); a pin id already present in the session fails with `{error, conflict}` instead of quietly duplicating.
+- `import_message/3` takes a caller-supplied `id` that keys the document (an existing id conflicts), closing the last place the API minted an id a consumer might already own.
+
+### Changed
+- `get_messages` orders by timestamp (id as tiebreak) instead of raw id order, so caller-supplied message ids that do not sort chronologically still list in order. Generated ids keep their exact previous order.
+
 ## [1.1.0] - 2026-08-25
 
 ### Added

--- a/apps/barrel_spaces/src/barrel_session.erl
+++ b/apps/barrel_spaces/src/barrel_session.erl
@@ -219,8 +219,10 @@ add_message(#{db := Db} = Space, Sid, #{role := Role,
 %% @doc Import a message with its own timestamp (the chronological id
 %% derives from it). Map keys: `role' and `content' (required), `ts'
 %% (unix ms, default now), `seq' (disambiguates messages inside one
-%% millisecond, default a fresh monotonic value), `metadata'. Does
-%% not slide the session's TTL.
+%% millisecond, default a fresh monotonic value), `id' (caller-supplied
+%% message id, keys the document instead of the derived id; an id
+%% already used in this session fails with a conflict), `metadata'.
+%% Does not slide the session's TTL.
 -spec import_message(barrel_spaces:space(), binary(), map()) ->
     {ok, binary()} | {error, term()}.
 import_message(#{db := Db} = Space, Sid, #{role := Role,
@@ -228,10 +230,7 @@ import_message(#{db := Db} = Space, Sid, #{role := Role,
     case get(Space, Sid) of
         {ok, _} ->
             Ts = maps:get(ts, Msg, barrel_spaces:now_ms()),
-            MsgId = case maps:find(seq, Msg) of
-                {ok, Seq} -> msg_id(Ts, Seq);
-                error -> msg_id(Ts)
-            end,
+            MsgId = import_msg_id(Msg, Ts),
             Doc = #{
                 <<"id">> => <<"session:", Sid/binary, ":msg:",
                               MsgId/binary>>,
@@ -249,6 +248,14 @@ import_message(#{db := Db} = Space, Sid, #{role := Role,
         {error, _} = Err ->
             Err
     end.
+
+%% The imported message's id: the caller's, else derived from ts+seq.
+import_msg_id(#{id := Id}, _Ts) when is_binary(Id), Id =/= <<>> ->
+    Id;
+import_msg_id(#{seq := Seq}, Ts) ->
+    msg_id(Ts, Seq);
+import_msg_id(_Msg, Ts) ->
+    msg_id(Ts).
 
 %% @doc The session's messages in chronological order.
 -spec get_messages(barrel_spaces:space(), binary()) -> {ok, [map()]}.
@@ -274,7 +281,13 @@ get_messages(#{db := #{docdb := DbBin}}, Sid, Opts) ->
            (_Doc, Acc) ->
                 {ok, Acc}
         end, [], #{id_prefix => <<"session:", Sid/binary, ":msg:">>}),
-    Asc = lists:reverse(Messages),
+    %% caller-supplied message ids need not sort chronologically, so
+    %% order by ts (id as tiebreak keeps generated ids' exact order)
+    Asc = lists:sort(
+        fun(#{<<"ts">> := TA, <<"id">> := IA},
+            #{<<"ts">> := TB, <<"id">> := IB}) ->
+            {TA, IA} =< {TB, IB}
+        end, Messages),
     Limit = maps:get(limit, Opts, infinity),
     case maps:get(order, Opts, asc) of
         asc -> {ok, take(Asc, Limit)};
@@ -315,29 +328,51 @@ set_summary(Space, Sid, Summary) when is_binary(Summary) ->
     update(Space, Sid, fun(Doc) -> Doc#{<<"summary">> => Summary} end).
 
 %% @doc Pin context that must survive truncation: `#{content := term(),
-%% priority => 0..10 (0 highest, default 5)}'. Returns the pin's id.
+%% priority => 0..10 (0 highest, default 5), id => binary()
+%% (caller-supplied pin id, default generated; an id already pinned in
+%% this session fails with conflict), pinned_at => unix ms (default
+%% now), metadata => map()}'. Returns the pin's id.
 -spec pin_context(barrel_spaces:space(), binary(), map()) ->
     {ok, binary()} | {error, term()}.
 pin_context(Space, Sid, #{content := Content} = Pin) ->
-    PinId = barrel_spaces:new_id(<<"pin_">>),
-    Item = #{
-        <<"id">> => PinId,
-        <<"content">> => Content,
-        <<"priority">> => maps:get(priority, Pin, 5),
-        <<"pinned_at">> => barrel_spaces:now_ms()
-    },
-    case update(Space, Sid, fun(Doc) ->
-             Pinned = maps:get(<<"pinned">>, Doc, []),
-             Sorted = lists:sort(
-                 fun(A, B) ->
-                     maps:get(<<"priority">>, A)
-                         =< maps:get(<<"priority">>, B)
-                 end, [Item | Pinned]),
-             Doc#{<<"pinned">> => Sorted}
-         end) of
-        {ok, _} -> {ok, PinId};
-        {error, _} = Err -> Err
+    PinId = maps:get(id, Pin, barrel_spaces:new_id(<<"pin_">>)),
+    case valid_pin_id(PinId) of
+        true ->
+            Item = #{
+                <<"id">> => PinId,
+                <<"content">> => Content,
+                <<"priority">> => maps:get(priority, Pin, 5),
+                <<"metadata">> => maps:get(metadata, Pin, #{}),
+                <<"pinned_at">> => maps:get(pinned_at, Pin,
+                                            barrel_spaces:now_ms())
+            },
+            case update(Space, Sid,
+                        fun(Doc) -> add_pin(Doc, Item) end) of
+                {ok, _} -> {ok, PinId};
+                {error, _} = Err -> Err
+            end;
+        false ->
+            {error, invalid_pin_id}
     end.
+
+%% Reject a duplicate id loudly instead of quietly corrupting the
+%% pinned list (unpin would then remove an arbitrary one of the two).
+add_pin(Doc, #{<<"id">> := PinId} = Item) ->
+    Pinned = maps:get(<<"pinned">>, Doc, []),
+    case [P || #{<<"id">> := I} = P <- Pinned, I =:= PinId] of
+        [_ | _] ->
+            {error, conflict};
+        [] ->
+            Sorted = lists:sort(
+                fun(A, B) ->
+                    maps:get(<<"priority">>, A)
+                        =< maps:get(<<"priority">>, B)
+                end, [Item | Pinned]),
+            Doc#{<<"pinned">> => Sorted}
+    end.
+
+valid_pin_id(Id) when is_binary(Id), byte_size(Id) > 0 -> true;
+valid_pin_id(_) -> false.
 
 %% @doc Remove a pinned item by id.
 -spec unpin_context(barrel_spaces:space(), binary(), binary()) ->
@@ -375,11 +410,16 @@ update(#{db := Db} = Space, Sid, Fun) ->
                 0 -> 0;
                 _ -> Now + Ttl * 1000
             end,
-            Updated = (Fun(Doc))#{<<"updated_at">> => Now},
-            case barrel:put_doc(Db, Updated,
-                                #{expires_at => ExpiresAt}) of
-                {ok, _} -> {ok, ExpiresAt};
-                {error, _} = Err -> Err
+            case Fun(Doc) of
+                {error, _} = Veto ->
+                    Veto;
+                Updated0 ->
+                    Updated = Updated0#{<<"updated_at">> => Now},
+                    case barrel:put_doc(Db, Updated,
+                                        #{expires_at => ExpiresAt}) of
+                        {ok, _} -> {ok, ExpiresAt};
+                        {error, _} = Err -> Err
+                    end
             end;
         {error, _} = Err ->
             Err

--- a/apps/barrel_spaces/src/barrel_spaces.app.src
+++ b/apps/barrel_spaces/src/barrel_spaces.app.src
@@ -1,6 +1,6 @@
 {application, barrel_spaces, [
     {description, "Barrel agent layer: spaces (shared context databases), capability tokens, sessions with TTL, and handoffs"},
-    {vsn, "1.1.0"},
+    {vsn, "1.2.0"},
     {registered, [barrel_spaces_sup]},
     {mod, {barrel_spaces_app, []}},
     {applications, [

--- a/apps/barrel_spaces/test/barrel_session_SUITE.erl
+++ b/apps/barrel_spaces/test/barrel_session_SUITE.erl
@@ -22,13 +22,15 @@
 
 -export([t_no_ttl_durable/1, t_import_with_ids/1, t_list_match_indexed/1]).
 
+-export([t_caller_pin_and_message_ids/1]).
+
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
 
 all() ->
     [t_create_get_touch, t_sliding_ttl, t_messages_chronological,
      t_message_ranges, t_data_summary_pinned, t_delete_cascade,
-     t_janitor_orphans, t_list_by_agent, t_no_ttl_durable, t_import_with_ids, t_list_match_indexed].
+     t_janitor_orphans, t_list_by_agent, t_no_ttl_durable, t_import_with_ids, t_list_match_indexed, t_caller_pin_and_message_ids].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(barrel_spaces),
@@ -260,4 +262,45 @@ t_list_match_indexed(Config) ->
     {ok, Limited} = barrel_session:list(Space, #{agent => <<"a1">>,
                                                  limit => 1}),
     ?assertEqual(1, length(Limited)),
+    ok.
+
+t_caller_pin_and_message_ids(Config) ->
+    Space = ?config(space, Config),
+    {ok, Sid} = barrel_session:create(Space, #{}),
+    T0 = 1750000000000,
+    %% a pin round-trips caller id, pinned_at, and metadata
+    {ok, <<"pin-a">>} = barrel_session:pin_context(Space, Sid, #{
+        id => <<"pin-a">>, content => <<"fact">>, priority => 1,
+        pinned_at => T0, metadata => #{<<"src">> => <<"legacy">>}}),
+    {ok, [P]} = barrel_session:list_pinned(Space, Sid),
+    ?assertEqual(<<"pin-a">>, maps:get(<<"id">>, P)),
+    ?assertEqual(T0, maps:get(<<"pinned_at">>, P)),
+    ?assertEqual(#{<<"src">> => <<"legacy">>},
+                 maps:get(<<"metadata">>, P)),
+    %% duplicates are refused loudly, bad ids too
+    ?assertEqual({error, conflict},
+                 barrel_session:pin_context(Space, Sid, #{
+                     id => <<"pin-a">>, content => <<"again">>})),
+    ?assertEqual({error, invalid_pin_id},
+                 barrel_session:pin_context(Space, Sid, #{
+                     id => <<>>, content => <<"x">>})),
+    %% the generated-id path is unchanged
+    {ok, GenId} = barrel_session:pin_context(Space, Sid,
+                                             #{content => <<"x">>}),
+    ?assertMatch(<<"pin_", _/binary>>, GenId),
+    {ok, _} = barrel_session:unpin_context(Space, Sid, <<"pin-a">>),
+    %% a message imported under a caller id; a duplicate conflicts
+    {ok, <<"msg-1">>} = barrel_session:import_message(Space, Sid, #{
+        role => <<"user">>, content => <<"hello">>, ts => T0,
+        id => <<"msg-1">>}),
+    ?assertMatch({error, _},
+                 barrel_session:import_message(Space, Sid, #{
+                     role => <<"user">>, content => <<"dup">>,
+                     ts => T0, id => <<"msg-1">>})),
+    %% listing orders by ts even though the id is not chronological
+    {ok, _} = barrel_session:add_message(Space, Sid, #{
+        role => <<"assistant">>, content => <<"later">>}),
+    {ok, [M1, M2]} = barrel_session:get_messages(Space, Sid),
+    ?assertEqual(<<"hello">>, maps:get(<<"content">>, M1)),
+    ?assertEqual(<<"later">>, maps:get(<<"content">>, M2)),
     ok.

--- a/docs/guides/spaces.md
+++ b/docs/guides/spaces.md
@@ -113,8 +113,15 @@ module keeps owning the document schema:
     %% ttl defaults to never for imports; ttl > 0 arms from updated_at
 {ok, _} = barrel_session:import_message(Space, <<"legacy-2">>, #{
     role => <<"user">>, content => <<"hello">>,
-    ts => 1750000050000, seq => 1}).   %% does not slide the TTL
+    ts => 1750000050000, id => <<"msg-legacy-1">>}),   %% no TTL slide
+%% pins keep their id, timestamp, and metadata too
+{ok, _} = barrel_session:pin_context(Space, <<"legacy-2">>, #{
+    id => <<"pin-legacy-1">>, content => <<"key fact">>,
+    pinned_at => 1750000060000, metadata => #{<<"src">> => <<"v1">>}}).
 ```
+
+Duplicate caller ids fail with `{error, conflict}` (a session id on
+create, a message id on import, a pin id on pin), never silently.
 
 ### Document TTL (the machinery underneath)
 


### PR DESCRIPTION
Found migrating barrel_memory's session store onto 1.1.0: sessions, data, summary and TTL map cleanly, pins do not, and messages only half do. This closes the last places the API mints an id a consumer might already own.

- `pin_context/3` takes caller-supplied `id`, `pinned_at`, and `metadata` (defaults unchanged). A pin id already present in the session fails with `{error, conflict}` instead of quietly duplicating; the check runs inside the session's read-modify-write (`update/3` funs can now veto with `{error, _}`), so it stays one CAS'd operation.
- `import_message/3` takes a caller-supplied `id` that keys the document; a duplicate conflicts through the normal document CAS.
- `get_messages` orders by timestamp with the id as tiebreak instead of raw id order, so caller ids that do not sort chronologically still list in order. Generated ids embed the padded timestamp, so their order is unchanged.

Green on OTP 29 and 28: eunit 675, ct 884 (new case covers the id round-trips, both duplicate conflicts, the invalid id, the generated paths, and the ordering), xref and dialyzer at the pre-existing baselines.