### PR TITLE
Signed sync requests v2: per-request nonce and signed query string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to the Barrel umbrella are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and each app
 is versioned independently under [Semantic Versioning](https://semver.org/).
 
+## [2026-08-26] Signed sync requests v2, checkpoint errors, venv opt-out
+
+Found while porting barrel_memory onto barrel. Two identical signed requests
+inside one millisecond were byte-identical, so the replay cache refused the
+second; replication repeats identical requests back to back and failed about
+half its runs over signed auth. Signature v2 adds a per-request nonce and
+signs the query string, which was outside the signed scope. Servers accept
+v1 and v2; roll servers first, then clients, then set `require_nonce`. A
+failed checkpoint write now ends the run with an error instead of raising.
+`barrel_embed` gains an opt-out for the managed venv bootstrap, and mTLS is
+documented as the CA-level transport gate it is.
+
+| App | Version | Change |
+|-----|---------|--------|
+| barrel_docdb | 1.4.0 | signature v2 (nonce, signed query), checkpoint errors returned |
+| barrel_server | 1.6.0 | verifies v1 and v2, `require_nonce`, mTLS wording |
+| barrel_embed | 2.4.0 | `managed_venv => false` skips the venv bootstrap |
+
 ## [2026-08-26] barrel_spaces caller-owned pin and message ids
 
 Feedback from the barrel_memory migration onto 1.1.0: sessions, data,

--- a/apps/barrel_docdb/CHANGELOG.md
+++ b/apps/barrel_docdb/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-08-26
+
+### Added
+- Signed sync requests are v2: the `Authorization: Signature` header carries a per-request `nonce`, and the signed string is `ts|keyId|nonce|METHOD|target|sha256`, where `target` is the path plus `?` and the raw query string when there is one. `barrel_sync_sig:sign/7,8`, `verify/7`, `canonical_v2/6`, `target/2`, `new_nonce/0`; `sign/6` and `verify/6` keep the v1 semantics. The HTTP transport sends v2 only.
+
+### Fixed
+- Two identical signed requests inside one millisecond produced byte-identical signatures, and the server refused the second as a replay; replication repeats identical requests back to back, so runs over `accept => [signed]` failed about half the time. The nonce makes every request distinct.
+- The query string was outside the signed scope (`?since=`, `?limit=` on attachment changes were unauthenticated); the v2 target signs it.
+- `barrel_rep_checkpoint` raised `case_clause` when a checkpoint read failed with anything but not_found (an `unauthorized` transport error, for instance); checkpoint failures are now returned as `{error, {checkpoint_failed, source | target, Reason}}` and end the replication run with that error, after the documents are committed.
+
+### Rollover
+- Servers accept v1 and v2 (barrel_server 1.6.0+). Upgrade every server first, then the clients (this app, including embedded users); a 1.4.0 client against a 1.5.x barrel_server gets 401 on every signed request. Once no client sends v1, set `require_nonce => true` on the server. Reverse proxies in front of the sync endpoint must forward path and query unmodified.
+
 ## [1.3.1] - 2026-08-23
 
 ### Fixed

--- a/apps/barrel_docdb/src/barrel_docdb.app.src
+++ b/apps/barrel_docdb/src/barrel_docdb.app.src
@@ -1,6 +1,6 @@
 {application, barrel_docdb, [
     {description, "Erlang document database with MVCC, queries, and replication"},
-    {vsn, "1.3.1"},
+    {vsn, "1.4.0"},
     {registered, [barrel_docdb_sup]},
     {mod, {barrel_docdb_app, []}},
     {applications, [

--- a/apps/barrel_docdb/src/barrel_rep.erl
+++ b/apps/barrel_docdb/src/barrel_rep.erl
@@ -227,11 +227,21 @@ replicate_one_shot(Config, Opts) ->
     CheckpointSize = maps:get(checkpoint_size, Opts, 10),
     Filter = maps:get(filter, Opts, #{}),
 
-    case do_replicate(Source, Target, SourceTransport, TargetTransport,
-                      StartSeq, BatchSize, CheckpointSize, Checkpoint, Filter) of
+    %% The final checkpoint write is part of the run: a failure ends it
+    %% with an error (docs are committed; the next run resumes earlier).
+    Run = case do_replicate(Source, Target, SourceTransport, TargetTransport,
+                            StartSeq, BatchSize, CheckpointSize, Checkpoint,
+                            Filter) of
+        {ok, Stats0, FinalCheckpoint0} ->
+            case barrel_rep_checkpoint:write_checkpoint(FinalCheckpoint0) of
+                ok -> {ok, Stats0, FinalCheckpoint0};
+                {error, _} = CpError -> CpError
+            end;
+        NotOk ->
+            NotOk
+    end,
+    case Run of
         {ok, Stats, FinalCheckpoint} ->
-            %% Write final checkpoint
-            ok = barrel_rep_checkpoint:write_checkpoint(FinalCheckpoint),
 
             %% Record replication metrics
             DocsWritten = maps:get(docs_written, Stats, 0),
@@ -346,18 +356,23 @@ do_replicate_batch_done(Source, Target, SourceTransport, TargetTransport,
     Checkpoint2 = barrel_rep_checkpoint:set_last_seq(LastSeq, Checkpoint),
     NewDocsProcessed = DocsProcessed + length(Changes),
 
-    %% Maybe write checkpoint
-    Checkpoint3 = case NewDocsProcessed >= CheckpointSize of
+    %% Maybe write checkpoint; a failed write ends the run
+    MaybeWritten = case NewDocsProcessed >= CheckpointSize of
         true ->
             barrel_rep_checkpoint:maybe_write_checkpoint(Checkpoint2);
         false ->
-            Checkpoint2
+            {ok, Checkpoint2}
     end,
-
-    %% Continue with next batch
-    do_replicate(Source, Target, SourceTransport, TargetTransport, LastSeq,
-                 BatchSize, CheckpointSize, Checkpoint3, Filter, MergedStats,
-                 NewDocsProcessed rem CheckpointSize).
+    case MaybeWritten of
+        {error, _} = CpError ->
+            CpError;
+        {ok, Checkpoint3} ->
+            %% Continue with next batch
+            do_replicate(Source, Target, SourceTransport, TargetTransport,
+                         LastSeq, BatchSize, CheckpointSize, Checkpoint3,
+                         Filter, MergedStats,
+                         NewDocsProcessed rem CheckpointSize)
+    end.
 
 %% @doc Deterministic replication ID. Each endpoint contributes its
 %% rep_id_term/1 when its transport exports one (network transports:

--- a/apps/barrel_docdb/src/barrel_rep_checkpoint.erl
+++ b/apps/barrel_docdb/src/barrel_rep_checkpoint.erl
@@ -109,20 +109,26 @@ seq_advanced(_Old, first) -> false;
 seq_advanced(first, _New) -> true;
 seq_advanced(Old, New) -> barrel_hlc:compare(New, Old) =:= gt.
 
-%% @doc Check if checkpoint should be written and write it if needed
--spec maybe_write_checkpoint(checkpoint()) -> checkpoint().
+%% @doc Check if checkpoint should be written and write it if needed.
+-spec maybe_write_checkpoint(checkpoint()) ->
+    {ok, checkpoint()} | {error, term()}.
 maybe_write_checkpoint(#checkpoint{docs_processed = DocsProcessed, options = Options} = Checkpoint) ->
     CheckpointSize = maps:get(checkpoint_size, Options, ?CHECKPOINT_SIZE),
     case DocsProcessed >= CheckpointSize of
         true ->
-            ok = write_checkpoint(Checkpoint),
-            Checkpoint#checkpoint{docs_processed = 0};
+            case write_checkpoint(Checkpoint) of
+                ok -> {ok, Checkpoint#checkpoint{docs_processed = 0}};
+                {error, _} = Err -> Err
+            end;
         false ->
-            Checkpoint
+            {ok, Checkpoint}
     end.
 
-%% @doc Write checkpoint to both source and target databases
--spec write_checkpoint(checkpoint()) -> ok.
+%% @doc Write checkpoint to both source and target databases. A failed
+%% write is reported (with the side that failed) instead of swallowed:
+%% the docs are already committed, the next run just resumes earlier.
+-spec write_checkpoint(checkpoint()) ->
+    ok | {error, {checkpoint_failed, source | target, term()}}.
 write_checkpoint(#checkpoint{
     rep_id = RepId,
     session_id = SessionId,
@@ -144,10 +150,20 @@ write_checkpoint(#checkpoint{
         <<"end_time_microsec">> => erlang:system_time(microsecond)
     },
 
-    %% Write to both source and target
-    _ = add_checkpoint(Source, SourceTransport, RepId, SessionId, HistorySize, Checkpoint),
-    _ = add_checkpoint(Target, TargetTransport, RepId, SessionId, HistorySize, Checkpoint),
-    ok.
+    %% Write both sides before reporting, so one failure never skips
+    %% the other side's checkpoint.
+    SourceRes = add_checkpoint(Source, SourceTransport, RepId, SessionId,
+                               HistorySize, Checkpoint),
+    TargetRes = add_checkpoint(Target, TargetTransport, RepId, SessionId,
+                               HistorySize, Checkpoint),
+    checkpoint_result([{source, SourceRes}, {target, TargetRes}]).
+
+checkpoint_result([]) ->
+    ok;
+checkpoint_result([{_Side, ok} | Rest]) ->
+    checkpoint_result(Rest);
+checkpoint_result([{Side, {error, Reason}} | _Rest]) ->
+    {error, {checkpoint_failed, Side, Reason}}.
 
 %% @doc Delete checkpoints from both databases
 -spec delete(checkpoint()) -> ok.
@@ -167,17 +183,25 @@ delete(#checkpoint{
 %% Internal functions
 %%====================================================================
 
-%% @doc Add a checkpoint entry to history
+%% @doc Add a checkpoint entry to history: ok | {error, Reason}. A
+%% transport error reading the previous doc (unauthorized, network) is
+%% returned, not raised.
 add_checkpoint(Db, Transport, RepId, SessionId, HistorySize, Checkpoint) ->
     DocId = checkpoint_docid(RepId),
-    Doc = case Transport:get_local_doc(Db, DocId) of
+    case Transport:get_local_doc(Db, DocId) of
         {ok, #{<<"history">> := H} = PreviousDoc} ->
             H2 = update_history(H, SessionId, HistorySize, Checkpoint),
-            PreviousDoc#{<<"history">> => H2};
+            Transport:put_local_doc(Db, DocId,
+                                    PreviousDoc#{<<"history">> => H2});
+        {ok, _NoHistory} ->
+            Transport:put_local_doc(Db, DocId,
+                                    #{<<"history">> => [Checkpoint]});
         {error, not_found} ->
-            #{<<"history">> => [Checkpoint]}
-    end,
-    Transport:put_local_doc(Db, DocId, Doc).
+            Transport:put_local_doc(Db, DocId,
+                                    #{<<"history">> => [Checkpoint]});
+        {error, _} = Err ->
+            Err
+    end.
 
 %% @doc Update checkpoint history
 update_history(History, SessionId, HistorySize, Checkpoint) ->

--- a/apps/barrel_docdb/src/barrel_rep_transport_http.erl
+++ b/apps/barrel_docdb/src/barrel_rep_transport_http.erl
@@ -280,7 +280,7 @@ get_attachment_stream(Endpoint, DocId, Name) ->
             case hackney:send_request(
                      ConnPid,
                      {get, url_path(Url),
-                      base_headers(Endpoint, <<"GET">>, url_path(Url),
+                      base_headers(Endpoint, <<"GET">>, url_target(Url),
                                    barrel_sync_sig:content_sha256(<<>>)),
                       <<>>}) of
                 {ok, 200, RespHeaders, ConnPid2} ->
@@ -312,6 +312,12 @@ url_path(Url) ->
     #{path := Path} = uri_string:parse(Url),
     Path.
 
+%% The signed target: path plus the raw query (`<<>>' when none), what
+%% the server signs on its side too.
+url_target(Url) ->
+    Parsed = uri_string:parse(Url),
+    {maps:get(path, Parsed), maps:get(query, Parsed, <<>>)}.
+
 att_read_fun(ClientRef) ->
     fun() ->
         case hackney:stream_body(ClientRef) of
@@ -332,7 +338,7 @@ put_attachment(Endpoint, DocId, Name, Meta, ReadFun) ->
                {?DIGEST_HEADER, Digest},
                {?ORIGIN_HEADER,
                 base64:encode(barrel_hlc:encode(Origin))}
-               | base_headers(Endpoint, <<"PUT">>, url_path(AttUrl), Digest)],
+               | base_headers(Endpoint, <<"PUT">>, url_target(AttUrl), Digest)],
     case hackney:request(put, AttUrl, Headers,
                          stream, stream_opts(Endpoint)) of
         {ok, ClientRef} ->
@@ -437,7 +443,7 @@ req(#{url := BaseUrl} = Endpoint, Method, PathSuffix, BodyTerm,
     ContentHash = barrel_sync_sig:content_sha256(Body),
     Headers = [{<<"content-type">>, <<"application/json">>}
                | ExtraHeaders]
-              ++ base_headers(Endpoint, method_bin(Method), url_path(Url),
+              ++ base_headers(Endpoint, method_bin(Method), url_target(Url),
                               ContentHash),
     HttpOpts = [with_body | stream_opts(Endpoint)],
     Deadline = maps:get(request_timeout, Endpoint, ?REQUEST_TIMEOUT),
@@ -471,12 +477,12 @@ bounded_request(Method, Url, Headers, Body, HttpOpts, Deadline) ->
     end.
 
 %% HLC + auth + endpoint headers. `Method' is the uppercase verb, `Path'
-%% the request path (matching what the server signs), `ContentHash' the
-%% hex SHA-256 of the body (or the attachment digest).
-base_headers(Endpoint, Method, Path, ContentHash) ->
+%% the request target `{Path, Query}' (matching what the server signs),
+%% `ContentHash' the hex SHA-256 of the body (or the attachment digest).
+base_headers(Endpoint, Method, Target, ContentHash) ->
     [{?HLC_HEADER,
       base64:encode(barrel_hlc:encode(barrel_hlc:get_hlc()))}]
-    ++ auth_headers(Endpoint, Method, Path, ContentHash)
+    ++ auth_headers(Endpoint, Method, Target, ContentHash)
     ++ maps:get(headers, Endpoint, []).
 
 stream_opts(Endpoint) ->
@@ -490,11 +496,13 @@ stream_opts(Endpoint) ->
 
 %% Signed requests take precedence over bearer when configured; otherwise
 %% fall back to the (unchanged) bearer resolution.
-auth_headers(Endpoint, Method, Path, ContentHash) ->
+auth_headers(Endpoint, Method, {Path, Query}, ContentHash) ->
     case signing_config(Endpoint) of
         #{key_id := KeyId, priv_key := PrivKey} ->
             TsMs = erlang:system_time(millisecond),
-            Auth = barrel_sync_sig:sign(KeyId, PrivKey, Method, Path,
+            %% v2: per-request nonce, query signed (servers must be on
+            %% barrel_server 1.6+, see the synchronization guide)
+            Auth = barrel_sync_sig:sign(KeyId, PrivKey, Method, Path, Query,
                                         ContentHash, TsMs),
             [{<<"authorization">>, Auth},
              {<<"x-barrel-content-sha256">>, ContentHash}];

--- a/apps/barrel_docdb/src/barrel_sync_sig.erl
+++ b/apps/barrel_docdb/src/barrel_sync_sig.erl
@@ -6,15 +6,24 @@
 %%% (`barrel_server_auth', which depends on barrel_docdb). It lives here,
 %%% the sync wire's home, so both sides share one canonical string.
 %%%
-%%% A request is authenticated by an Ed25519 signature over:
+%%% A request is authenticated by an Ed25519 signature over (v2):
 %%% ```
-%%%   ts | keyId | METHOD | path | content_sha256_hex
+%%%   ts | keyId | nonce | METHOD | target | content_sha256_hex
 %%% '''
-%%% `ts' is milliseconds since the epoch (decimal ASCII); `content_sha256'
-%%% is the lowercase hex SHA-256 of the request body, carried in the
+%%% `ts' is milliseconds since the epoch (decimal ASCII); `nonce' is 16
+%%% random bytes (base64url, no padding) making every request distinct
+%%% even inside one millisecond; `target' is the path plus `?' and the raw
+%%% query string exactly as sent when there is one; `content_sha256' is
+%%% the lowercase hex SHA-256 of the request body, carried in the
 %%% `x-barrel-content-sha256' header so the verifier never reads the body
 %%% (streamed attachments can be large). The signature travels in an
-%%% `Authorization: Signature keyId="..",ts="..",sig="base64"' header.
+%%% `Authorization: Signature keyId="..",ts="..",nonce="..",sig="base64"'
+%%% header.
+%%%
+%%% v1 (no nonce, path only: `ts | keyId | METHOD | path | hash') is still
+%%% verified by verify/7 unless `require_nonce' is set, so a fleet rolls
+%%% servers first, then clients; the same-millisecond replay and the
+%%% unsigned query of v1 are why v2 exists.
 %%%
 %%% This mirrors the retired barrel_memory peer-auth scheme, fixing its
 %%% two weaknesses: the body is bound end to end (the handler re-hashes it
@@ -26,13 +35,14 @@
 -module(barrel_sync_sig).
 
 -export([content_sha256/1,
-         canonical/5,
-         sign/6,
+         canonical/5, canonical_v2/6,
+         target/2, new_nonce/0,
+         sign/6, sign/7, sign/8,
          parse_auth/1,
-         verify/6]).
+         verify/6, verify/7]).
 
 -type parsed() :: #{key_id := binary(), ts := integer(),
-                    sig := binary()}.
+                    sig := binary(), nonce => binary()}.
 -export_type([parsed/0]).
 
 %%====================================================================
@@ -55,8 +65,32 @@ canonical(TsBin, KeyId, Method, Path, ContentHashHex)
     <<TsBin/binary, "|", KeyId/binary, "|", Method/binary, "|",
       Path/binary, "|", ContentHashHex/binary>>.
 
-%% @doc Build the `Authorization: Signature ...' header value for a
-%% request. `PrivKey' is a 32-byte raw Ed25519 private key.
+%% @doc The v2 canonical signing string; `Target' comes from target/2.
+-spec canonical_v2(binary(), binary(), binary(), binary(), binary(),
+                   binary()) -> binary().
+canonical_v2(TsBin, KeyId, Nonce, Method, Target, ContentHashHex)
+        when is_binary(TsBin) ->
+    <<TsBin/binary, "|", KeyId/binary, "|", Nonce/binary, "|",
+      Method/binary, "|", Target/binary, "|", ContentHashHex/binary>>.
+
+%% @doc The signed target: the path, plus `?' and the raw query bytes as
+%% sent when the query is non-empty (`/p?' and `/p' sign the same).
+-spec target(binary(), binary()) -> binary().
+target(Path, <<>>) ->
+    Path;
+target(Path, Query) ->
+    <<Path/binary, "?", Query/binary>>.
+
+%% @doc A fresh per-request nonce (16 random bytes, base64url, no
+%% padding: safe inside the comma-separated header).
+-spec new_nonce() -> binary().
+new_nonce() ->
+    base64:encode(crypto:strong_rand_bytes(16),
+                  #{mode => urlsafe, padding => false}).
+
+%% @doc Build a v1 `Authorization: Signature ...' header value (no nonce,
+%% path only). Kept for callers that must talk to pre-v2 verifiers;
+%% new code uses sign/7. `PrivKey' is a 32-byte raw Ed25519 private key.
 -spec sign(binary(), binary(), binary(), binary(), binary(), integer()) ->
     binary().
 sign(KeyId, PrivKey, Method, Path, ContentHashHex, TsMs) ->
@@ -66,6 +100,27 @@ sign(KeyId, PrivKey, Method, Path, ContentHashHex, TsMs) ->
     SigB64 = base64:encode(Sig),
     <<"Signature keyId=\"", KeyId/binary, "\",ts=\"", TsBin/binary,
       "\",sig=\"", SigB64/binary, "\"">>.
+
+%% @doc Build a v2 header value with a fresh nonce. `Query' is the raw
+%% query string (`<<>>' when none).
+-spec sign(binary(), binary(), binary(), binary(), binary(), binary(),
+           integer()) -> binary().
+sign(KeyId, PrivKey, Method, Path, Query, ContentHashHex, TsMs) ->
+    sign(KeyId, PrivKey, Method, Path, Query, ContentHashHex, TsMs,
+         new_nonce()).
+
+%% @doc Build a v2 header value with an explicit nonce (tests, replay
+%% experiments).
+-spec sign(binary(), binary(), binary(), binary(), binary(), binary(),
+           integer(), binary()) -> binary().
+sign(KeyId, PrivKey, Method, Path, Query, ContentHashHex, TsMs, Nonce) ->
+    TsBin = integer_to_binary(TsMs),
+    Canonical = canonical_v2(TsBin, KeyId, Nonce, Method,
+                             target(Path, Query), ContentHashHex),
+    Sig = crypto:sign(eddsa, none, Canonical, [PrivKey, ed25519]),
+    SigB64 = base64:encode(Sig),
+    <<"Signature keyId=\"", KeyId/binary, "\",ts=\"", TsBin/binary,
+      "\",nonce=\"", Nonce/binary, "\",sig=\"", SigB64/binary, "\"">>.
 
 %% @doc Parse an `Authorization' header value. Returns `not_signature'
 %% for anything that is not the Signature scheme (e.g. Bearer), so the
@@ -78,19 +133,43 @@ parse_auth(<<"Signature ", Rest/binary>>) ->
 parse_auth(_Other) ->
     not_signature.
 
-%% @doc Verify a parsed signature against the configured signers and a
-%% skew window. Pure: replay is checked separately by the caller.
-%% `Signers' maps keyId to a 32-byte raw Ed25519 public key.
+%% @doc Verify a parsed v1 signature (path only) against the configured
+%% signers and a skew window. Pure: replay is checked separately by the
+%% caller. `Signers' maps keyId to a 32-byte raw Ed25519 public key.
 -spec verify(binary(), binary(), binary(), parsed(), map(), integer()) ->
     ok | {error, unknown_key | bad_signature | stale}.
 verify(Method, Path, ContentHashHex,
        #{key_id := KeyId, ts := TsMs, sig := Sig}, Signers, SkewMs) ->
+    TsBin = integer_to_binary(TsMs),
+    Canonical = canonical(TsBin, KeyId, Method, Path, ContentHashHex),
+    verify_canonical(KeyId, Canonical, Sig, Signers, SkewMs, TsMs).
+
+%% @doc Verify by version: a header with a nonce is checked over the v2
+%% canonical (path plus raw query), one without over v1, unless
+%% `require_nonce' rejects v1 before any crypto runs. Opts:
+%% `#{skew_ms := integer(), require_nonce => boolean()}'.
+-spec verify(binary(), binary(), binary(), binary(), parsed(), map(),
+             map()) ->
+    ok | {error, unknown_key | bad_signature | stale | nonce_required}.
+verify(Method, Path, Query, ContentHashHex,
+       #{nonce := Nonce, key_id := KeyId, ts := TsMs, sig := Sig},
+       Signers, #{skew_ms := SkewMs}) ->
+    TsBin = integer_to_binary(TsMs),
+    Canonical = canonical_v2(TsBin, KeyId, Nonce, Method,
+                             target(Path, Query), ContentHashHex),
+    verify_canonical(KeyId, Canonical, Sig, Signers, SkewMs, TsMs);
+verify(_Method, _Path, _Query, _ContentHashHex, _Parsed, _Signers,
+       #{require_nonce := true}) ->
+    {error, nonce_required};
+verify(Method, Path, _Query, ContentHashHex, Parsed, Signers,
+       #{skew_ms := SkewMs}) ->
+    verify(Method, Path, ContentHashHex, Parsed, Signers, SkewMs).
+
+verify_canonical(KeyId, Canonical, Sig, Signers, SkewMs, TsMs) ->
     case maps:get(KeyId, Signers, undefined) of
         undefined ->
             {error, unknown_key};
         PubKey ->
-            TsBin = integer_to_binary(TsMs),
-            Canonical = canonical(TsBin, KeyId, Method, Path, ContentHashHex),
             case crypto:verify(eddsa, none, Canonical, Sig,
                                [PubKey, ed25519]) of
                 true -> check_skew(TsMs, SkewMs);
@@ -116,10 +195,19 @@ parse_params(Bin) ->
         KeyId = maps:get(<<"keyId">>, Map),
         TsMs = binary_to_integer(maps:get(<<"ts">>, Map)),
         Sig = base64:decode(maps:get(<<"sig">>, Map)),
-        {ok, #{key_id => KeyId, ts => TsMs, sig => Sig}}
+        {ok, with_nonce(Map, #{key_id => KeyId, ts => TsMs, sig => Sig})}
     catch
         _:_ -> {error, malformed}
     end.
+
+%% A nonce must decode (base64url, no padding) to at least 8 bytes; the
+%% signed value is the encoded form.
+with_nonce(#{<<"nonce">> := Nonce}, Parsed) ->
+    Decoded = base64:decode(Nonce, #{mode => urlsafe, padding => false}),
+    true = byte_size(Decoded) >= 8,
+    Parsed#{nonce => Nonce};
+with_nonce(_Map, Parsed) ->
+    Parsed.
 
 %% `keyId="node1"' -> {<<"keyId">>, <<"node1">>}; tolerant of surrounding
 %% whitespace, strict about the quoted value.

--- a/apps/barrel_docdb/test/barrel_rep_SUITE.erl
+++ b/apps/barrel_docdb/test/barrel_rep_SUITE.erl
@@ -46,7 +46,8 @@ groups() ->
             replicate_with_updates,
             replicate_deleted_doc,
             replicate_checkpoint_persistence,
-            no_progress_seq_guard
+            no_progress_seq_guard,
+            checkpoint_unauthorized_returns_error
         ]},
         {filtered_replication, [sequence], [
             replicate_with_query_filter,
@@ -1172,4 +1173,23 @@ task_attachments_disabled_survives_restart(_Config) ->
                                              <<"f">>)),
     ok = barrel_rep_tasks:stop_task(TaskId),
     ok = barrel_rep_tasks:delete_task(TaskId),
+    ok.
+
+%% A checkpoint read refused by the peer (401 -> unauthorized) used to
+%% raise case_clause from add_checkpoint/6; it is an error now, naming
+%% the side that failed.
+checkpoint_unauthorized_returns_error(_Config) ->
+    Cp = barrel_rep_checkpoint:new(#{
+        id => <<"unauth-cp">>,
+        source => <<"test_source">>,
+        target => <<"remote">>,
+        source_transport => barrel_rep_transport_local,
+        target_transport => barrel_rep_unauth_transport}),
+    ?assertEqual({error, {checkpoint_failed, target, unauthorized}},
+                 barrel_rep_checkpoint:write_checkpoint(Cp)),
+    %% a run against that peer ends with an error, never a crash
+    ?assertMatch({error, _},
+                 barrel_rep:replicate(<<"test_source">>, <<"remote">>,
+                                      #{target_transport =>
+                                            barrel_rep_unauth_transport})),
     ok.

--- a/apps/barrel_docdb/test/barrel_rep_unauth_transport.erl
+++ b/apps/barrel_docdb/test/barrel_rep_unauth_transport.erl
@@ -1,0 +1,21 @@
+%%%-------------------------------------------------------------------
+%%% @doc A replication transport whose peer refuses every request with
+%%% `unauthorized' (what the HTTP transport returns on 401). Used to
+%%% prove checkpoint failures come back as errors, not crashes.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_rep_unauth_transport).
+
+-export([get_doc/3, put_version/5, diff_versions/2, get_changes/3,
+         get_local_doc/2, put_local_doc/3, delete_local_doc/2,
+         db_info/1, sync_hlc/2]).
+
+get_doc(_, _, _) -> {error, unauthorized}.
+put_version(_, _, _, _, _) -> {error, unauthorized}.
+diff_versions(_, _) -> {error, unauthorized}.
+get_changes(_, _, _) -> {error, unauthorized}.
+get_local_doc(_, _) -> {error, unauthorized}.
+put_local_doc(_, _, _) -> {error, unauthorized}.
+delete_local_doc(_, _) -> {error, unauthorized}.
+db_info(_) -> {error, unauthorized}.
+sync_hlc(_, _) -> {error, unauthorized}.

--- a/apps/barrel_docdb/test/barrel_sync_sig_tests.erl
+++ b/apps/barrel_docdb/test/barrel_sync_sig_tests.erl
@@ -86,3 +86,100 @@ content_sha256_test() ->
     ?assertEqual(
         <<"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855">>,
         barrel_sync_sig:content_sha256(<<>>)).
+
+%%====================================================================
+%% Signature v2: nonce + signed target (path plus raw query)
+%%====================================================================
+
+-define(QUERY, <<"since=first&limit=1">>).
+-define(OPTS, #{skew_ms => 300000}).
+
+v2_roundtrip_query_test() ->
+    {Pub, Priv} = keypair(),
+    KeyId = <<"node1">>,
+    Signers = #{KeyId => Pub},
+    CH = barrel_sync_sig:content_sha256(<<>>),
+    Ts = erlang:system_time(millisecond),
+    Auth = barrel_sync_sig:sign(KeyId, Priv, <<"GET">>, ?PATH, ?QUERY, CH,
+                                Ts),
+    {ok, #{nonce := _} = Parsed} = barrel_sync_sig:parse_auth(Auth),
+    ?assertEqual(ok, barrel_sync_sig:verify(<<"GET">>, ?PATH, ?QUERY, CH,
+                                            Parsed, Signers, ?OPTS)),
+    %% an altered query no longer verifies
+    ?assertEqual({error, bad_signature},
+                 barrel_sync_sig:verify(<<"GET">>, ?PATH,
+                                        <<"since=first&limit=2">>, CH,
+                                        Parsed, Signers, ?OPTS)),
+    %% a v1 verifier (path only) cannot accept a v2 header
+    ?assertEqual({error, bad_signature},
+                 barrel_sync_sig:verify(<<"GET">>, ?PATH, CH, Parsed,
+                                        Signers, 300000)).
+
+v2_no_query_test() ->
+    {Pub, Priv} = keypair(),
+    KeyId = <<"node1">>,
+    Signers = #{KeyId => Pub},
+    CH = barrel_sync_sig:content_sha256(<<"{}">>),
+    Ts = erlang:system_time(millisecond),
+    Auth = barrel_sync_sig:sign(KeyId, Priv, ?METHOD, ?PATH, <<>>, CH, Ts),
+    {ok, Parsed} = barrel_sync_sig:parse_auth(Auth),
+    ?assertEqual(ok, barrel_sync_sig:verify(?METHOD, ?PATH, <<>>, CH,
+                                            Parsed, Signers, ?OPTS)),
+    %% `/p?' and `/p' sign the same target
+    ?assertEqual(?PATH, barrel_sync_sig:target(?PATH, <<>>)),
+    ?assertEqual(<<?PATH/binary, "?a=1">>,
+                 barrel_sync_sig:target(?PATH, <<"a=1">>)).
+
+%% The whole point: two requests in the same millisecond differ.
+v2_same_ms_distinct_test() ->
+    {_Pub, Priv} = keypair(),
+    CH = barrel_sync_sig:content_sha256(<<>>),
+    Ts = erlang:system_time(millisecond),
+    A = barrel_sync_sig:sign(<<"k">>, Priv, <<"GET">>, ?PATH, <<>>, CH, Ts),
+    B = barrel_sync_sig:sign(<<"k">>, Priv, <<"GET">>, ?PATH, <<>>, CH, Ts),
+    ?assertNotEqual(A, B),
+    %% v1 was byte-identical in that situation
+    ?assertEqual(barrel_sync_sig:sign(<<"k">>, Priv, <<"GET">>, ?PATH, CH, Ts),
+                 barrel_sync_sig:sign(<<"k">>, Priv, <<"GET">>, ?PATH, CH, Ts)).
+
+nonce_tamper_test() ->
+    {Pub, Priv} = keypair(),
+    KeyId = <<"node1">>,
+    Signers = #{KeyId => Pub},
+    CH = barrel_sync_sig:content_sha256(<<>>),
+    Ts = erlang:system_time(millisecond),
+    Auth = barrel_sync_sig:sign(KeyId, Priv, <<"GET">>, ?PATH, <<>>, CH, Ts,
+                                barrel_sync_sig:new_nonce()),
+    {ok, Parsed} = barrel_sync_sig:parse_auth(Auth),
+    Swapped = Parsed#{nonce => barrel_sync_sig:new_nonce()},
+    ?assertEqual({error, bad_signature},
+                 barrel_sync_sig:verify(<<"GET">>, ?PATH, <<>>, CH, Swapped,
+                                        Signers, ?OPTS)).
+
+malformed_nonce_test() ->
+    Sig = base64:encode(<<0:512>>),
+    Bad = <<"Signature keyId=\"k\",ts=\"1\",nonce=\"!!!\",sig=\"",
+            Sig/binary, "\"">>,
+    ?assertEqual({error, malformed}, barrel_sync_sig:parse_auth(Bad)),
+    %% decodes, but to fewer than 8 bytes
+    Short = <<"Signature keyId=\"k\",ts=\"1\",nonce=\"AAAA\",sig=\"",
+              Sig/binary, "\"">>,
+    ?assertEqual({error, malformed}, barrel_sync_sig:parse_auth(Short)).
+
+%% v1 headers keep verifying through verify/7 until require_nonce.
+v1_through_verify7_test() ->
+    {Pub, Priv} = keypair(),
+    KeyId = <<"node1">>,
+    Signers = #{KeyId => Pub},
+    CH = barrel_sync_sig:content_sha256(<<>>),
+    Ts = erlang:system_time(millisecond),
+    Auth = barrel_sync_sig:sign(KeyId, Priv, ?METHOD, ?PATH, CH, Ts),
+    {ok, Parsed} = barrel_sync_sig:parse_auth(Auth),
+    ?assertNot(maps:is_key(nonce, Parsed)),
+    ?assertEqual(ok, barrel_sync_sig:verify(?METHOD, ?PATH, <<>>, CH,
+                                            Parsed, Signers, ?OPTS)),
+    ?assertEqual({error, nonce_required},
+                 barrel_sync_sig:verify(?METHOD, ?PATH, <<>>, CH, Parsed,
+                                        Signers,
+                                        #{skew_ms => 300000,
+                                          require_nonce => true})).

--- a/apps/barrel_embed/CHANGELOG.md
+++ b/apps/barrel_embed/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.4.0] - 2026-08-26
+
+### Added
+- `managed_venv` app env (default true). Set it to `false` to skip the managed-venv bootstrap at application start: nothing is created or checked, `managed_venv_path` stays unset, and providers use their own `python`. For deployments that ship an interpreter with the libraries installed (and images without `python3-venv`, which logged a warning on every boot).
+
 ## [2.3.2] - 2026-08-23
 
 ### Fixed

--- a/apps/barrel_embed/README.md
+++ b/apps/barrel_embed/README.md
@@ -226,10 +226,17 @@ location in `sys.config`:
 %% sys.config
 [
     {barrel_embed, [
-        {venv_dir, "/path/to/.venv"}  %% Optional: custom venv location
+        {venv_dir, "/path/to/.venv"},  %% Optional: custom venv location
+        {managed_venv, false}          %% Optional: skip the bootstrap
     ]}
 ].
 ```
+
+Set `managed_venv` to `false` when the deployment supplies its own
+interpreter with the model libraries installed (each provider's `python`
+option): the venv is neither created nor checked at start, so an image
+without `python3-venv` boots silently. Installing `python3-venv` just to
+silence the warning would create an empty venv nothing uses.
 
 ## Python Setup
 

--- a/apps/barrel_embed/docs/venv-setup.md
+++ b/apps/barrel_embed/docs/venv-setup.md
@@ -61,6 +61,18 @@ Set a custom venv path via application config:
 ]}.
 ```
 
+## Bringing your own interpreter
+
+If the image already has an interpreter with the provider libraries
+installed, skip the managed venv entirely and point each provider at it:
+
+```erlang
+{barrel_embed, [{managed_venv, false}]}.
+%% then per provider: #{python => "/usr/bin/python3", ...}
+```
+
+Nothing is created or checked at application start.
+
 ## Provider Dependencies
 
 | Provider | Packages | Size |

--- a/apps/barrel_embed/src/barrel_embed.app.src
+++ b/apps/barrel_embed/src/barrel_embed.app.src
@@ -1,6 +1,6 @@
 {application, barrel_embed,
  [{description, "Lightweight embedding generation for Erlang"},
-  {vsn, "2.3.2"},
+  {vsn, "2.4.0"},
   {registered, []},
   {mod, {barrel_embed_app, []}},
   {applications,

--- a/apps/barrel_embed/src/barrel_embed_app.erl
+++ b/apps/barrel_embed/src/barrel_embed_app.erl
@@ -13,10 +13,13 @@
 %%====================================================================
 
 start(_StartType, _StartArgs) ->
-    %% Ensure managed venv exists
-    case barrel_embed_venv:ensure_venv() of
+    %% Managed venv bootstrap (opt out with managed_venv => false)
+    case barrel_embed_venv:bootstrap() of
         {ok, VenvPath} ->
             error_logger:info_msg("barrel_embed: using venv at ~s~n", [VenvPath]);
+        skipped ->
+            error_logger:info_msg(
+                "barrel_embed: managed venv disabled by config~n");
         {error, Reason} ->
             error_logger:warning_msg(
                 "barrel_embed: failed to create managed venv: ~p~n"

--- a/apps/barrel_embed/src/barrel_embed_venv.erl
+++ b/apps/barrel_embed/src/barrel_embed_venv.erl
@@ -25,6 +25,7 @@
 
 -export([
     ensure_venv/0,
+    bootstrap/0,
     create_venv/0,
     install_deps/1,
     refresh/0,
@@ -46,6 +47,16 @@ venv_path() ->
     case application:get_env(barrel_embed, venv_dir) of
         {ok, Path} -> Path;
         undefined -> default_venv_path()
+    end.
+
+%% @doc The application-start bootstrap: ensure_venv/0 unless the
+%% `managed_venv' app env is false, in which case nothing is touched and
+%% `managed_venv_path' stays unset (providers use their own `python').
+-spec bootstrap() -> {ok, string()} | skipped | {error, term()}.
+bootstrap() ->
+    case application:get_env(barrel_embed, managed_venv, true) of
+        false -> skipped;
+        _ -> ensure_venv()
     end.
 
 %% @doc Ensure venv exists and is valid.

--- a/apps/barrel_embed/test/barrel_embed_venv_tests.erl
+++ b/apps/barrel_embed/test/barrel_embed_venv_tests.erl
@@ -338,3 +338,25 @@ run_cmd_trapping(Cmd, Timeout) ->
     after 15000 ->
         error(run_cmd_test_timeout)
     end.
+
+%%====================================================================
+%% Bootstrap opt-out (managed_venv => false): no Python needed
+%%====================================================================
+
+bootstrap_opt_out_test() ->
+    Saved = application:get_env(barrel_embed, managed_venv),
+    SavedPath = application:get_env(barrel_embed, managed_venv_path),
+    application:unset_env(barrel_embed, managed_venv_path),
+    application:set_env(barrel_embed, managed_venv, false),
+    try
+        ?assertEqual(skipped, barrel_embed_venv:bootstrap()),
+        %% nothing was bootstrapped: providers fall back to their python
+        ?assertEqual(undefined,
+                     application:get_env(barrel_embed, managed_venv_path))
+    after
+        restore_env(managed_venv, Saved),
+        restore_env(managed_venv_path, SavedPath)
+    end.
+
+restore_env(Key, undefined) -> application:unset_env(barrel_embed, Key);
+restore_env(Key, {ok, V}) -> application:set_env(barrel_embed, Key, V).

--- a/apps/barrel_server/CHANGELOG.md
+++ b/apps/barrel_server/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.6.0] - 2026-08-26
+
+### Added
+- Signed-request verification accepts signature v2 (per-request nonce, path plus raw query string signed) next to v1. New auth option `require_nonce => true` rejects v1 once the fleet has rolled; v1 acceptances log at debug level so you can tell when that is. Upgrade servers before clients: a v2 client against a 1.5.x server is refused.
+
+### Changed
+- mTLS is documented for what it is: a transport gate that authenticates the CA a client certificate chains to, not the peer. Identity and per-database rights come from bearer or signed auth layered on top.
+
 ## [1.5.0] - 2026-08-15
 
 ### Fixed

--- a/apps/barrel_server/src/barrel_server.app.src
+++ b/apps/barrel_server/src/barrel_server.app.src
@@ -1,6 +1,6 @@
 {application, barrel_server, [
     {description, "Multi-protocol server for the barrel edge database (REST/JSON over livery)"},
-    {vsn, "1.5.0"},
+    {vsn, "1.6.0"},
     {registered, [barrel_server_sup]},
     {mod, {barrel_server_app, []}},
     {applications, [

--- a/apps/barrel_server/src/barrel_server_auth.erl
+++ b/apps/barrel_server/src/barrel_server_auth.erl
@@ -52,16 +52,18 @@ state_from_env() ->
 
 %% Legacy bearer-only config: byte-for-byte the previous behavior.
 legacy_state(#{tokens := Tokens}) when is_list(Tokens), Tokens =/= [] ->
-    base_state([crypto:hash(sha256, T) || T <- Tokens], #{}, [bearer], 300000);
+    base_state([crypto:hash(sha256, T) || T <- Tokens], #{}, [bearer],
+               300000, false);
 legacy_state(#{token := Token}) when is_binary(Token) ->
-    base_state([crypto:hash(sha256, Token)], #{}, [bearer], 300000);
+    base_state([crypto:hash(sha256, Token)], #{}, [bearer], 300000, false);
 legacy_state(Other) ->
     logger:warning("ignoring invalid barrel_server auth config: ~p", [Other]),
     undefined.
 
-%% New-style config: accept => [bearer|signed|mtls], optional signers and
-%% skew. Unknown accept methods are dropped; an empty accept locks the
-%% server (every request 401s) rather than falling open.
+%% New-style config: accept => [bearer|signed|mtls], optional signers,
+%% skew, and `require_nonce' (reject v1 signed requests once every client
+%% sends v2). Unknown accept methods are dropped; an empty accept locks
+%% the server (every request 401s) rather than falling open.
 multi_state(Cfg) ->
     Accept0 = [M || M <- maps:get(accept, Cfg, [bearer]),
                     lists:member(M, [bearer, signed, mtls])],
@@ -69,7 +71,8 @@ multi_state(Cfg) ->
     Hashes = token_hashes(Cfg),
     Signers = maps:get(signers, Cfg, #{}),
     SkewMs = maps:get(skew_ms, Cfg, 300000),
-    base_state(Hashes, Signers, Accept, SkewMs).
+    RequireNonce = maps:get(require_nonce, Cfg, false) =:= true,
+    base_state(Hashes, Signers, Accept, SkewMs, RequireNonce).
 
 %% mtls_ok trusts that a TLS connection carries a verified client cert,
 %% which only holds when the listener actually gates on it. If mtls is
@@ -99,9 +102,10 @@ token_hashes(#{token := Token}) when is_binary(Token) ->
 token_hashes(_) ->
     [].
 
-base_state(Hashes, Signers, Accept, SkewMs) ->
+base_state(Hashes, Signers, Accept, SkewMs, RequireNonce) ->
     #{hashes => Hashes, signers => Signers,
-      accept => Accept, skew_ms => SkewMs}.
+      accept => Accept, skew_ms => SkewMs,
+      require_nonce => RequireNonce}.
 
 %% @doc The configured token hashes (undefined = open server). The
 %% MCP auth provider checks server bearers against the same set.
@@ -147,17 +151,24 @@ authorized(Req, #{accept := Accept} = State) ->
 %% Ed25519 signed request: verify the signature, then consume it against
 %% the replay cache. Any failure (no header, unknown key, bad signature,
 %% stale timestamp, replay, or cache down) is a decline.
-try_signed(Req, #{signers := Signers, skew_ms := SkewMs}) ->
+try_signed(Req, #{signers := Signers, skew_ms := SkewMs} = State) ->
     case barrel_sync_sig:parse_auth(
              livery_req:header(<<"authorization">>, Req, undefined)) of
         {ok, #{key_id := KeyId, ts := Ts, sig := Sig} = Parsed} ->
             Method = livery_req:method(Req),
             Path = livery_req:path(Req),
+            %% raw query bytes as sent: part of the v2 signed target
+            Query = livery_req:query(Req),
             ContentHash = livery_req:header(<<"x-barrel-content-sha256">>,
                                             Req, <<>>),
-            case barrel_sync_sig:verify(Method, Path, ContentHash,
-                                          Parsed, Signers, SkewMs) of
+            Opts = #{skew_ms => SkewMs,
+                     require_nonce => maps:get(require_nonce, State, false)},
+            case barrel_sync_sig:verify(Method, Path, Query, ContentHash,
+                                          Parsed, Signers, Opts) of
                 ok ->
+                    log_v1(Parsed, KeyId),
+                    %% Ed25519 is deterministic and the nonce is inside
+                    %% the signed string, so the sig alone keys replays
                     barrel_server_sig_cache:check_and_insert(
                         {KeyId, Ts, Sig}, 2 * SkewMs) =:= ok;
                 {error, _} ->
@@ -166,6 +177,14 @@ try_signed(Req, #{signers := Signers, skew_ms := SkewMs}) ->
         _ ->
             false
     end.
+
+%% v1 (no nonce) acceptances at debug: shows when a fleet has rolled and
+%% `require_nonce' can be turned on.
+log_v1(#{nonce := _}, _KeyId) ->
+    ok;
+log_v1(_Parsed, KeyId) ->
+    logger:debug("barrel_server: accepted v1 signed request from ~s",
+                 [KeyId]).
 
 %% Constant-time global bearer check (bsp_ tokens never reach here).
 try_bearer(Req, #{hashes := Hashes}) ->
@@ -180,8 +199,10 @@ try_bearer(Req, #{hashes := Hashes}) ->
 
 %% mTLS transport gate: a request that arrived over TLS is authenticated,
 %% relying on the listener's `fail_if_no_peer_cert' so arrival implies a
-%% verified client cert. H1-TLS surfaces `tls => #{}'; H2/H3 surface no
-%% tls today (see the companion livery change), so this is H1-only.
+%% verified client cert. This authenticates the CA, not the peer: livery
+%% surfaces `tls => #{}' with no certificate details, so per-peer
+%% identity and rights come from bearer or signed auth layered on top.
+%% H1-TLS surfaces the marker; H2/H3 do not on livery 0.6, so H1-only.
 mtls_ok(Req) ->
     livery_req:tls(Req) =/= undefined.
 

--- a/apps/barrel_server/test/barrel_server_signed_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_signed_SUITE.erl
@@ -18,7 +18,12 @@
     t_unknown_key_rejected/1,
     t_stale_rejected/1,
     t_replay_rejected/1,
-    t_tampered_body_rejected/1
+    t_tampered_body_rejected/1,
+    t_same_ms_distinct_nonce_accepted/1,
+    t_query_tamper_rejected/1,
+    t_legacy_v1_accepted/1,
+    t_legacy_rejected_when_required/1,
+    t_replication_over_signed/1
 ]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -31,23 +36,27 @@
 all() ->
     [t_bearer_authenticates, t_signed_authenticates, t_no_auth_rejected,
      t_unknown_key_rejected, t_stale_rejected, t_replay_rejected,
-     t_tampered_body_rejected].
+     t_tampered_body_rejected, t_same_ms_distinct_nonce_accepted,
+     t_query_tamper_rejected, t_legacy_v1_accepted,
+     t_legacy_rejected_when_required, t_replication_over_signed].
 
 init_per_suite(Config) ->
     {Pub, Priv} = crypto:generate_key(eddsa, ed25519),
     application:load(barrel_server),
     application:set_env(barrel_server, data_dir, ?config(priv_dir, Config)),
     application:set_env(barrel_server, http_port, 0),
-    application:set_env(barrel_server, auth,
-                        #{accept => [bearer, signed],
-                          tokens => [?TOKEN],
-                          signers => #{?KEYID => Pub},
-                          skew_ms => 300000}),
+    application:set_env(barrel_server, auth, auth_env(Pub)),
     {ok, _} = application:ensure_all_started(barrel_server),
     {ok, _} = application:ensure_all_started(hackney),
     Base = "http://127.0.0.1:" ++ integer_to_list(discover_port()),
     {201, _} = send(put, Base, <<"/db/", ?DB, "">>, bearer(), <<>>),
-    [{base, Base}, {priv, Priv} | Config].
+    [{base, Base}, {priv, Priv}, {pub, Pub} | Config].
+
+auth_env(Pub) ->
+    #{accept => [bearer, signed],
+      tokens => [?TOKEN],
+      signers => #{?KEYID => Pub},
+      skew_ms => 300000}.
 
 end_per_suite(_Config) ->
     application:stop(barrel_server),
@@ -58,25 +67,25 @@ end_per_suite(_Config) ->
 %% Cases
 %%====================================================================
 
-t_bearer_authenticates(Config) ->
-    B = ?config(base, Config),
+t_bearer_authenticates(_Config) ->
+    B = current_base(),
     {200, _} = send(get, B, <<"/db/", ?DB, "">>, bearer(), <<>>),
     ok.
 
 t_signed_authenticates(Config) ->
-    B = ?config(base, Config),
+    B = current_base(),
     H = build_signed(get, <<"/db/", ?DB, "">>, <<>>, ?config(priv, Config),
                      now_ms()),
     {200, _} = send(get, B, <<"/db/", ?DB, "">>, H, <<>>),
     ok.
 
-t_no_auth_rejected(Config) ->
-    B = ?config(base, Config),
+t_no_auth_rejected(_Config) ->
+    B = current_base(),
     {401, _} = send(get, B, <<"/db/", ?DB, "">>, [], <<>>),
     ok.
 
-t_unknown_key_rejected(Config) ->
-    B = ?config(base, Config),
+t_unknown_key_rejected(_Config) ->
+    B = current_base(),
     {_OtherPub, OtherPriv} = crypto:generate_key(eddsa, ed25519),
     %% a key the server does not know, even though the signature is valid
     H = build_signed_as(<<"ghost">>, get, <<"/db/", ?DB, "">>, <<>>,
@@ -85,7 +94,7 @@ t_unknown_key_rejected(Config) ->
     ok.
 
 t_stale_rejected(Config) ->
-    B = ?config(base, Config),
+    B = current_base(),
     H = build_signed(get, <<"/db/", ?DB, "">>, <<>>, ?config(priv, Config),
                      now_ms() - 600000),
     {401, _} = send(get, B, <<"/db/", ?DB, "">>, H, <<>>),
@@ -93,7 +102,7 @@ t_stale_rejected(Config) ->
 
 %% A byte-identical signed request replayed within the window is refused.
 t_replay_rejected(Config) ->
-    B = ?config(base, Config),
+    B = current_base(),
     Path = <<"/db/", ?DB, "/_sync/info">>,
     H = build_signed(get, Path, <<>>, ?config(priv, Config), now_ms()),
     {200, _} = send(get, B, Path, H, <<>>),
@@ -104,7 +113,7 @@ t_replay_rejected(Config) ->
 %% not hash to it: the handler rejects. Tampering the header instead would
 %% break the signature (401); tampering the body alone is 400.
 t_tampered_body_rejected(Config) ->
-    B = ?config(base, Config),
+    B = current_base(),
     Path = <<"/db/", ?DB, "/_sync/changes">>,
     Signed = <<"{\"since\":\"first\"}">>,
     Sent = <<"{\"since\":\"tampered\"}">>,
@@ -112,9 +121,111 @@ t_tampered_body_rejected(Config) ->
     {400, _} = send(post, B, Path, H, Sent),
     ok.
 
+%% Two v2 requests in the same millisecond carry different nonces, so
+%% neither is mistaken for a replay of the other (the v1 bug).
+t_same_ms_distinct_nonce_accepted(Config) ->
+    B = current_base(),
+    Path = <<"/db/", ?DB, "/_sync/info">>,
+    Ts = now_ms(),
+    H1 = build_signed(get, Path, <<>>, ?config(priv, Config), Ts),
+    H2 = build_signed(get, Path, <<>>, ?config(priv, Config), Ts),
+    {200, _} = send(get, B, Path, H1, <<>>),
+    {200, _} = send(get, B, Path, H2, <<>>),
+    ok.
+
+%% The query string is part of the signed target: altering it 401s.
+t_query_tamper_rejected(Config) ->
+    B = current_base(),
+    Path = <<"/db/", ?DB, "/_sync/att_changes">>,
+    H = build_signed_q(get, Path, <<"since=first&limit=1">>, <<>>,
+                       ?config(priv, Config), now_ms()),
+    {401, _} = send(get, B, <<Path/binary, "?since=first&limit=2">>, H,
+                    <<>>),
+    H2 = build_signed_q(get, Path, <<"since=first&limit=1">>, <<>>,
+                        ?config(priv, Config), now_ms()),
+    {200, _} = send(get, B, <<Path/binary, "?since=first&limit=1">>, H2,
+                    <<>>),
+    ok.
+
+%% A pre-v2 client (no nonce, path only) still authenticates by default.
+t_legacy_v1_accepted(Config) ->
+    B = current_base(),
+    Path = <<"/db/", ?DB, "">>,
+    CH = barrel_sync_sig:content_sha256(<<>>),
+    Auth = barrel_sync_sig:sign(?KEYID, ?config(priv, Config), <<"GET">>,
+                                Path, CH, now_ms()),
+    H = [{<<"authorization">>, Auth}, {<<"x-barrel-content-sha256">>, CH}],
+    {200, _} = send(get, B, Path, H, <<>>),
+    ok.
+
+%% With require_nonce the v1 form is refused and v2 keeps working.
+t_legacy_rejected_when_required(Config) ->
+    Pub = ?config(pub, Config),
+    B = restart_with_auth((auth_env(Pub))#{require_nonce => true}),
+    try
+        Path = <<"/db/", ?DB, "">>,
+        CH = barrel_sync_sig:content_sha256(<<>>),
+        V1 = barrel_sync_sig:sign(?KEYID, ?config(priv, Config), <<"GET">>,
+                                  Path, CH, now_ms()),
+        {401, _} = send(get, B, Path,
+                        [{<<"authorization">>, V1},
+                         {<<"x-barrel-content-sha256">>, CH}], <<>>),
+        H = build_signed(get, Path, <<>>, ?config(priv, Config), now_ms()),
+        {200, _} = send(get, B, Path, H, <<>>)
+    after
+        _ = restart_with_auth(auth_env(Pub))
+    end,
+    ok.
+
+%% The original failure: replication repeats identical requests back to
+%% back; over signed auth every run must complete.
+t_replication_over_signed(Config) ->
+    B = current_base(),
+    Local = <<"signed_rep_local">>,
+    {ok, _} = barrel_docdb:create_db(Local, #{
+        data_dir => filename:join(?config(priv_dir, Config), "signed_local")
+    }),
+    try
+        lists:foreach(
+            fun(I) ->
+                {ok, _} = barrel_docdb:put_doc(Local, #{
+                    <<"id">> => <<"d", (integer_to_binary(I))/binary>>,
+                    <<"n">> => I})
+            end, lists:seq(1, 5)),
+        Endpoint0 = barrel_rep_transport_http:endpoint(
+            list_to_binary(B ++ "/db/" ++ ?DB)),
+        Endpoint = Endpoint0#{signing => #{key_id => ?KEYID,
+                                           priv_key => ?config(priv, Config)}},
+        lists:foreach(
+            fun(_) ->
+                {ok, #{ok := true}} = barrel_rep:replicate(
+                    Local, Endpoint,
+                    #{target_transport => barrel_rep_transport_http})
+            end, lists:seq(1, 5)),
+        H = build_signed(get, <<"/db/", ?DB, "/doc/d5">>, <<>>,
+                         ?config(priv, Config), now_ms()),
+        {200, _} = send(get, B, <<"/db/", ?DB, "/doc/d5">>, H, <<>>)
+    after
+        try barrel_docdb:delete_db(Local) catch _:_ -> ok end
+    end,
+    ok.
+
 %%====================================================================
 %% Helpers
 %%====================================================================
+
+%% The live base URL: a case may have restarted the server on another
+%% ephemeral port, so never trust the one captured at suite init.
+current_base() ->
+    "http://127.0.0.1:" ++ integer_to_list(discover_port()).
+
+%% Stop and restart barrel_server with another auth config; returns the
+%% new base URL (the port is ephemeral).
+restart_with_auth(Auth) ->
+    ok = application:stop(barrel_server),
+    application:set_env(barrel_server, auth, Auth),
+    {ok, _} = application:ensure_all_started(barrel_server),
+    "http://127.0.0.1:" ++ integer_to_list(discover_port()).
 
 now_ms() -> erlang:system_time(millisecond).
 
@@ -123,9 +234,17 @@ bearer() -> [{<<"authorization">>, <<"Bearer ", ?TOKEN/binary>>}].
 build_signed(Method, Path, SignBody, Priv, Ts) ->
     build_signed_as(?KEYID, Method, Path, SignBody, Priv, Ts).
 
+build_signed_q(Method, Path, Query, SignBody, Priv, Ts) ->
+    build_signed_as(?KEYID, Method, Path, Query, SignBody, Priv, Ts).
+
 build_signed_as(KeyId, Method, Path, SignBody, Priv, Ts) ->
+    build_signed_as(KeyId, Method, Path, <<>>, SignBody, Priv, Ts).
+
+%% v2 header: nonce, path plus raw query signed
+build_signed_as(KeyId, Method, Path, Query, SignBody, Priv, Ts) ->
     CH = barrel_sync_sig:content_sha256(SignBody),
-    Auth = barrel_sync_sig:sign(KeyId, Priv, method_bin(Method), Path, CH, Ts),
+    Auth = barrel_sync_sig:sign(KeyId, Priv, method_bin(Method), Path, Query,
+                                CH, Ts),
     [{<<"authorization">>, Auth},
      {<<"x-barrel-content-sha256">>, CH},
      {<<"content-type">>, <<"application/json">>}].

--- a/docs/guides/synchronization.md
+++ b/docs/guides/synchronization.md
@@ -94,10 +94,12 @@ application:set_env(barrel_docdb, sync_auth,
 
 Bearer tokens replay without TLS. For per-request Ed25519 authentication, add
 `accept` (the list of accepted methods) and `signers` (keyId to 32-byte raw
-public key). Each request is signed over `ts|keyId|method|path|sha256(body)`,
-with replay protection and a skew window. `accept => [bearer, signed]` accepts
-both, so a fleet rolls over node by node; `accept => [bearer]` (or no `accept`)
-is exactly the bearer-only behavior above.
+public key). Each request is signed over
+`ts|keyId|nonce|METHOD|target|sha256(body)`, where `nonce` is fresh per
+request and `target` is the path plus `?` and the raw query string when there
+is one (signature v2), with replay protection and a skew window.
+`accept => [bearer, signed]` accepts both, so a fleet rolls over node by node;
+`accept => [bearer]` (or no `accept`) is exactly the bearer-only behavior above.
 
 ```erlang
 %% server: know each peer's public key
@@ -117,6 +119,21 @@ application:set_env(barrel_docdb, sync_signing,
 Generate a key pair with `crypto:generate_key(eddsa, ed25519)`. Signing takes
 precedence over a bearer token on the same endpoint. Private keys are never
 written into persisted task configs.
+
+Rolling from signature v1 (barrel_docdb < 1.4.0, no nonce, path only) to v2:
+servers on barrel_server 1.6.0+ accept both, so upgrade every server first,
+then the clients, which send v2 only (a v2 client against an older server is
+refused with 401 on every signed request). Once no client sends v1 (v1
+acceptances log at debug level), close the v1 window:
+
+```erlang
+application:set_env(barrel_server, auth,
+                    #{accept => [signed], signers => Signers,
+                      require_nonce => true}).
+```
+
+A reverse proxy in front of the sync endpoint must forward the path and the
+query string unmodified: the query is part of the signed target.
 
 ## How (TLS and mTLS)
 
@@ -144,8 +161,15 @@ Mtls = Endpoint#{ssl_options => [{certfile, "client.pem"},
 
 Notes: H1-TLS and H2 are full mTLS gates (OTP `ssl`). H3 serves over TLS but is
 not yet a client-cert gate (a QUIC-level change is pending); do not rely on H3
-for mTLS. Mapping a client cert to an identity/allowed-db needs a livery change
-and is not available yet.
+for mTLS.
+
+What mTLS authenticates: that the client holds a certificate chaining to the
+configured CA, not which client it is. `accept => [mtls]` alone treats every
+such client as one trusted peer with access to every database. For identity
+and per-database rights, layer bearer or signed auth on top
+(`accept => [mtls, signed]` gates the transport and identifies the peer by its
+signing key). Mapping a client certificate to an identity needs livery to
+surface the peer certificate, which it does not yet.
 
 ## How (selective replication)
 


### PR DESCRIPTION
Found while porting barrel_memory onto barrel (items 1 to 4 of the outstanding brief; the livery/barrel_mcp move follows separately).

- Signature v2: the `Authorization: Signature` header carries a per-request `nonce`, and the signed string is `ts|keyId|nonce|METHOD|target|sha256` with `target` = path plus `?` and the raw query when there is one. Fixes two identical requests in one millisecond being refused as a replay (replication repeats `_sync/info` and checkpoint reads back to back, so about half the runs over `accept => [signed]` failed) and the query string being unauthenticated. The replay cache key is unchanged: Ed25519 is deterministic and the nonce sits inside the signed string.
- Rollover: servers 1.6.0+ verify v1 and v2; upgrade servers first, then clients (barrel_docdb 1.4.0 sends v2 only; against a 1.5.x server it gets 401). Once no client sends v1 (v1 acceptances log at debug), set `require_nonce => true`. Reverse proxies must forward path and query unmodified. Bearer, capability, mTLS and barrel-lite are untouched.
- Checkpoint writes that fail (an `unauthorized` peer, for instance) now return `{error, {checkpoint_failed, source | target, Reason}}` and end the run with it, instead of raising `case_clause`; both sides are still written.
- `barrel_embed`: `managed_venv => false` skips the venv bootstrap at start for deployments that ship their own interpreter (no more warning on every boot in images without `python3-venv`).
- mTLS documented as a transport gate that authenticates the CA, not the peer; layer bearer or signed auth for identity.

Versions: barrel_docdb 1.4.0, barrel_server 1.6.0, barrel_embed 2.4.0.

Green on OTP 29 and 28: eunit 681 (+ 7 new sync_sig cases, venv opt-out), ct 885, server ct 1026 (5 new signed cases incl. five back-to-back replication runs over signed auth, same-ms distinct nonces, query tamper, v1 accept and require_nonce), xref and dialyzer at the pre-existing baselines. One pre-existing OTP 29-only failure in `barrel_server_att_SUITE:t_push_large_blob` reproduces on the unmodified tree and is unrelated.