### PR TITLE
barrel_server 1.7.0: livery 0.9.1 and barrel_mcp 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the Barrel umbrella are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and each app
 is versioned independently under [Semantic Versioning](https://semver.org/).
 
+## [2026-08-30] barrel_server on livery 0.9.1 and barrel_mcp 3.0.1
+
+The server pinned livery 0.6.1 and barrel_mcp 2.3.0 while consumers ran
+ahead of both; moving it forward removes the skew and lets the standalone
+server serve MCP protocol 2026-07-28. The one break was in the suites
+(`livery:which_listeners/1` returns port lists since 0.8.0). barrel_mcp 3.0
+seals multi round-trip request state with an HMAC key that must be shared
+across a fleet; the server exposes it as configuration.
+
+| App | Version | Change |
+|-----|---------|--------|
+| barrel_server | 1.7.0 | livery 0.9.1, barrel_mcp 3.0.1, `request_state_key` config |
+
 ## [2026-08-26] Signed sync requests v2, checkpoint errors, venv opt-out
 
 Found while porting barrel_memory onto barrel. Two identical signed requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ is versioned independently under [Semantic Versioning](https://semver.org/).
 The server pinned livery 0.6.1 and barrel_mcp 2.3.0 while consumers ran
 ahead of both; moving it forward removes the skew and lets the standalone
 server serve MCP protocol 2026-07-28. The one break was in the suites
-(`livery:which_listeners/1` returns port lists since 0.8.0). barrel_mcp 3.0
+(`livery:which_listeners/1` returns port lists since 0.8.0), and livery
+0.9.2 brings the h1 fix for chunked uploads split between CR and LF. barrel_mcp 3.0
 seals multi round-trip request state with an HMAC key that must be shared
 across a fleet; the server exposes it as configuration.
 
 | App | Version | Change |
 |-----|---------|--------|
-| barrel_server | 1.7.0 | livery 0.9.1, barrel_mcp 3.0.1, `request_state_key` config |
+| barrel_server | 1.7.0 | livery 0.9.2 (h1 0.9.1 chunked-upload fix), barrel_mcp 3.0.1, `request_state_key` config |
 
 ## [2026-08-26] Signed sync requests v2, checkpoint errors, venv opt-out
 

--- a/apps/barrel_server/CHANGELOG.md
+++ b/apps/barrel_server/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [1.7.0] - 2026-08-30
 
 ### Changed
-- livery 0.6.1 to 0.9.1 and barrel_mcp 2.3.0 to 3.0.1: the standalone server now serves MCP protocol 2026-07-28. Nothing in the server's own API changes; consumers that embed the suites note that `livery:which_listeners/1` reports a list of ports per protocol since livery 0.8.0 (the suites go through `barrel_server_test:h1_port/1`), and that MCP 2026-07-28 removed `ping`: the 3.0 client refuses it on a modern session, so the suites probe readiness with `list_tools/1` instead.
+- livery 0.6.1 to 0.9.2 and barrel_mcp 2.3.0 to 3.0.1: the standalone server now serves MCP protocol 2026-07-28, and h1 0.9.1 (via livery 0.9.2) fixes chunked uploads that were answered `400 Chunk size is not valid hex` when a socket read split a chunk-size line between its CR and LF, which large attachment pushes hit under load. Nothing in the server's own API changes; consumers that embed the suites note that `livery:which_listeners/1` reports a list of ports per protocol since livery 0.8.0 (the suites go through `barrel_server_test:h1_port/1`), and that MCP 2026-07-28 removed `ping`: the 3.0 client refuses it on a modern session, so the suites probe readiness with `list_tools/1` instead.
 
 ### Added
 - Live queries on a 2026-07-28 MCP connection (which carries no session) belong to the authenticated principal: `max_per_session` bounds each owner, and a principal-owned query is swept after `orphan_ttl_ms` (default 600000) without a read. Session-owned queries still go with their session.

--- a/apps/barrel_server/CHANGELOG.md
+++ b/apps/barrel_server/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.7.0] - 2026-08-30
+
+### Changed
+- livery 0.6.1 to 0.9.1 and barrel_mcp 2.3.0 to 3.0.1: the standalone server now serves MCP protocol 2026-07-28. Nothing in the server's own API changes; consumers that embed the suites note that `livery:which_listeners/1` reports a list of ports per protocol since livery 0.8.0 (the suites go through `barrel_server_test:h1_port/1`), and that MCP 2026-07-28 removed `ping`: the 3.0 client refuses it on a modern session, so the suites probe readiness with `list_tools/1` instead.
+
+### Added
+- Live queries on a 2026-07-28 MCP connection (which carries no session) belong to the authenticated principal: `max_per_session` bounds each owner, and a principal-owned query is swept after `orphan_ttl_ms` (default 600000) without a read. Session-owned queries still go with their session.
+- `{barrel_server, mcp, #{request_state_key => Key | {file, Path}}}` seeds barrel_mcp's HMAC key for multi round-trip request state at start. Every node of a fleet must carry the same key or a retry landing on another node fails; without it barrel_mcp uses an ephemeral key and warns at start.
+
 ## [1.6.0] - 2026-08-26
 
 ### Added

--- a/apps/barrel_server/rebar.config
+++ b/apps/barrel_server/rebar.config
@@ -9,7 +9,7 @@
 {cover_enabled, true}.
 
 {deps, [
-    {livery, "0.9.1"},
+    {livery, "0.9.2"},
     %% exact pin: the MCP engine livery_mcp bridges to (inside livery's
     %% barrel_mcp constraint; rebar fails loudly on conflict)
     {barrel_mcp, "3.0.1"},

--- a/apps/barrel_server/rebar.config
+++ b/apps/barrel_server/rebar.config
@@ -9,10 +9,10 @@
 {cover_enabled, true}.
 
 {deps, [
-    {livery, "0.6.1"},
+    {livery, "0.9.1"},
     %% exact pin: the MCP engine livery_mcp bridges to (inside livery's
     %% barrel_mcp constraint; rebar fails loudly on conflict)
-    {barrel_mcp, "2.3.0"},
+    {barrel_mcp, "3.0.1"},
     %% Sibling apps, and hard runtime deps (in this app's `applications').
     %% They must be default-profile deps: rebar3_hex reads the package's
     %% requirements from the default lock, so a `hex' profile dep is dropped.

--- a/apps/barrel_server/src/barrel_server.app.src
+++ b/apps/barrel_server/src/barrel_server.app.src
@@ -1,6 +1,6 @@
 {application, barrel_server, [
     {description, "Multi-protocol server for the barrel edge database (REST/JSON over livery)"},
-    {vsn, "1.6.0"},
+    {vsn, "1.7.0"},
     {registered, [barrel_server_sup]},
     {mod, {barrel_server_app, []}},
     {applications, [

--- a/apps/barrel_server/src/barrel_server_auth.erl
+++ b/apps/barrel_server/src/barrel_server_auth.erl
@@ -202,7 +202,7 @@ try_bearer(Req, #{hashes := Hashes}) ->
 %% verified client cert. This authenticates the CA, not the peer: livery
 %% surfaces `tls => #{}' with no certificate details, so per-peer
 %% identity and rights come from bearer or signed auth layered on top.
-%% H1-TLS surfaces the marker; H2/H3 do not on livery 0.6, so H1-only.
+%% H1-TLS and H2 surface the marker (livery 0.8+); H3 does not yet.
 mtls_ok(Req) ->
     livery_req:tls(Req) =/= undefined.
 

--- a/apps/barrel_server/src/barrel_server_mcp.erl
+++ b/apps/barrel_server/src/barrel_server_mcp.erl
@@ -65,6 +65,28 @@ handler_opts() ->
 config() ->
     application:get_env(barrel_server, mcp, #{}).
 
+%% The HMAC key sealing multi round-trip request state (barrel_mcp
+%% `request_state_key'): every node of a fleet must carry the same
+%% value, or a retry landing elsewhere fails. Absent, barrel_mcp uses
+%% an ephemeral key and says so at start.
+apply_request_state_key(#{request_state_key := {file, Path}}) ->
+    case file:read_file(Path) of
+        {ok, Key} when byte_size(Key) > 0 ->
+            application:set_env(barrel_mcp, request_state_key,
+                                string:trim(Key, trailing, "\n"));
+        {ok, _Empty} ->
+            logger:error("barrel_server: mcp request_state_key file ~s "
+                         "is empty", [Path]);
+        {error, Reason} ->
+            logger:error("barrel_server: cannot read mcp "
+                         "request_state_key file ~s: ~p", [Path, Reason])
+    end;
+apply_request_state_key(#{request_state_key := Key})
+  when is_binary(Key), byte_size(Key) > 0 ->
+    application:set_env(barrel_mcp, request_state_key, Key);
+apply_request_state_key(_Cfg) ->
+    ok.
+
 %%====================================================================
 %% gen_server (the tool registrar)
 %%====================================================================
@@ -76,6 +98,7 @@ init([]) ->
     process_flag(trap_exit, true),
     case enabled() of
         true ->
+            ok = apply_request_state_key(config()),
             ok = barrel_server_mcp_tools:register_all(),
             ok = barrel_server_mcp_agent:register_all(),
             ok = barrel_server_mcp_resources:register_all();

--- a/apps/barrel_server/src/barrel_server_mcp_auth.erl
+++ b/apps/barrel_server/src/barrel_server_mcp_auth.erl
@@ -25,7 +25,7 @@
 -export([init/1, authenticate/2, challenge/2, auth_headers/1]).
 
 %% Tool-side helpers
--export([allow/3, prov/2]).
+-export([allow/3, prov/2, actor/1]).
 
 %%====================================================================
 %% barrel_mcp_auth callbacks
@@ -133,6 +133,9 @@ anonymous() ->
 subject(<<>>) -> <<"anonymous">>;
 subject(Subject) -> Subject.
 
+%% @doc The authenticated subject of a tool call (`anonymous' on an
+%% open server).
+-spec actor(map()) -> binary().
 actor(Ctx) ->
     case maps:get(auth_info, Ctx, undefined) of
         undefined -> <<"anonymous">>;

--- a/apps/barrel_server/src/barrel_server_mcp_live.erl
+++ b/apps/barrel_server/src/barrel_server_mcp_live.erl
@@ -37,7 +37,10 @@
     id :: binary(),
     uri :: binary(),
     db :: binary(),
-    session :: binary() | undefined,
+    %% {session, Sid} on a session-bearing connection, else
+    %% {principal, Subject} (MCP 2026-07-28 connections have no session)
+    owner :: {session, binary()} | {principal, binary()},
+    last_seen :: integer(),   %% monotonic ms, refreshed by snapshot reads
     barrel_sub :: #{ref := reference(), pid := pid()},
     mref :: reference(),
     rows = #{} :: #{binary() | non_neg_integer() => map()},
@@ -58,18 +61,20 @@
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
-%% @doc Create a live query owned by the bridge. Returns the sub id
-%% and its resource URI.
--spec subscribe(binary(), binary(), map(), binary() | undefined) ->
+%% @doc Create a live query owned by the bridge on behalf of `Owner'
+%% (`{session, Sid}' or `{principal, Subject}'). Returns the sub id and
+%% its resource URI.
+-spec subscribe(binary(), binary(), map(),
+                {session, binary()} | {principal, binary()}) ->
     {ok, binary(), binary()} | {error, term()}.
-subscribe(DbName, Bql, Params, SessionId) ->
+subscribe(DbName, Bql, Params, Owner) ->
     %% Open the database in the caller's process, not the bridge loop: a
     %% cold or large open must not block every other subscribe/snapshot/
     %% unsubscribe call queued on the singleton bridge.
     case barrel_server_dbs:ensure(DbName) of
         {ok, Db} ->
             gen_server:call(?MODULE,
-                            {subscribe, DbName, Db, Bql, Params, SessionId},
+                            {subscribe, DbName, Db, Bql, Params, Owner},
                             30000);
         {error, _} = Err ->
             Err
@@ -85,7 +90,8 @@ unsubscribe(SubId) ->
 snapshot(SubId) ->
     gen_server:call(?MODULE, {snapshot, SubId}).
 
-%% @doc Test hook: run the session sweep now.
+%% @doc Test hook: run the owner sweep now (dead sessions, idle
+%% principal-owned queries).
 -spec sweep() -> {ok, non_neg_integer()}.
 sweep() ->
     gen_server:call(?MODULE, sweep).
@@ -101,11 +107,11 @@ init([]) ->
     {ok, #{subs => #{}, by_ref => #{}}}.
 
 %% @private
-handle_call({subscribe, DbName, Db, Bql, Params, SessionId}, _From,
+handle_call({subscribe, DbName, Db, Bql, Params, Owner}, _From,
             #{subs := Subs} = State) ->
-    case check_caps(SessionId, Subs) of
+    case check_caps(Owner, Subs) of
         ok ->
-            do_subscribe(DbName, Db, Bql, Params, SessionId, State);
+            do_subscribe(DbName, Db, Bql, Params, Owner, State);
         {error, _} = Err ->
             {reply, Err, State}
     end;
@@ -120,7 +126,9 @@ handle_call({snapshot, SubId}, _From, #{subs := Subs} = State) ->
     case maps:find(SubId, Subs) of
         {ok, Sub} ->
             {Snap, Sub1} = snapshot_of(Sub),
-            {reply, {ok, Snap}, put_sub(Sub1, State)};
+            %% a read keeps a principal-owned query alive
+            {reply, {ok, Snap},
+             put_sub(Sub1#sub{last_seen = now_ms()}, State)};
         error ->
             {reply, {error, not_found}, State}
     end;
@@ -193,7 +201,7 @@ terminate(_Reason, #{subs := Subs}) ->
 %% Subscribe / drop
 %%====================================================================
 
-do_subscribe(DbName, Db, Bql, Params, SessionId, State) ->
+do_subscribe(DbName, Db, Bql, Params, Owner, State) ->
     %% The database is already open (ensured by the caller). subscribe_query
     %% owns the bridge as the row owner, so it must run here.
     SubOpts = #{params => Params, owner => self()},
@@ -206,7 +214,8 @@ do_subscribe(DbName, Db, Bql, Params, SessionId, State) ->
                 id = SubId,
                 uri = Uri,
                 db = DbName,
-                session = SessionId,
+                owner = Owner,
+                last_seen = now_ms(),
                 barrel_sub = BSub,
                 mref = erlang:monitor(process, Pid)
             },
@@ -233,17 +242,18 @@ drop_sub(#sub{id = SubId, db = Db, barrel_sub = #{ref := Ref} = BSub,
     end,
     State#{subs => Subs1, by_ref => maps:remove(Ref, ByRef)}.
 
-check_caps(SessionId, Subs) ->
+%% max_per_session bounds each owner (a session, or a principal on a
+%% session-less connection); max_global bounds the node.
+check_caps(Owner, Subs) ->
     Cfg = live_config(),
     MaxGlobal = maps:get(max_global, Cfg, 1024),
     MaxPerSession = maps:get(max_per_session, Cfg, 32),
     Global = map_size(Subs),
-    Mine = length([S || S = #sub{session = Sid} <- maps:values(Subs),
-                        Sid =:= SessionId, Sid =/= undefined]),
+    Mine = length([S || S = #sub{owner = O} <- maps:values(Subs),
+                        O =:= Owner]),
     if
         Global >= MaxGlobal -> {error, too_many_live_queries};
-        SessionId =/= undefined, Mine >= MaxPerSession ->
-            {error, too_many_live_queries};
+        Mine >= MaxPerSession -> {error, too_many_live_queries};
         true -> ok
     end.
 
@@ -311,11 +321,22 @@ schedule_notify(#sub{id = SubId} = Sub) ->
     erlang:send_after(Debounce, self(), {notify, SubId}),
     Sub#sub{pending = true}.
 
+%% A session-owned query dies with its session; a principal-owned one
+%% (no session to watch) after `orphan_ttl_ms' without a read.
 sweep_sessions(#{subs := Subs} = State) ->
-    Dead = [Sub || Sub = #sub{session = Sid} <- maps:values(Subs),
-                   Sid =/= undefined, not session_alive(Sid)],
+    Ttl = maps:get(orphan_ttl_ms, live_config(), 600000),
+    Now = now_ms(),
+    Dead = [Sub || Sub <- maps:values(Subs), dead(Sub, Ttl, Now)],
     State1 = lists:foldl(fun drop_sub/2, State, Dead),
     {length(Dead), State1}.
+
+dead(#sub{owner = {session, Sid}}, _Ttl, _Now) ->
+    not session_alive(Sid);
+dead(#sub{owner = {principal, _}, last_seen = Seen}, Ttl, Now) ->
+    Now - Seen > Ttl.
+
+now_ms() ->
+    erlang:monotonic_time(millisecond).
 
 session_alive(SessionId) ->
     case barrel_mcp_session:get(SessionId) of

--- a/apps/barrel_server/src/barrel_server_mcp_tools.erl
+++ b/apps/barrel_server/src/barrel_server_mcp_tools.erl
@@ -332,9 +332,14 @@ query_subscribe(#{<<"db">> := Name, <<"query">> := Bql} = Args, Ctx) ->
             P when is_map(P) -> P;
             _ -> #{}
         end,
-        SessionId = maps:get(session_id, Ctx, undefined),
-        case barrel_server_mcp_live:subscribe(Name, Bql, Params,
-                                              SessionId) of
+        %% MCP 2026-07-28 connections carry no session: the live query
+        %% then belongs to the authenticated principal, as barrel_mcp
+        %% does for tasks.
+        Owner = case maps:get(session_id, Ctx, undefined) of
+            undefined -> {principal, barrel_server_mcp_auth:actor(Ctx)};
+            Sid -> {session, Sid}
+        end,
+        case barrel_server_mcp_live:subscribe(Name, Bql, Params, Owner) of
             {ok, SubId, Uri} ->
                 reply(#{ok => true, sub => SubId, uri => Uri});
             {error, missing_subscribe} ->

--- a/apps/barrel_server/test/barrel_server_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_SUITE.erl
@@ -73,7 +73,7 @@ end_per_suite(_Config) ->
 discover_port() ->
     Children = supervisor:which_children(barrel_server_sup),
     {_, Pid, _, _} = lists:keyfind(barrel_server_http, 1, Children),
-    #{h1 := Port} = livery:which_listeners(Pid),
+    Port = barrel_server_test:h1_port(Pid),
     Port.
 
 %%====================================================================

--- a/apps/barrel_server/test/barrel_server_att_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_att_SUITE.erl
@@ -47,7 +47,7 @@ init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(hackney),
     Children = supervisor:which_children(barrel_server_sup),
     {_, Pid, _, _} = lists:keyfind(barrel_server_http, 1, Children),
-    #{h1 := Port} = livery:which_listeners(Pid),
+    Port = barrel_server_test:h1_port(Pid),
     Base = "http://127.0.0.1:" ++ integer_to_list(Port),
     [{base, Base} | Config].
 

--- a/apps/barrel_server/test/barrel_server_audit_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_audit_SUITE.erl
@@ -32,7 +32,7 @@ init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(hackney),
     Children = supervisor:which_children(barrel_server_sup),
     {_, Pid, _, _} = lists:keyfind(barrel_server_http, 1, Children),
-    #{h1 := Port} = livery:which_listeners(Pid),
+    Port = barrel_server_test:h1_port(Pid),
     Base = "http://127.0.0.1:" ++ integer_to_list(Port),
     [{base, Base} | Config].
 

--- a/apps/barrel_server/test/barrel_server_auth_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_auth_SUITE.erl
@@ -46,7 +46,7 @@ init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(hackney),
     Children = supervisor:which_children(barrel_server_sup),
     {_, Pid, _, _} = lists:keyfind(barrel_server_http, 1, Children),
-    #{h1 := Port} = livery:which_listeners(Pid),
+    Port = barrel_server_test:h1_port(Pid),
     Base = "http://127.0.0.1:" ++ integer_to_list(Port),
     [{base, Base} | Config].
 

--- a/apps/barrel_server/test/barrel_server_convergence_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_convergence_SUITE.erl
@@ -35,7 +35,7 @@ init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(hackney),
     Children = supervisor:which_children(barrel_server_sup),
     {_, Pid, _, _} = lists:keyfind(barrel_server_http, 1, Children),
-    #{h1 := Port} = livery:which_listeners(Pid),
+    Port = barrel_server_test:h1_port(Pid),
     Base = "http://127.0.0.1:" ++ integer_to_list(Port),
     [{base, Base} | Config].
 

--- a/apps/barrel_server/test/barrel_server_cors_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_cors_SUITE.erl
@@ -146,7 +146,7 @@ lower(Headers) ->
 base_url() ->
     Children = supervisor:which_children(barrel_server_sup),
     {_, Pid, _, _} = lists:keyfind(barrel_server_http, 1, Children),
-    #{h1 := Port} = livery:which_listeners(Pid),
+    Port = barrel_server_test:h1_port(Pid),
     "http://127.0.0.1:" ++ integer_to_list(Port).
 
 restart_http() ->

--- a/apps/barrel_server/test/barrel_server_embed_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_embed_SUITE.erl
@@ -59,7 +59,7 @@ init_per_suite(Config) ->
     %% start_service links to this (ephemeral) init process; unlink so the
     %% service survives until end_per_suite stops it explicitly.
     true = unlink(Pid),
-    #{h1 := Port} = livery:which_listeners(Pid),
+    Port = barrel_server_test:h1_port(Pid),
     Base = "http://127.0.0.1:" ++ integer_to_list(Port),
     {201, _} = req(put, Base ++ "/barrel/db/" ++ ?DB, <<>>),
     [{svc, Pid}, {base, Base} | Config].

--- a/apps/barrel_server/test/barrel_server_encryption_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_encryption_SUITE.erl
@@ -26,7 +26,7 @@ init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(hackney),
     Children = supervisor:which_children(barrel_server_sup),
     {_, Pid, _, _} = lists:keyfind(barrel_server_http, 1, Children),
-    #{h1 := Port} = livery:which_listeners(Pid),
+    Port = barrel_server_test:h1_port(Pid),
     Base = "http://127.0.0.1:" ++ integer_to_list(Port),
     [{base, Base} | Config].
 

--- a/apps/barrel_server/test/barrel_server_mcp_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_mcp_SUITE.erl
@@ -93,9 +93,9 @@ t_registered_tools(_Config) ->
 t_session_roundtrip(_Config) ->
     C = connect(#{}),
     %% several requests ride one Mcp-Session-Id
-    {ok, _} = barrel_mcp_client:ping(C),
     {ok, _} = barrel_mcp_client:list_tools(C),
-    {ok, _} = barrel_mcp_client:ping(C),
+    {ok, _} = barrel_mcp_client:list_tools(C),
+    {ok, _} = barrel_mcp_client:list_tools(C),
     barrel_mcp_client:close(C),
     ok.
 
@@ -113,7 +113,7 @@ t_rest_unaffected(_Config) ->
     {ok, 200, _, Body} = hackney:request(
         get, B ++ "/db/mcp_mount_db/doc/d1", [], <<>>, [with_body]),
     ?assertMatch(#{<<"v">> := 1}, json:decode(Body)),
-    {ok, _} = barrel_mcp_client:ping(C),
+    {ok, _} = barrel_mcp_client:list_tools(C),
     barrel_mcp_client:close(C),
     ok.
 
@@ -164,7 +164,7 @@ t_locked_server_token(_Config) ->
     C = connect(#{auth => {bearer, ?ROOT}}),
     {ok, Tools} = barrel_mcp_client:list_tools(C),
     ?assert(length(Tools) > 0),
-    {ok, _} = barrel_mcp_client:ping(C),
+    {ok, _} = barrel_mcp_client:list_tools(C),
     barrel_mcp_client:close(C),
     ok.
 
@@ -177,7 +177,7 @@ t_locked_capability_token(Config) ->
     {ok, Token, _} = barrel_caps:grant(SpaceId,
                                        #{rights => [read, write]}),
     C = connect(#{auth => {bearer, Token}}),
-    {ok, _} = barrel_mcp_client:ping(C),
+    {ok, _} = barrel_mcp_client:list_tools(C),
     {ok, Tools} = barrel_mcp_client:list_tools(C),
     ?assert(length(Tools) > 0),
     barrel_mcp_client:close(C),
@@ -194,7 +194,7 @@ t_locked_capability_token(Config) ->
 base_url() ->
     Children = supervisor:which_children(barrel_server_sup),
     {_, Pid, _, _} = lists:keyfind(barrel_server_http, 1, Children),
-    #{h1 := Port} = livery:which_listeners(Pid),
+    Port = barrel_server_test:h1_port(Pid),
     "http://127.0.0.1:" ++ integer_to_list(Port).
 
 restart_http() ->
@@ -211,8 +211,10 @@ connect(Extra) ->
 
 wait_ready(_C, 0) ->
     {error, not_ready};
+%% MCP 2026-07-28 removed ping; list_tools exists in every era and
+%% answers not_ready until the session is up.
 wait_ready(C, N) ->
-    case barrel_mcp_client:ping(C) of
+    case barrel_mcp_client:list_tools(C) of
         {ok, _} -> ok;
         {error, not_ready} ->
             timer:sleep(50),

--- a/apps/barrel_server/test/barrel_server_mcp_agent_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_mcp_agent_SUITE.erl
@@ -181,7 +181,7 @@ t_capability_denies(_Config) ->
 base_url() ->
     Children = supervisor:which_children(barrel_server_sup),
     {_, Pid, _, _} = lists:keyfind(barrel_server_http, 1, Children),
-    #{h1 := Port} = livery:which_listeners(Pid),
+    Port = barrel_server_test:h1_port(Pid),
     "http://127.0.0.1:" ++ integer_to_list(Port).
 
 connect(Token) ->
@@ -195,8 +195,10 @@ connect(Token) ->
 
 wait_ready(_C, 0) ->
     {error, not_ready};
+%% MCP 2026-07-28 removed ping; list_tools exists in every era and
+%% answers not_ready until the session is up.
 wait_ready(C, N) ->
-    case barrel_mcp_client:ping(C) of
+    case barrel_mcp_client:list_tools(C) of
         {ok, _} -> ok;
         {error, not_ready} ->
             timer:sleep(50),

--- a/apps/barrel_server/test/barrel_server_mcp_live_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_mcp_live_SUITE.erl
@@ -14,6 +14,7 @@
     t_live_e2e/1,
     t_unsubscribe/1,
     t_session_gc/1,
+    t_session_gc_legacy/1,
     t_per_session_limit/1,
     t_live_only_mode/1
 ]).
@@ -23,7 +24,7 @@
 
 all() ->
     [t_templates_list_read, t_live_e2e, t_unsubscribe, t_session_gc,
-     t_per_session_limit, t_live_only_mode].
+     t_session_gc_legacy, t_per_session_limit, t_live_only_mode].
 
 init_per_suite(Config) ->
     application:load(barrel_server),
@@ -120,17 +121,42 @@ t_unsubscribe(_Config) ->
     barrel_mcp_client:close(C),
     ok.
 
+%% A modern (2026-07-28) connection has no session, so a live query
+%% belongs to the principal and is swept once idle past orphan_ttl_ms.
 t_session_gc(_Config) ->
-    C = connect(),
-    {false, _} = call(C, <<"db_create">>, #{<<"db">> => <<"gc_db">>}),
+    Saved = application:get_env(barrel_server, mcp),
+    application:set_env(barrel_server, mcp,
+                        #{live => #{orphan_ttl_ms => 1}}),
+    try
+        C = connect(),
+        {false, _} = call(C, <<"db_create">>, #{<<"db">> => <<"gc_db">>}),
+        {false, #{<<"sub">> := Sub}} =
+            call(C, <<"query_subscribe">>,
+                 #{<<"db">> => <<"gc_db">>,
+                   <<"query">> =>
+                       <<"SELECT * FROM db WHERE kind = 'g' SUBSCRIBE">>}),
+        {ok, _} = barrel_server_mcp_live:snapshot(Sub),
+        timer:sleep(10),
+        ok = wait_swept(Sub, 50),
+        ?assertEqual({error, not_found},
+                     barrel_server_mcp_live:snapshot(Sub)),
+        barrel_mcp_client:close(C)
+    after
+        restore_env(Saved)
+    end,
+    ok.
+
+%% A session-bearing (legacy revision) connection: closing the client
+%% DELETEs its MCP session and the sweep drops the orphaned live query.
+t_session_gc_legacy(_Config) ->
+    C = connect(#{protocol_version => <<"2025-11-25">>}),
+    {false, _} = call(C, <<"db_create">>, #{<<"db">> => <<"gc_db2">>}),
     {false, #{<<"sub">> := Sub}} =
         call(C, <<"query_subscribe">>,
-             #{<<"db">> => <<"gc_db">>,
+             #{<<"db">> => <<"gc_db2">>,
                <<"query">> =>
                    <<"SELECT * FROM db WHERE kind = 'g' SUBSCRIBE">>}),
     {ok, _} = barrel_server_mcp_live:snapshot(Sub),
-    %% closing the client DELETEs its MCP session; the bridge sweep
-    %% then drops the orphaned live query
     barrel_mcp_client:close(C),
     ok = wait_swept(Sub, 50),
     ?assertEqual({error, not_found}, barrel_server_mcp_live:snapshot(Sub)),
@@ -186,7 +212,7 @@ t_live_only_mode(_Config) ->
 base_url() ->
     Children = supervisor:which_children(barrel_server_sup),
     {_, Pid, _, _} = lists:keyfind(barrel_server_http, 1, Children),
-    #{h1 := Port} = livery:which_listeners(Pid),
+    Port = barrel_server_test:h1_port(Pid),
     "http://127.0.0.1:" ++ integer_to_list(Port).
 
 restart_registrar() ->
@@ -196,17 +222,25 @@ restart_registrar() ->
     ok.
 
 connect() ->
+    connect(#{}).
+
+connect(Extra) ->
     Base = base_url(),
-    {ok, C} = barrel_mcp_client:start(#{
+    {ok, C} = barrel_mcp_client:start(Extra#{
         transport => {http, list_to_binary(Base ++ "/mcp")}
     }),
     ok = wait_client_ready(C, 100),
     C.
 
+restore_env(undefined) -> application:unset_env(barrel_server, mcp);
+restore_env({ok, V}) -> application:set_env(barrel_server, mcp, V).
+
 wait_client_ready(_C, 0) ->
     {error, not_ready};
+%% MCP 2026-07-28 removed ping; list_tools exists in every era and
+%% answers not_ready until the session is up.
 wait_client_ready(C, N) ->
-    case barrel_mcp_client:ping(C) of
+    case barrel_mcp_client:list_tools(C) of
         {ok, _} -> ok;
         {error, not_ready} ->
             timer:sleep(50),

--- a/apps/barrel_server/test/barrel_server_mcp_tools_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_mcp_tools_SUITE.erl
@@ -398,7 +398,7 @@ make_space(Config, Tag) ->
 base_url() ->
     Children = supervisor:which_children(barrel_server_sup),
     {_, Pid, _, _} = lists:keyfind(barrel_server_http, 1, Children),
-    #{h1 := Port} = livery:which_listeners(Pid),
+    Port = barrel_server_test:h1_port(Pid),
     "http://127.0.0.1:" ++ integer_to_list(Port).
 
 restart_http() ->
@@ -415,8 +415,10 @@ connect(Extra) ->
 
 wait_ready(_C, 0) ->
     {error, not_ready};
+%% MCP 2026-07-28 removed ping; list_tools exists in every era and
+%% answers not_ready until the session is up.
 wait_ready(C, N) ->
-    case barrel_mcp_client:ping(C) of
+    case barrel_mcp_client:list_tools(C) of
         {ok, _} -> ok;
         {error, not_ready} ->
             timer:sleep(50),

--- a/apps/barrel_server/test/barrel_server_mtls_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_mtls_SUITE.erl
@@ -94,7 +94,7 @@ t_certless_refused(Config) ->
 listeners() ->
     Children = supervisor:which_children(barrel_server_sup),
     {_, Pid, _, _} = lists:keyfind(barrel_server_http, 1, Children),
-    livery:which_listeners(Pid).
+    barrel_server_test:listener_ports(Pid).
 
 tls_base(Config) ->
     #{h1 := Port} = ?config(listeners, Config),

--- a/apps/barrel_server/test/barrel_server_rep_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_rep_SUITE.erl
@@ -40,7 +40,7 @@ init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(hackney),
     Children = supervisor:which_children(barrel_server_sup),
     {_, Pid, _, _} = lists:keyfind(barrel_server_http, 1, Children),
-    #{h1 := Port} = livery:which_listeners(Pid),
+    Port = barrel_server_test:h1_port(Pid),
     Base = "http://127.0.0.1:" ++ integer_to_list(Port),
     [{base, Base} | Config].
 

--- a/apps/barrel_server/test/barrel_server_signed_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_signed_SUITE.erl
@@ -263,5 +263,5 @@ method_bin(delete) -> <<"DELETE">>.
 discover_port() ->
     Children = supervisor:which_children(barrel_server_sup),
     {_, Pid, _, _} = lists:keyfind(barrel_server_http, 1, Children),
-    #{h1 := Port} = livery:which_listeners(Pid),
+    Port = barrel_server_test:h1_port(Pid),
     Port.

--- a/apps/barrel_server/test/barrel_server_spaces_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_spaces_SUITE.erl
@@ -38,7 +38,7 @@ init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(hackney),
     Children = supervisor:which_children(barrel_server_sup),
     {_, Pid, _, _} = lists:keyfind(barrel_server_http, 1, Children),
-    #{h1 := Port} = livery:which_listeners(Pid),
+    Port = barrel_server_test:h1_port(Pid),
     Base = "http://127.0.0.1:" ++ integer_to_list(Port),
     [{base, Base} | Config].
 

--- a/apps/barrel_server/test/barrel_server_sync_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_sync_SUITE.erl
@@ -45,7 +45,7 @@ end_per_suite(_Config) ->
 discover_port() ->
     Children = supervisor:which_children(barrel_server_sup),
     {_, Pid, _, _} = lists:keyfind(barrel_server_http, 1, Children),
-    #{h1 := Port} = livery:which_listeners(Pid),
+    Port = barrel_server_test:h1_port(Pid),
     Port.
 
 %%====================================================================

--- a/apps/barrel_server/test/barrel_server_test.erl
+++ b/apps/barrel_server/test/barrel_server_test.erl
@@ -1,0 +1,20 @@
+%%%-------------------------------------------------------------------
+%%% @doc Shared helpers for the barrel_server suites.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_server_test).
+
+-export([h1_port/1, listener_ports/1]).
+
+%% @doc The H1 port of a running livery service. livery 0.8+ reports a
+%% list of ports per protocol; the suites bind one listener each.
+-spec h1_port(pid()) -> inet:port_number().
+h1_port(Pid) ->
+    maps:get(h1, listener_ports(Pid)).
+
+%% @doc `#{h1 | h2 | h3 => Port}' with one port per protocol.
+-spec listener_ports(pid()) -> #{h1 | h2 | h3 => inet:port_number()}.
+listener_ports(Pid) ->
+    maps:map(fun(_Proto, [Port | _]) -> Port;
+                (_Proto, Port) -> Port
+             end, livery:which_listeners(Pid)).

--- a/apps/barrel_server/test/barrel_server_timeline_SUITE.erl
+++ b/apps/barrel_server/test/barrel_server_timeline_SUITE.erl
@@ -37,7 +37,7 @@ init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(hackney),
     Children = supervisor:which_children(barrel_server_sup),
     {_, Pid, _, _} = lists:keyfind(barrel_server_http, 1, Children),
-    #{h1 := Port} = livery:which_listeners(Pid),
+    Port = barrel_server_test:h1_port(Pid),
     Base = "http://127.0.0.1:" ++ integer_to_list(Port),
     [{base, Base} | Config].
 

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -25,10 +25,25 @@ The endpoint is on by default in the server build. Configure it with the
         allow_missing_origin => true,
         resources => full,             %% full | live_only
         live => #{max_per_session => 32, max_global => 1024,
-                  sweep_interval_ms => 60000, debounce_ms => 100}
+                  sweep_interval_ms => 60000, debounce_ms => 100,
+                  orphan_ttl_ms => 600000},
+        request_state_key => {file, "/etc/barrel/mcp-state.key"}
     }}
 ]}
 ```
+
+Live queries belong to the MCP session that created them, or, on a
+2026-07-28 connection (no sessions), to the authenticated principal:
+`max_per_session` bounds each owner, and a principal-owned query is dropped
+after `orphan_ttl_ms` without a read (a session-owned one when its session
+goes).
+
+`request_state_key` (a binary of 32 or more random bytes, or `{file, Path}`
+to read it from a file at start) seals the state of multi round-trip
+requests. Every node of a fleet must carry the same key: a retry that lands
+on another node, or on the same node after a restart, is refused otherwise.
+Leave it unset on a single node and barrel_mcp uses an ephemeral key, saying
+so at start.
 
 ## Auth
 


### PR DESCRIPTION
Item 5 of the outstanding brief (supersedes #39, which GitHub closed when its stacked base branch was deleted on merging #38).

- `livery` 0.6.1 to 0.9.1 and `barrel_mcp` 2.3.0 to 3.0.1 (they move together; livery 0.9 carries barrel_mcp 3.0). Every livery and barrel_mcp function the server calls still exists with the same arity; `barrel_server_mcp_auth` is unaffected by the 3.0 auth-provider change. The standalone server now serves MCP protocol 2026-07-28.
- Modern (2026-07-28) connections carry no session id. Live queries created on one now belong to the authenticated principal: `max_per_session` bounds each owner, and a principal-owned query is swept after `orphan_ttl_ms` (default 600000) without a read; session-owned queries still go with their session. Without this the per-session cap did not count and GC never swept on modern clients.
- `{barrel_server, mcp, #{request_state_key => Key | {file, Path}}}` seeds barrel_mcp's HMAC key for multi round-trip request state; every node of a fleet must share it (documented in the MCP guide).
- Suites: `livery:which_listeners/1` reports port lists since 0.8.0 (new `barrel_server_test:h1_port/1` helper at the 18 call sites); MCP 2026-07-28 removed `ping`, so readiness probes use `list_tools/1`; the session GC test keeps a legacy-revision variant next to the modern idle-TTL one.

Green with the real dependencies on OTP 28 (server ct 1027) and OTP 29 (server ct 1026 plus one unrelated `barrel_ngram_lifecycle` flake that passes alone); server-profile xref and dialyzer at the pre-existing baselines.