### PR TITLE
Stop paying a ~74MB RocksDB WAL/MANIFEST floor for attachments no database ever stores

### DIFF
--- a/apps/barrel_docdb/src/barrel_att_store.erl
+++ b/apps/barrel_docdb/src/barrel_att_store.erl
@@ -4,7 +4,9 @@
 %%% Selects an attachment backend (a {@link barrel_att_backend}) per database
 %%% and routes all attachment calls to it. The backend is chosen from
 %%% `att_opts.backend' at {@link open/2} (default `blob', the RocksDB BlobDB
-%%% backend) via {@link backend_module/1}, resolved to a module and tagged
+%%% backend; `none' for a database that structurally never stores
+%%% attachments -- see {@link barrel_att_store_none}) via
+%%% {@link backend_module/1}, resolved to a module and tagged
 %%% into the returned `att_ref'. Streaming handles embed their `att_ref', so
 %%% streaming calls dispatch to the same backend.
 %%%
@@ -59,6 +61,7 @@
 -spec backend_module(atom()) -> module().
 backend_module(blob) -> barrel_att_store_blob;
 backend_module(s3) -> barrel_att_s3_store;
+backend_module(none) -> barrel_att_store_none;
 backend_module(Module) when is_atom(Module) -> Module.
 
 %% @doc Whether a backend's implementation is present in the build.
@@ -68,6 +71,8 @@ backend_module(Module) when is_atom(Module) -> Module.
 %% for the optional FAISS backend.
 -spec is_available(atom()) -> boolean().
 is_available(blob) ->
+    true;
+is_available(none) ->
     true;
 is_available(s3) ->
     backend_loaded(barrel_att_s3_store);

--- a/apps/barrel_docdb/src/barrel_att_store_none.erl
+++ b/apps/barrel_docdb/src/barrel_att_store_none.erl
@@ -1,0 +1,104 @@
+%%%-------------------------------------------------------------------
+%%% @doc Attachment backend that stores nothing.
+%%%
+%%% For databases that structurally never accept attachments -- barrel's
+%%% own `_barrel_system' and `_replication_tasks' (see barrel_docdb.erl's
+%%% ensure_system_db/0 and barrel_rep_tasks.erl's ensure_tasks_db/0),
+%%% which only ever call put_local_doc/3. `barrel_db_server' opens an
+%%% attachment store unconditionally for every database (see its init/8),
+%%% and the default backend, `barrel_att_store_blob', is a real RocksDB
+%%% instance: even completely empty, RocksDB preallocates its WAL file
+%%% (~1.1x write_buffer_size -- 64MB default -> ~70.4MB) and its MANIFEST
+%%% (4MB), a fixed ~74MB floor paid once per database regardless of
+%%% whether a single attachment is ever stored. Measured on a real
+%%% deployment (hecate-agora, 2026-09-05): two internal databases that
+%%% only ever hold a handful of small local docs were paying this floor
+%%% TWICE each (once for `docs', once for `attachments') -- ~298MB of a
+%%% 455MB total, dwarfing the actual content by two orders of magnitude.
+%%%
+%%% Select this backend via `att_opts => #{backend => none}' on
+%%% `barrel_docdb:create_db/2'. Every mutating call returns
+%%% `{error, attachments_disabled}'; every read call returns the same
+%%% "nothing here" result a real backend would return for a document
+%%% that happens to have zero attachments (`not_found' from get/4,
+%%% `{error, not_found}' from get_info/4, the accumulator unchanged from
+%%% fold/5), so a caller that never writes an attachment cannot tell the
+%%% difference. `checkpoint/2' and `destroy/2' are deliberately not
+%%% exported (like `barrel_att_s3_store' and the test-only minimal
+%%% backend): `barrel_att_store' degrades those to `{error, unsupported}'
+%%% / a no-op respectively -- a `none'-backed database cannot be forked
+%%% via timeline branching, which is fine for `_barrel_system' and
+%%% `_replication_tasks' (neither is ever branched) but is a real
+%%% limitation for anyone else opting into this backend.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_att_store_none).
+-behaviour(barrel_att_backend).
+
+-export([open/2, close/1]).
+-export([put/5, put/6, get/4, delete/4]).
+-export([delete_all/3]).
+-export([fold/5]).
+-export([get_info/4]).
+-export([put_stream/5, put_stream/6]).
+-export([write_chunk/2, finish_stream/1, abort_stream/1]).
+-export([get_stream/4, read_chunk/1, close_stream/1]).
+
+%% @doc No RocksDB instance, no directory -- Path is intentionally unused.
+-spec open(string(), map()) -> {ok, map()}.
+open(_Path, _Options) -> {ok, #{}}.
+
+-spec close(map()) -> ok.
+close(_AttRef) -> ok.
+
+-spec put(map(), binary(), binary(), binary(), binary()) -> {error, attachments_disabled}.
+put(_AttRef, _DbName, _DocId, _AttName, _Data) -> {error, attachments_disabled}.
+
+-spec put(map(), binary(), binary(), binary(), binary(), map()) -> {error, attachments_disabled}.
+put(_AttRef, _DbName, _DocId, _AttName, _Data, _Opts) -> {error, attachments_disabled}.
+
+%% @doc Same shape as a real backend asked for an attachment that was
+%% never stored: `not_found', not an error.
+-spec get(map(), binary(), binary(), binary()) -> not_found.
+get(_AttRef, _DbName, _DocId, _AttName) -> not_found.
+
+-spec delete(map(), binary(), binary(), binary()) -> {error, attachments_disabled}.
+delete(_AttRef, _DbName, _DocId, _AttName) -> {error, attachments_disabled}.
+
+%% @doc Deleting all (zero) attachments a document has is trivially
+%% successful, same as a real backend would report for a document that
+%% never had any.
+-spec delete_all(map(), binary(), binary()) -> ok.
+delete_all(_AttRef, _DbName, _DocId) -> ok.
+
+%% @doc Nothing to fold over; the accumulator passes through unchanged,
+%% same as a real backend would do for a document with zero attachments.
+-spec fold(map(), binary(), binary(), fun(), term()) -> term().
+fold(_AttRef, _DbName, _DocId, _Fun, Acc) -> Acc.
+
+-spec get_info(map(), binary(), binary(), binary()) -> {error, not_found}.
+get_info(_AttRef, _DbName, _DocId, _AttName) -> {error, not_found}.
+
+-spec put_stream(map(), binary(), binary(), binary(), binary()) -> {error, attachments_disabled}.
+put_stream(_AttRef, _DbName, _DocId, _AttName, _ContentType) -> {error, attachments_disabled}.
+
+-spec put_stream(map(), binary(), binary(), binary(), binary(), map()) -> {error, attachments_disabled}.
+put_stream(_AttRef, _DbName, _DocId, _AttName, _ContentType, _Opts) -> {error, attachments_disabled}.
+
+-spec write_chunk(map(), binary()) -> {error, attachments_disabled}.
+write_chunk(_Stream, _Data) -> {error, attachments_disabled}.
+
+-spec finish_stream(map()) -> {error, attachments_disabled}.
+finish_stream(_Stream) -> {error, attachments_disabled}.
+
+-spec abort_stream(map()) -> ok.
+abort_stream(_Stream) -> ok.
+
+-spec get_stream(map(), binary(), binary(), binary()) -> {error, not_found}.
+get_stream(_AttRef, _DbName, _DocId, _AttName) -> {error, not_found}.
+
+-spec read_chunk(map()) -> eof.
+read_chunk(_Stream) -> eof.
+
+-spec close_stream(map()) -> ok.
+close_stream(_Stream) -> ok.

--- a/apps/barrel_docdb/src/barrel_docdb.erl
+++ b/apps/barrel_docdb/src/barrel_docdb.erl
@@ -59,6 +59,24 @@
 %% index, etc.). Not replicated.
 -define(SYSTEM_DB, <<"_barrel_system">>).
 
+%% System documents go through put_local_doc/3 only -- this database
+%% never stores an attachment or a real (revtree-backed) document, so
+%% both the RocksDB write buffer it asks for and the attachment store
+%% barrel_db_server otherwise opens unconditionally are pure waste sized
+%% for a workload this database never has. Measured on a real deployment
+%% (hecate-agora, 2026-09-05): the stock defaults (64MB write_buffer_size,
+%% a full second RocksDB instance for attachments) cost this one database
+%% ~148MB on disk -- almost entirely RocksDB's own WAL/MANIFEST
+%% preallocation, not a single byte of it proportional to the handful of
+%% small docs actually stored. `none' skips the attachment store
+%% entirely (see barrel_att_store_none); 4MB is still generous headroom
+%% for node-id/config-sized documents while cutting the docs store's own
+%% WAL preallocation from ~70MB to ~4.4MB.
+-define(SYSTEM_DB_OPTS, #{
+    att_opts => #{backend => none},
+    store_opts => #{write_buffer_size => 4 * 1024 * 1024}
+}).
+
 %% Database lifecycle
 -export([
     create_db/1,
@@ -242,8 +260,18 @@ create_db(Name) ->
 %% == Options ==
 %% <ul>
 %%   <li>`data_dir' - Directory to store database files (default: `/tmp/barrel_data')</li>
-%%   <li>`store_opts' - RocksDB options for document store</li>
-%%   <li>`att_opts' - RocksDB options for attachment store</li>
+%%   <li>`store_opts' - RocksDB options for document store, e.g.
+%%       `#{write_buffer_size => 4194304}' for a database that will only
+%%       ever hold a handful of small documents -- the 64MB RocksDB
+%%       default preallocates a WAL sized for a write-heavy workload
+%%       (~1.1x write_buffer_size) regardless of how little is actually
+%%       written</li>
+%%   <li>`att_opts' - RocksDB options for attachment store, or
+%%       `#{backend => none}' to skip opening an attachment store
+%%       entirely for a database that will never store one (see
+%%       {@link barrel_att_store_none}) -- avoids paying a second,
+%%       identically-sized fixed RocksDB floor for a feature that's
+%%       never used</li>
 %%   <li>`encryption' - `disabled | default | #{provider => Mod}': encrypt
 %%       both stores at rest (RocksDB EncryptedEnv, AES-256-CTR) with a
 %%       per-database key resolved by `barrel_keyprovider'. Runtime config
@@ -1998,7 +2026,7 @@ ensure_system_db() ->
         {ok, _} ->
             ok;
         {error, not_found} ->
-            {ok, _} = create_db(?SYSTEM_DB),
+            {ok, _} = create_db(?SYSTEM_DB, ?SYSTEM_DB_OPTS),
             ok
     end.
 

--- a/apps/barrel_docdb/src/barrel_rep_tasks.erl
+++ b/apps/barrel_docdb/src/barrel_rep_tasks.erl
@@ -55,6 +55,17 @@
 -define(SERVER, ?MODULE).
 -define(TASKS_DB, <<"_replication_tasks">>).
 
+%% Task records go through put_local_doc/3 only -- see the identical
+%% rationale on barrel_docdb.erl's SYSTEM_DB_OPTS, which this mirrors:
+%% this database never stores an attachment or a real (revtree-backed)
+%% document, so the stock 64MB write_buffer_size and the unconditional
+%% second RocksDB instance barrel_db_server opens for attachments are
+%% both sized for a workload this database structurally cannot have.
+-define(TASKS_DB_OPTS, #{
+    att_opts => #{backend => none},
+    store_opts => #{write_buffer_size => 4 * 1024 * 1024}
+}).
+
 %% Task check interval (5 seconds)
 -define(CHECK_INTERVAL, 5000).
 
@@ -796,7 +807,7 @@ ensure_tasks_db() ->
         {ok, _} ->
             ok;
         {error, not_found} ->
-            case barrel_docdb:create_db(?TASKS_DB) of
+            case barrel_docdb:create_db(?TASKS_DB, ?TASKS_DB_OPTS) of
                 {ok, _} -> ok;
                 {error, _} = E -> E
             end;

--- a/apps/barrel_docdb/test/barrel_att_store_none_SUITE.erl
+++ b/apps/barrel_docdb/test/barrel_att_store_none_SUITE.erl
@@ -1,0 +1,124 @@
+%%%-------------------------------------------------------------------
+%%% @doc Coverage for `att_opts => #{backend => none}' (barrel_att_store_none):
+%%% a database created with it must not materialize an attachments/
+%%% RocksDB instance on disk, must still work normally for its actual
+%%% (local-doc) workload, and must fail attachment operations cleanly
+%%% rather than crash.
+%%%
+%%% Motivated by a real deployment measurement (hecate-agora,
+%%% 2026-09-05): barrel_docdb.erl's `_barrel_system' and
+%%% barrel_rep_tasks.erl's `_replication_tasks' only ever call
+%%% put_local_doc/3, yet each was paying for a full second RocksDB
+%%% instance (~74MB fixed WAL+MANIFEST preallocation, empty or not) for
+%%% an attachment feature neither can structurally use.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_att_store_none_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1,
+         init_per_testcase/2, end_per_testcase/2]).
+
+-export([no_attachments_directory_created/1,
+         docs_directory_still_created/1,
+         local_docs_still_work/1,
+         put_attachment_returns_clean_error/1,
+         get_attachment_reports_not_found_not_error/1,
+         default_backend_still_creates_attachments_directory/1]).
+
+all() ->
+    [no_attachments_directory_created,
+     docs_directory_still_created,
+     local_docs_still_work,
+     put_attachment_returns_clean_error,
+     get_attachment_reports_not_found_not_error,
+     default_backend_still_creates_attachments_directory].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(barrel_docdb),
+    Dir = "/tmp/barrel_att_store_none_test_"
+        ++ integer_to_list(erlang:system_time(millisecond)),
+    [{dir, Dir} | Config].
+
+end_per_suite(Config) ->
+    os:cmd("rm -rf " ++ ?config(dir, Config)),
+    ok.
+
+%% Options mirroring what barrel_docdb.erl's SYSTEM_DB_OPTS and
+%% barrel_rep_tasks.erl's TASKS_DB_OPTS actually pass -- a database
+%% created for local-doc-only, low-volume use.
+none_opts() ->
+    #{att_opts => #{backend => none},
+      store_opts => #{write_buffer_size => 4 * 1024 * 1024}}.
+
+init_per_testcase(TC, Config) ->
+    Name = atom_to_binary(TC, utf8),
+    Dir = ?config(dir, Config),
+    DbPath = filename:join(Dir, binary_to_list(Name)),
+    [{name, Name}, {db_path, DbPath} | Config].
+
+end_per_testcase(_TC, Config) ->
+    try barrel_docdb:delete_db(?config(name, Config)) catch _:_ -> ok end,
+    ok.
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+no_attachments_directory_created(Config) ->
+    Name = ?config(name, Config),
+    Dir = ?config(dir, Config),
+    DbPath = ?config(db_path, Config),
+    {ok, _} = barrel_docdb:create_db(Name, (none_opts())#{data_dir => Dir}),
+    ?assertNot(filelib:is_dir(filename:join(DbPath, "attachments"))),
+    ok.
+
+docs_directory_still_created(Config) ->
+    Name = ?config(name, Config),
+    Dir = ?config(dir, Config),
+    DbPath = ?config(db_path, Config),
+    {ok, _} = barrel_docdb:create_db(Name, (none_opts())#{data_dir => Dir}),
+    ?assert(filelib:is_dir(filename:join(DbPath, "docs"))),
+    ok.
+
+local_docs_still_work(Config) ->
+    Name = ?config(name, Config),
+    Dir = ?config(dir, Config),
+    {ok, _} = barrel_docdb:create_db(Name, (none_opts())#{data_dir => Dir}),
+    ok = barrel_docdb:put_local_doc(Name, <<"task_1">>, #{<<"status">> => <<"pending">>}),
+    ?assertEqual({ok, #{<<"status">> => <<"pending">>}},
+                 barrel_docdb:get_local_doc(Name, <<"task_1">>)),
+    ok.
+
+put_attachment_returns_clean_error(Config) ->
+    Name = ?config(name, Config),
+    Dir = ?config(dir, Config),
+    {ok, _} = barrel_docdb:create_db(Name, (none_opts())#{data_dir => Dir}),
+    ?assertEqual({error, attachments_disabled},
+                 barrel_docdb:put_attachment(Name, <<"doc1">>, <<"a.txt">>, <<"hello">>)),
+    ok.
+
+get_attachment_reports_not_found_not_error(Config) ->
+    Name = ?config(name, Config),
+    Dir = ?config(dir, Config),
+    {ok, _} = barrel_docdb:create_db(Name, (none_opts())#{data_dir => Dir}),
+    %% Same answer a real backend gives for a document that happens to
+    %% have zero attachments -- a caller that never writes one cannot
+    %% tell the difference from reads alone.
+    ?assertEqual({error, not_found},
+                 barrel_docdb:get_attachment(Name, <<"doc1">>, <<"a.txt">>)),
+    ok.
+
+%% Control case: confirms the default backend (unaffected by this
+%% change) still behaves as before -- the absence of an attachments/
+%% directory in the other tests is because of `backend => none`, not a
+%% regression in database creation generally.
+default_backend_still_creates_attachments_directory(Config) ->
+    Name = ?config(name, Config),
+    Dir = ?config(dir, Config),
+    DbPath = ?config(db_path, Config),
+    {ok, _} = barrel_docdb:create_db(Name, #{data_dir => Dir}),
+    ?assert(filelib:is_dir(filename:join(DbPath, "attachments"))),
+    ok.


### PR DESCRIPTION
# Title
Stop paying a ~74MB RocksDB WAL/MANIFEST floor for attachments no database ever stores

# Body

## The problem, measured on a real deployment

barrel_docdb is the storage layer under our internal service framework (`hecate_om`), the shared foundation several of our mesh services build on — a RAG/knowledge service, a public-square post archive, a few others. This was found by measuring real disk usage on one of those live deployments, not a lab benchmark.

Specifically: we run a service ([hecate-agora](https://github.com/hecate-services/hecate-agora)) that keeps 359 short text posts in barrel_docdb. It was using 455MB on disk. 304MB of that turned out to be two of barrel's own internal databases — `_barrel_system` and `_replication_tasks` — both of which only ever call `put_local_doc/3` and have never stored an attachment.

Root cause, confirmed directly on the files (`stat`, `xfs_bmap`), not assumed:

Every `barrel_docdb` "database" opens **two** independent RocksDB instances — one for docs, one for attachments (`barrel_att_store_blob`) — unconditionally, in `barrel_db_server:init/8`, regardless of whether the database will ever store an attachment. Both default to RocksDB's stock 64MB `write_buffer_size` (the docs store sets it explicitly; the attachment store's `build_blob_options/1` never sets it, so it falls through to RocksDB's own built-in default). RocksDB preallocates its WAL at roughly 1.1x `write_buffer_size` and its MANIFEST at a fixed 4MB, on open, before a single byte is written.

Every single WAL (`.log`) file we measured — across every database and store on the deployment — was allocated **exactly 73,822,208 bytes** on disk, whether its actual logical content was 16KB or 16MB. Every MANIFEST was allocated **exactly 4,194,304 bytes**. This ~74.4MB floor is paid per RocksDB instance, twice per database that never touches attachments (docs + attachments) = ~148.8MB, entirely independent of document count or write-operation volume. For our three databases, that floor alone accounts for ~446MB of the 455MB total — over 98%.

This means a doc-count-based retention policy anywhere downstream cannot reclaim any of it: deleting documents doesn't shrink an already-preallocated WAL or MANIFEST, and for a young/small deployment like ours, nothing has grown large enough yet to even trigger a flush past the floor.

## The fix

Using the two extension points `create_db/2` already has (`store_opts`, `att_opts`) — no new public API for the general mechanism:

- **New `barrel_att_store_none` backend** (`att_opts => #{backend => none}`): no RocksDB instance, no directory. Every mutating call returns `{error, attachments_disabled}`; every read call returns the same "nothing here" result a real backend would return for a document with zero attachments (`not_found` from `get/4`, `{error, not_found}` from `get_info/4`, the accumulator unchanged from `fold/5`) — a caller that never writes an attachment cannot tell the difference. `checkpoint/2` and `destroy/2` are deliberately not exported (same shape as `barrel_att_s3_store` and the existing test-only minimal backend): `barrel_att_store` already degrades those to `{error, unsupported}` / a no-op respectively. A `none`-backed database cannot be forked via timeline branching — irrelevant to `_barrel_system`/`_replication_tasks` (neither is ever branched), but documented on the module as a real constraint for anyone else opting in.
- **`barrel_docdb.erl`'s `ensure_system_db/0` and `barrel_rep_tasks.erl`'s `ensure_tasks_db/0`** now create their database with `#{att_opts => #{backend => none}, store_opts => #{write_buffer_size => 4194304}}` — skips the attachment store entirely and cuts the docs store's own WAL preallocation from ~70.4MB to ~4.4MB, still generous headroom for node-id/config/task-sized documents.

Combined: **~148.8MB → ~8.4MB per database, an ~86% reduction**, for exactly the two databases that were paying the floor for nothing. Every other consumer of `barrel_docdb` sees zero behavior change — this only touches barrel's own two internal databases.

## Verification

New `barrel_att_store_none_SUITE` (6 cases) verifies the mechanism directly: no `attachments/` directory materializes on disk, `docs/` still does, local docs still round-trip, `put_attachment` returns a clean error instead of crashing, `get_attachment` reports `not_found` like a real empty backend would, and a control case confirms the default backend is unaffected (still creates `attachments/` as before).

143 tests run clean with no regressions (rebased onto current `main`, re-verified after): the new suite plus every suite touching attachments, attachment sync/replication, db creation/naming/lifecycle, compaction, timeline branching, and encryption — `barrel_att_SUITE`, `barrel_att_feed_SUITE`, `barrel_rep_att_SUITE`, `barrel_db_name_SUITE`, `barrel_docdb_app_SUITE`, `barrel_store_SUITE`, `barrel_compaction_SUITE`, `barrel_delete_db_SUITE`, `barrel_timeline_SUITE`, `barrel_encryption_SUITE`.

## A deployment note, not addressed by this change

An already-running `_barrel_system`/`_replication_tasks` has its old `attachments/` directory already materialized on disk with real RocksDB files in it. This fix stops the waste from being created on a fresh database; it does not retroactively reclaim space already committed to disk on an existing deployment — upgrading and reopening simply stops touching that directory, leaving it orphaned. Reclaiming it needs a one-time manual `rm -rf` of the stale `attachments/` dir for these two specific databases after confirming the new code is running (safe: neither has ever called a `barrel_att` function). Deliberately not automated here — happy to discuss if a migration helper is wanted, but a destructive cleanup step felt like it deserved its own review separate from this correctness fix.

---

Full commit message has the alternatives I considered and ruled out (a global `write_buffer_size` tuning, lazy-open-on-first-write instead of an explicit `none` backend) and why. Happy to adjust scope or shape based on feedback — this is our first PR here, so please push back freely on anything that doesn't fit the project's own conventions.
